### PR TITLE
Removed $ sign before cli

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -12,7 +12,7 @@ To run the draft 7 ``type``-keyword tests on the Lua ``jsonschema`` implementati
 
 .. code:: sh
 
-    $ bowtie suite -i lua-jsonschema https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft7/type.json | bowtie report
+    bowtie suite -i lua-jsonschema https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft7/type.json | bowtie report
 
 
 Running the Official Suite Across All Implementations
@@ -22,7 +22,7 @@ The following will run all Draft 7 tests from the `official test suite`_ (which 
 
 .. code:: sh
 
-    $ bowtie suite $(find /path/to/bowtie/checkout/implementations/ -mindepth 1 -maxdepth 1 -type d | sed 's/.*\/implementations\//-i /') https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft7 | bowtie report
+    bowtie suite $(find /path/to/bowtie/checkout/implementations/ -mindepth 1 -maxdepth 1 -type d | sed 's/.*\/implementations\//-i /') https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft7 | bowtie report
 
 
 Running Test Suite Tests From Local Checkouts
@@ -32,7 +32,7 @@ Providing a local path to the test suite can be used as well, which is useful if
 
 .. code:: sh
 
-    $ bowtie suite $(find /path/to/bowtie/checkout/implementations/ -mindepth 1 -maxdepth 1 -type d | sed 's/.*\/implementations\//-i /') ~/path/to/json-schema-org/suite/tests/draft2020-12/ | bowtie report
+    bowtie suite $(find /path/to/bowtie/checkout/implementations/ -mindepth 1 -maxdepth 1 -type d | sed 's/.*\/implementations\//-i /') ~/path/to/json-schema-org/suite/tests/draft2020-12/ | bowtie report
 
 
 Checking An Implementation Functions On Basic Input
@@ -43,7 +43,7 @@ E.g., to verify the Golang ``jsonschema`` implementation is functioning, you can
 
 .. code:: sh
 
-   $ bowtie smoke -i go-jsonschema
+   bowtie smoke -i go-jsonschema
 
 
 Reference

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,7 +12,7 @@ If you're going to work on Bowtie itself, you likely will want to install it usi
 
 .. code:: sh
 
-    $ pip install -e wherever/you/cloned/bowtie
+    pip install -e wherever/you/cloned/bowtie
 
 which will allow you to make changes to files within Bowtie and see the results without reinstalling it repeatedly.
 
@@ -27,7 +27,7 @@ You can run them using `nox <nox:index>`, which you can install using the `linke
 
 .. code:: sh
 
-    $ nox -s tests-3.11
+    nox -s tests-3.11
 
 to run the tests using Python 3.11 (or any other version you'd like).
 


### PR DESCRIPTION
## Why this is needed
- Every time when I copy a line from copy button this include a $ and space before the line
![Screenshot_94](https://user-images.githubusercontent.com/92979541/233001946-13c3e586-a1d6-4114-ac54-3ba0e52fd486.png)
- And then I have manually move my cursor to remove that
- I thought, let's remove the $ sign before that line, and make it developer friendly