### PR TITLE
Fix failing smoke tests for java images

### DIFF
--- a/implementations/java-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -107,7 +107,7 @@ public class BowtieJsonSchemaValidator {
         "https://github.com/networknt/json-schema-validator/issues",
         System.getProperty("os.name"),
         System.getProperty("os.version"),
-        System.getProperty("java.vendor.version")
+        Runtime.version().toString()
       )
     );
     output.println(objectMapper.writeValueAsString(startResponse));

--- a/implementations/java-json-schema/BowtieJsonSchema.java
+++ b/implementations/java-json-schema/BowtieJsonSchema.java
@@ -78,7 +78,7 @@ public class BowtieJsonSchema {
                 "https://github.com/harrel56/json-schema/issues",
                 System.getProperty("os.name"),
                 System.getProperty("os.version"),
-                System.getProperty("java.vendor.version"),
+                Runtime.version().toString(),
                 List.of(
                         new Link("https://harrel.dev", "Group homepage"),
                         new Link(createMavenUrl("Implementation", attributes), "Maven Central - implementation"),


### PR DESCRIPTION
Seems that `java.vendor.version` is optional property and it's not provided in liberica. No idea how all images managed to build on my fork - must have mixed something up I guess

<!-- readthedocs-preview bowtie-json-schema start -->
----
:books: Documentation preview :books:: https://bowtie-json-schema--469.org.readthedocs.build/en/469/

<!-- readthedocs-preview bowtie-json-schema end -->