### PR TITLE
Compressing HTML report using gzip library

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from typing import Any, TextIO, Union
 from urllib.parse import urljoin
 import asyncio
+import gzip
 import json
 import os
 import sys
 import zipfile
-import gzip
 
 from rich import console, panel
 import aiodocker

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import zipfile
+import gzip
 
 from rich import console, panel
 import aiodocker
@@ -106,7 +107,9 @@ def report(input: Iterable[str], output: TextIO):
         keep_trailing_newline=True,
     )
     template = env.get_template("report.html.j2")
-    output.write(template.render(**_report.from_input(input)))
+    # output.write(template.render(**_report.from_input(input)))
+    with gzip.open("bowtie-report.html", "wt", encoding="utf-8") as f:
+        f.write(template.render(**_report.from_input(input)))
 
 
 @main.command()


### PR DESCRIPTION
This PR refers to #146 

Issue: The file size of generated HTML report is around 10MB.

Aim: To reduce the size of generated HTML report.

This PR implements Python's inbuilt `gzip` library to compress the HTML report.