### PR TITLE
Fix Hyperjump JSV test harness

### DIFF
--- a/implementations/js-hyperjump/bowtie_hyperjump.js
+++ b/implementations/js-hyperjump/bowtie_hyperjump.js
@@ -112,7 +112,7 @@ const cmds = {
       });
     } else {
       try {
-        const fakeURI = "bowtie.sent.schema." + args.seq.toString() + ".json";
+        const fakeURI = "https://example.com/bowtie.sent.schema." + args.seq.toString() + ".json";
         addSchema(testCase.schema, fakeURI, dialect);
         const _validate = await validate(fakeURI);
         results = testCase.tests.map((test) => {


### PR DESCRIPTION
All the Hyperjump tests are failing with an "Invalid URL" error. I noticed that the `fakeURI` variable is not a full non-relative URI as is required. That's probably the reason for the error. I'm surprised it worked in the previous version. It shouldn't have.