### PR TITLE
bump JsonSchema.Net to v3.3.2

### DIFF
--- a/implementations/dotnet-jsonschema-net/bowtie_json_everything.csproj
+++ b/implementations/dotnet-jsonschema-net/bowtie_json_everything.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="3.3.1" />
+    <PackageReference Include="JsonSchema.Net" Version="3.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Should fix the `unevaluated*` issues.