### PR TITLE
fix: Support for multiple BASE_URL variables

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 18.x
       - run: npm ci
         working-directory: ./frontend
-      - run: npm run build
+      - run: npm run build -- --base=${{ vars.BOWTIE_BASE_URL || '/bowtie' }}
         working-directory: ./frontend
       - uses: actions/upload-artifact@v3
         with:

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -11,9 +11,9 @@ import { DragAndDrop } from "./components/DragAndDrop/DragAndDrop";
 import { parseReportData } from "./data/parseReportData";
 
 const reportUrl =
-    import.meta.env.MODE === "development"
-            ? "https://bowtie.report"
-            : import.meta.env.BASE_URL;
+  import.meta.env.MODE === "development"
+    ? "https://bowtie.report"
+    : import.meta.env.BASE_URL;
 const titleTag = document.getElementsByTagName("title")[0];
 const dialectToName = {
   "draft2020-12": "Draft 2020-12",

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -10,7 +10,10 @@ import { BowtieVersionContextProvider } from "./context/BowtieVersionContext";
 import { DragAndDrop } from "./components/DragAndDrop/DragAndDrop";
 import { parseReportData } from "./data/parseReportData";
 
-const reportUrl = "https://bowtie.report";
+const reportUrl =
+    import.meta.env.MODE === "development"
+            ? "https://bowtie.report"
+            : import.meta.env.BASE_URL;
 const titleTag = document.getElementsByTagName("title")[0];
 const dialectToName = {
   "draft2020-12": "Draft 2020-12",


### PR DESCRIPTION
Things got a little complicated with custom domain name. It now requires base url to be equal to `/`, but for fork deployments it still should be `/bowtie` (e.g. link `https://harrel56.github.io/assets/index-e150a41d.js` should be `https://harrel56.github.io/bowtie/assets/index-e150a41d.js`). This PR introduces a way to control base url using GH variable (`BOWTIE_BASE_URL`). I did it so if the variable is absent it uses `/bowtie` value. This way all future fork deployments should work without any additional configuration, but the original bowtie repo should set up a variable (`BOWTIE_BASE_URL` with value `/`) in order to work correctly.

@Julian Let me know what you think about this approach, couldn't come up with anything simpler and ofc I'm open to other ideas.

<!-- readthedocs-preview bowtie-json-schema start -->
----
:books: Documentation preview :books:: https://bowtie-json-schema--373.org.readthedocs.build/en/373/

<!-- readthedocs-preview bowtie-json-schema end -->