### PR TITLE
Build rust images using cargo's sparse registry option, reducing their memory usage

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -35,7 +35,7 @@ jobs:
 
   build:
     needs: list
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       packages: write

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -35,7 +35,7 @@ jobs:
 
   build:
     needs: list
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     permissions:
       packages: write

--- a/implementations/rust-boon/Dockerfile
+++ b/implementations/rust-boon/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /usr/src/myapp
 COPY . .
 
 ENV RUSTFLAGS='-C linker=x86_64-linux-gnu-gcc'
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN cargo build --target x86_64-unknown-linux-musl --release
 
 FROM alpine

--- a/implementations/rust-jsonschema/Dockerfile
+++ b/implementations/rust-jsonschema/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /usr/src/myapp
 COPY . .
 
 ENV RUSTFLAGS='-C linker=x86_64-linux-gnu-gcc'
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 RUN cargo build --target x86_64-unknown-linux-musl --release
 
 FROM alpine


### PR DESCRIPTION
https://github.com/actions/runner-images/discussions/7188

the above issue says it ubuntu-20.04 is not affected by this