### PR TITLE
Add runtime info to harness' metadata

### DIFF
--- a/bowtie/schemas/io-schema.json
+++ b/bowtie/schemas/io-schema.json
@@ -97,6 +97,7 @@
                     "language_version": {
                       "type": "string",
                       "description": "Version of language used to run the implementation"
+                    }
                   }
                 }
               }

--- a/bowtie/schemas/io-schema.json
+++ b/bowtie/schemas/io-schema.json
@@ -85,7 +85,18 @@
                           "url": { "type": "string", "format": "uri" }
                         }
                       }
-                    }
+                    },
+                    "os": {
+                      "type": "string",
+                      "description": "Operating system the implementation is running on"
+                    },
+                    "os_version": {
+                      "type": "string",
+                      "description": "Version of OS the implementation is running on"
+                    },
+                    "language_version": {
+                      "type": "string",
+                      "description": "Version of language used to run the implementation"
                   }
                 }
               }

--- a/implementations/go-gojsonschema/bowtie_gojsonschema.go
+++ b/implementations/go-gojsonschema/bowtie_gojsonschema.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"strings"
+	"syscall"
 
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -16,6 +18,21 @@ var drafts = map[string]gojsonschema.Draft{
 	"http://json-schema.org/draft-07/schema#": gojsonschema.Draft7,
 	"http://json-schema.org/draft-06/schema#": gojsonschema.Draft6,
 	"http://json-schema.org/draft-04/schema#": gojsonschema.Draft4,
+}
+
+func getOsVersion() string {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return ""
+	}
+	release := ""
+	for _, b := range uname.Release {
+		if b == 0 {
+			break
+		}
+		release += string(b)
+	}
+	return fmt.Sprintf(release)
 }
 
 func main() {
@@ -59,6 +76,9 @@ func main() {
 						"http://json-schema.org/draft-06/schema#",
 						"http://json-schema.org/draft-04/schema#",
 					},
+					"os":runtime.GOOS,
+					"os_version": getOsVersion(),
+					"language_version":runtime.Version(),
 				},
 			}
 			printJSON(data)

--- a/implementations/go-gojsonschema/bowtie_gojsonschema.go
+++ b/implementations/go-gojsonschema/bowtie_gojsonschema.go
@@ -76,9 +76,9 @@ func main() {
 						"http://json-schema.org/draft-06/schema#",
 						"http://json-schema.org/draft-04/schema#",
 					},
-					"os":runtime.GOOS,
-					"os_version": getOsVersion(),
-					"language_version":runtime.Version(),
+					"os":               runtime.GOOS,
+					"os_version":       getOsVersion(),
+					"language_version": runtime.Version(),
 				},
 			}
 			printJSON(data)

--- a/implementations/go-jsonschema/bowtie_jsonschema.go
+++ b/implementations/go-jsonschema/bowtie_jsonschema.go
@@ -82,9 +82,9 @@ func main() {
 						"http://json-schema.org/draft-06/schema#",
 						"http://json-schema.org/draft-04/schema#",
 					},
-					"os":runtime.GOOS,
-					"os_version": getOsVersion(),
-					"language_version":runtime.Version(),
+					"os":               runtime.GOOS,
+					"os_version":       getOsVersion(),
+					"language_version": runtime.Version(),
 				},
 			}
 			printJSON(data)

--- a/implementations/go-jsonschema/bowtie_jsonschema.go
+++ b/implementations/go-jsonschema/bowtie_jsonschema.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"strings"
+	"syscall"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
@@ -20,6 +22,21 @@ var drafts = map[string]*jsonschema.Draft{
 	"http://json-schema.org/draft-07/schema#":      jsonschema.Draft7,
 	"http://json-schema.org/draft-06/schema#":      jsonschema.Draft6,
 	"http://json-schema.org/draft-04/schema#":      jsonschema.Draft4,
+}
+
+func getOsVersion() string {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return ""
+	}
+	release := ""
+	for _, b := range uname.Release {
+		if b == 0 {
+			break
+		}
+		release += string(b)
+	}
+	return fmt.Sprintf(release)
 }
 
 func main() {
@@ -65,6 +82,9 @@ func main() {
 						"http://json-schema.org/draft-06/schema#",
 						"http://json-schema.org/draft-04/schema#",
 					},
+					"os":runtime.GOOS,
+					"os_version": getOsVersion(),
+					"language_version":runtime.Version(),
 				},
 			}
 			printJSON(data)

