### PR TITLE
Attempt to fix Hyperjump JSV version not showing

### DIFF
--- a/implementations/js-hyperjump/bowtie_hyperjump.js
+++ b/implementations/js-hyperjump/bowtie_hyperjump.js
@@ -4,10 +4,9 @@ import "@hyperjump/json-schema/draft-2019-09";
 import "@hyperjump/json-schema/draft-07";
 import "@hyperjump/json-schema/draft-06";
 import "@hyperjump/json-schema/draft-04";
+import packageJson from "./node_modules/@hyperjump/json-schema/package.json" assert { type: "json" };
 
-const hyperjump_version = await import("./package.json", {
-  assert: { type: "json" },
-}).version;
+const hyperjump_version = packageJson.version;
 
 const stdio = readline.createInterface({
   input: process.stdin,


### PR DESCRIPTION
This might fix the problem with the version not showing for `hyperjump-jsv` on the homepage.