### PR TITLE
Reducing the file size of HTML Report 

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import zipfile
+import zlib
 
 from rich import console, panel
 import aiodocker
@@ -19,7 +20,6 @@ import click
 import jinja2
 import structlog
 import structlog.typing
-import zlib
 
 from bowtie import _report
 from bowtie._commands import ReportableResult, Test, TestCase
@@ -101,9 +101,11 @@ def report(input: Iterable[str], output: TextIO):
     Generate a Bowtie report from a previous run.
     """
 
-    report_data = _report.from_input(input)   #to generate the report data
+    report_data = _report.from_input(input)  # to generate the report data
 
-    compressed_data = zlib.compress(report_data.encode()) #to compress the report data
+    compressed_data = zlib.compress(
+        report_data.encode()
+    )  # to compress the report data
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader("bowtie"),

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -19,6 +19,7 @@ import click
 import jinja2
 import structlog
 import structlog.typing
+import zlib
 
 from bowtie import _report
 from bowtie._commands import ReportableResult, Test, TestCase
@@ -100,13 +101,17 @@ def report(input: Iterable[str], output: TextIO):
     Generate a Bowtie report from a previous run.
     """
 
+    report_data = _report.from_input(input)   #to generate the report data
+
+    compressed_data = zlib.compress(report_data.encode()) #to compress the report data
+
     env = jinja2.Environment(
         loader=jinja2.PackageLoader("bowtie"),
         undefined=jinja2.StrictUndefined,
         keep_trailing_newline=True,
     )
     template = env.get_template("report.html.j2")
-    output.write(template.render(**_report.from_input(input)))
+    output.write(template.render(compressed_data=compressed_data))
 
 
 @main.command()

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -101,11 +101,9 @@ def report(input: Iterable[str], output: TextIO):
     Generate a Bowtie report from a previous run.
     """
 
-    report_data = _report.from_input(input)  # to generate the report data
+    # report_data = _report.from_input(input)  # to generate the report data
 
-    compressed_data = zlib.compress(
-        report_data.encode()
-    )  # to compress the report data
+    # compressed_data = zlib.compress(report_data.encode())  # to compress the report data
 
     env = jinja2.Environment(
         loader=jinja2.PackageLoader("bowtie"),
@@ -113,7 +111,8 @@ def report(input: Iterable[str], output: TextIO):
         keep_trailing_newline=True,
     )
     template = env.get_template("report.html.j2")
-    output.write(template.render(compressed_data=compressed_data))
+    # output.write(template.render(compressed_data=compressed_data))
+    output.write(template.render(_report.from_input(input)))
 
 
 @main.command()

--- a/bowtie/templates/dummy_report.html.j2
+++ b/bowtie/templates/dummy_report.html.j2
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bowtie</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+  </head>
+
+  <body>
+    <nav class="navbar navbar-expand-lg sticky-top bg-light mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="#">Bowtie</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" href="#run-info">Run Info</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#summary">Summary</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#cases">Details</a>
+            </li>
+          </ul>
+        </div>
+
+        <a href="https://github.com/bowtie-json-schema/bowtie/" class="link-secondary">
+          <span class="navbar-text">
+            <small id='test'></small>
+          </span>
+        </a>
+      </div>
+    </nav>
+
+
+    <script>
+      var compressedData = "{{ data }}";
+      var compressedDataUint8Array = new Uint8Array(atob(compressedData).split("").map(function (c) {
+        return c.charCodeAt(0);
+      }));
+    </script>
+    
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.4/pako.min.js"></script>
+    <script>
+      var decompressedDataUint8Array = pako.inflate(compressedDataUint8Array);
+      var jsonData = JSON.parse(new TextDecoder().decode(decompressedDataUint8Array));
+    </script>
+    
+    <script>
+      console.log(compressedData);
+      console.log(decompressedDataUint8Array);
+      console.log(jsonData);
+      console.log(jsonData.run_info);
+      console.log(jsonData.run_info.bowtie_version);
+      console.log(jsonData.summary.implementations);
+      document.getElementById('test').innerText = `Bowtie v ${jsonData.run_info.bowtie_version}`
+    </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+    <script>
+      const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+      const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+    </script>
+
+    <script>
+      var ago = Date.now()/ 1000;
+      var agoUnits = 'seconds';
+      if (ago > 60) {
+        ago /= 60; agoUnits = 'minutes';
+        if (ago > 60) {
+          ago /= 60; agoUnits = 'hours';
+          if (ago > 24) {
+            ago /= 24; agoUnits = 'days';
+            if (ago > 7) { ago /= 7; agoUnits = 'weeks'; }
+          }
+        }
+      };
+      document.getElementById('runStarted').textContent = new Intl.RelativeTimeFormat(
+        'en', {numeric: 'auto'}
+      ).format(-Math.round(ago), agoUnits);
+    </script>
+  </body>
+</html>

--- a/bowtie/templates/report.html.j2
+++ b/bowtie/templates/report.html.j2
@@ -275,6 +275,14 @@
       </div>
     {% endfor %}
 
+
+    <script>
+      var compressed_data = "{{ compressed_data }}";
+      var uncompressed_data = pako.inflate(compressed_data, { to: 'string' });
+      var data = JSON.parse(uncompressed_data);
+      // implementation is remaining
+    </script>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
     <script>
       const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')

--- a/bowtie/templates/report.html.j2
+++ b/bowtie/templates/report.html.j2
@@ -277,10 +277,6 @@
 
 
     <script>
-      var compressed_data = "{{ compressed_data }}";
-      var uncompressed_data = pako.inflate(compressed_data, { to: 'string' });
-      var data = JSON.parse(uncompressed_data);
-      // implementation is remaining
     </script>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>


### PR DESCRIPTION
This PR refers to #146 

Issue: The file size of generated HTML report is around 10MB.

Aim: To reduce the size of generated HTML report.

This PR implements `zlib` library to compress the HTML report.