--- a/implementations/js-ajv/bowtie_ajv.js
+++ b/implementations/js-ajv/bowtie_ajv.js
@@ -1,9 +1,11 @@
 const path = require("path");
 const readline = require("readline");
+const os = require("os");
+const process = require("process");
 
 const ajv_version = require(path.join(
   path.dirname(path.dirname(require.resolve("ajv"))),
-  "package.json",
+  "package.json"
 )).version;
 
 const DRAFTS = {
@@ -47,6 +49,9 @@ const cmds = {
           "http://json-schema.org/draft-06/schema#",
           "http://json-schema.org/draft-04/schema#",
         ],
+        os: os.platform(),
+        os_version: os.release(),
+        language_version: process.version,
       },
     };
   },

--- a/implementations/js-hyperjump/bowtie_hyperjump.js
+++ b/implementations/js-hyperjump/bowtie_hyperjump.js
@@ -1,4 +1,6 @@
 import readline from "readline/promises";
+import os from 'os';
+import process from 'process';
 import { addSchema, validate } from "@hyperjump/json-schema/draft-2020-12";
 import "@hyperjump/json-schema/draft-2019-09";
 import "@hyperjump/json-schema/draft-07";
@@ -80,6 +82,9 @@ const cmds = {
           "http://json-schema.org/draft-06/schema#",
           "http://json-schema.org/draft-04/schema#",
         ],
+        os: os.platform(),
+        os_version: os.release(),
+        language_version: process.version,
       },
     };
   },

--- a/implementations/python-fastjsonschema/bowtie_fastjsonschema.py
+++ b/implementations/python-fastjsonschema/bowtie_fastjsonschema.py
@@ -5,6 +5,7 @@ import io
 import json
 import sys
 import traceback
+import platform
 
 import fastjsonschema
 
@@ -41,6 +42,9 @@ class Runner:
                     "http://json-schema.org/draft-06/schema#",
                     "http://json-schema.org/draft-04/schema#",
                 ],
+                os=platform.system(),
+                os_version=platform.release(),
+                language_version=platform.python_version(),
             ),
         )
 

--- a/implementations/python-jschon/bowtie_jschon.py
+++ b/implementations/python-jschon/bowtie_jschon.py
@@ -5,6 +5,7 @@ import io
 import json
 import sys
 import traceback
+import platform
 
 import jschon
 
@@ -65,6 +66,9 @@ class Runner:
                     "https://json-schema.org/draft/2020-12/schema",
                     "https://json-schema.org/draft/2019-09/schema",
                 ],
+                os=platform.system(),
+                os_version=platform.release(),
+                language_version=platform.python_version(),
             ),
         )
 

--- a/implementations/python-jsonschema/bowtie_jsonschema.py
+++ b/implementations/python-jsonschema/bowtie_jsonschema.py
@@ -5,6 +5,7 @@ import io
 import json
 import sys
 import traceback
+import platform
 
 from jsonschema.protocols import Validator
 from jsonschema.validators import RefResolver, validator_for
@@ -46,6 +47,9 @@ class Runner:
                     "http://json-schema.org/draft-04/schema#",
                     "http://json-schema.org/draft-03/schema#",
                 ],
+                os=platform.system(),
+                os_version=platform.release(),
+                language_version=platform.python_version(),
             ),
         )
 


### PR DESCRIPTION
### This PR refers to #117 

### What is this PR for?
This PR adds runtime information (including `os`, `os_version`, and `language_version`) to the implementation harness' metadata which is returned by `bowtie info` !

This is a subset PR that adds runtime info to JavaScript and Python based harnesses, and other harnesses' info will be added down the line in this PR itself.


Edit:
Golang based harnesses are also modified to add runtime info.