### PR TITLE
Skip bignum multipleof test for JsonSchema.Net

### DIFF
--- a/implementations/dotnet-jsonschema-net/Program.cs
+++ b/implementations/dotnet-jsonschema-net/Program.cs
@@ -20,6 +20,11 @@ var drafts = new Dictionary<string, Draft> {
     { "http://json-schema.org/draft-06/schema#", Draft.Draft6 },
 };
 
+var unsupportedTests = new Dictionary<(string, string), string>
+{
+	[("float division = inf", "always invalid, but naive implementations may raise an overflow error")] = "System.Decimal does not support large values like 1e308"
+};
+
 while (cmdSource.GetNextCommand() is {} line && line != "")
 {
     var root = JsonNode.Parse(line);
@@ -78,6 +83,8 @@ while (cmdSource.GetNextCommand() is {} line && line != "")
             }
 
             var testCase = root["case"];
+            var testCaseDescription = testCase["description"].GetValue<string>();
+            string? testDescription = null;
             var schemaText = testCase["schema"];
             var registry = testCase["registry"];
 
@@ -89,22 +96,34 @@ while (cmdSource.GetNextCommand() is {} line && line != "")
 
             try
             {
-                var results = new JsonArray();
+	            var results = new JsonArray();
 
-                foreach (var test in tests)
-                {
-                    var validationResult = schema.Validate(test["instance"], options);
-                    var testResult = JsonSerializer.SerializeToNode(validationResult);
-                    results.Add(testResult);
-                }
+	            foreach (var test in tests)
+	            {
+		            testDescription = test["description"].GetValue<string>();
+		            var validationResult = schema.Validate(test["instance"], options);
+		            var testResult = JsonSerializer.SerializeToNode(validationResult);
+		            results.Add(testResult);
+	            }
 
-                var runResult = new JsonObject {
-                    ["seq"] = root["seq"].GetValue<int>(),
-                    ["results"] = results,
-                };
-                Console.WriteLine(runResult.ToJsonString());
+	            var runResult = new JsonObject
+	            {
+		            ["seq"] = root["seq"].GetValue<int>(),
+		            ["results"] = results,
+	            };
+	            Console.WriteLine(runResult.ToJsonString());
             }
-            catch (Exception e)
+            catch (Exception) when (unsupportedTests.TryGetValue((testCaseDescription, testDescription), out var message))
+            {
+	            var skipResult = new JsonObject
+	            {
+		            ["seq"] = root["seq"].GetValue<int>(),
+		            ["skipped"] = true,
+		            ["message"] = message
+	            };
+	            Console.WriteLine(skipResult.ToJsonString());
+            }
+			catch (Exception e)
             {
                 var errorResult = new JsonObject {
                     ["seq"] = root["seq"].GetValue<int>(),

--- a/implementations/dotnet-jsonschema-net/Program.cs
+++ b/implementations/dotnet-jsonschema-net/Program.cs
@@ -20,10 +20,11 @@ var drafts = new Dictionary<string, Draft> {
     { "http://json-schema.org/draft-06/schema#", Draft.Draft6 },
 };
 
-var unsupportedTests = new Dictionary<(string, string), string>
-{
-    [("float division = inf", "always invalid, but naive implementations may raise an overflow error")] = "System.Decimal does not support large values like 1e308"
-};
+var unsupportedTests =
+    new Dictionary<(string, string),
+                   string> { [("float division = inf",
+                               "always invalid, but naive implementations may raise an overflow error")] =
+                                 "System.Decimal does not support large values like 1e308" };
 
 while (cmdSource.GetNextCommand() is {} line && line != "")
 {
@@ -106,21 +107,17 @@ while (cmdSource.GetNextCommand() is {} line && line != "")
                     results.Add(testResult);
                 }
 
-                var runResult = new JsonObject
-                {
+                var runResult = new JsonObject {
                     ["seq"] = root["seq"].GetValue<int>(),
                     ["results"] = results,
                 };
                 Console.WriteLine(runResult.ToJsonString());
             }
-            catch (Exception) when (unsupportedTests.TryGetValue((testCaseDescription, testDescription), out var message))
+            catch (Exception)
+                when (unsupportedTests.TryGetValue((testCaseDescription, testDescription), out var message))
             {
-                var skipResult = new JsonObject
-                {
-                    ["seq"] = root["seq"].GetValue<int>(),
-                    ["skipped"] = true,
-                    ["message"] = message
-                };
+                var skipResult =
+                    new JsonObject { ["seq"] = root["seq"].GetValue<int>(), ["skipped"] = true, ["message"] = message };
                 Console.WriteLine(skipResult.ToJsonString());
             }
             catch (Exception e)

--- a/implementations/dotnet-jsonschema-net/Program.cs
+++ b/implementations/dotnet-jsonschema-net/Program.cs
@@ -22,7 +22,7 @@ var drafts = new Dictionary<string, Draft> {
 
 var unsupportedTests = new Dictionary<(string, string), string>
 {
-	[("float division = inf", "always invalid, but naive implementations may raise an overflow error")] = "System.Decimal does not support large values like 1e308"
+    [("float division = inf", "always invalid, but naive implementations may raise an overflow error")] = "System.Decimal does not support large values like 1e308"
 };
 
 while (cmdSource.GetNextCommand() is {} line && line != "")
@@ -96,34 +96,34 @@ while (cmdSource.GetNextCommand() is {} line && line != "")
 
             try
             {
-	            var results = new JsonArray();
+                var results = new JsonArray();
 
-	            foreach (var test in tests)
-	            {
-		            testDescription = test["description"].GetValue<string>();
-		            var validationResult = schema.Validate(test["instance"], options);
-		            var testResult = JsonSerializer.SerializeToNode(validationResult);
-		            results.Add(testResult);
-	            }
+                foreach (var test in tests)
+                {
+                    testDescription = test["description"].GetValue<string>();
+                    var validationResult = schema.Validate(test["instance"], options);
+                    var testResult = JsonSerializer.SerializeToNode(validationResult);
+                    results.Add(testResult);
+                }
 
-	            var runResult = new JsonObject
-	            {
-		            ["seq"] = root["seq"].GetValue<int>(),
-		            ["results"] = results,
-	            };
-	            Console.WriteLine(runResult.ToJsonString());
+                var runResult = new JsonObject
+                {
+                    ["seq"] = root["seq"].GetValue<int>(),
+                    ["results"] = results,
+                };
+                Console.WriteLine(runResult.ToJsonString());
             }
             catch (Exception) when (unsupportedTests.TryGetValue((testCaseDescription, testDescription), out var message))
             {
-	            var skipResult = new JsonObject
-	            {
-		            ["seq"] = root["seq"].GetValue<int>(),
-		            ["skipped"] = true,
-		            ["message"] = message
-	            };
-	            Console.WriteLine(skipResult.ToJsonString());
+                var skipResult = new JsonObject
+                {
+                    ["seq"] = root["seq"].GetValue<int>(),
+                    ["skipped"] = true,
+                    ["message"] = message
+                };
+                Console.WriteLine(skipResult.ToJsonString());
             }
-			catch (Exception e)
+            catch (Exception e)
             {
                 var errorResult = new JsonObject {
                     ["seq"] = root["seq"].GetValue<int>(),


### PR DESCRIPTION
This should handle (kind of) the `multipleOf` test, which just isn't supported.