### PR TITLE
Fix Hyperjump test harness for file URIs

### DIFF
--- a/implementations/js-hyperjump/bowtie_hyperjump.js
+++ b/implementations/js-hyperjump/bowtie_hyperjump.js
@@ -116,10 +116,9 @@ const cmds = {
       });
     } else {
       try {
-        const idToken =
-          args.dialect === "http://json-schema.org/draft-04/schema#"
-            ? "id"
-            : "$id";
+        const idToken = dialect === "http://json-schema.org/draft-04/schema#"
+          ? "id"
+          : "$id";
         const host = testCase.schema?.[idToken]?.startsWith("file:")
           ? "file://"
           : "https://example.com";

--- a/implementations/js-hyperjump/bowtie_hyperjump.js
+++ b/implementations/js-hyperjump/bowtie_hyperjump.js
@@ -116,9 +116,8 @@ const cmds = {
       });
     } else {
       try {
-        const idToken = dialect === "http://json-schema.org/draft-04/schema#"
-          ? "id"
-          : "$id";
+        const idToken =
+          dialect === "http://json-schema.org/draft-04/schema#" ? "id" : "$id";
         const host = testCase.schema?.[idToken]?.startsWith("file:")
           ? "file://"
           : "https://example.com";


### PR DESCRIPTION
I noticed that a [fix](https://github.com/bowtie-json-schema/bowtie/pull/325) I made previously to my test harness didn't actually work the way I thought it did and wasn't working for draft-04. This appears to fix the problem.

(I managed to get it to run this time and verify that it works. I needed to use docker instead of podman to build the images. When I built the image with podman like the documentation says, bowtie couldn't find the image. When I built with docker instead, everything worked as expected.)

<!-- readthedocs-preview bowtie-json-schema start -->
----
:books: Documentation preview :books:: https://bowtie-json-schema--413.org.readthedocs.build/en/413/

<!-- readthedocs-preview bowtie-json-schema end -->