### PR TITLE
Hyperjump: Allow a different set of skips per dialect

### DIFF
--- a/implementations/js-hyperjump/bowtie_hyperjump.js
+++ b/implementations/js-hyperjump/bowtie_hyperjump.js
@@ -46,7 +46,10 @@ const boundaryCrossingSkippedTests = {
 };
 
 const modernSkippedTests = { ...keywordsNotInSchemaSkippedTests };
-const legacySkippedTests = { ...boundaryCrossingSkippedTests, ...keywordsNotInSchemaSkippedTests };
+const legacySkippedTests = {
+  ...boundaryCrossingSkippedTests,
+  ...keywordsNotInSchemaSkippedTests,
+};
 
 const dialectSkippedTests = {
   "https://json-schema.org/draft/2020-12/schema": modernSkippedTests,


### PR DESCRIPTION
I noticed that I was skipping tests in 2019-09/2020-12 that should only be skipped in draft-07 and under. So, I refactored to take the dialect into account when skipping tests.