### PR TITLE
Show compliance summaries across all implementations for a specific JSON Schema Vocabulary

### DIFF
--- a/frontend/src/DialectReportView.tsx
+++ b/frontend/src/DialectReportView.tsx
@@ -45,7 +45,7 @@ export const DialectReportView = ({
     return Array.from(vocabSet);
   }, [reportData]);
 
-  console.log(vocabularies);
+  // console.log(vocabularies);
   const filteredData = useMemo(() => {
     let filteredData = reportData;
     if (params.getAll("language").length) {
@@ -63,7 +63,7 @@ export const DialectReportView = ({
     <div>
       <div className="container p-4">
         <RunInfoSection runInfo={filteredData.runInfo} />
-        <FilterSection languages={languages} />
+        <FilterSection languages={languages} vocabularies={vocabularies} />
         <SummarySection reportData={filteredData} />
         <CasesSection reportData={filteredData} />
       </div>

--- a/frontend/src/DialectReportView.tsx
+++ b/frontend/src/DialectReportView.tsx
@@ -18,7 +18,7 @@ export const DialectReportView = ({
 
   const languages = useMemo(() => {
     const langs = Array.from(reportData.implementations.values()).map(
-      (impl) => impl.metadata.language
+      (impl) => impl.metadata.language,
     );
     return Array.from(new Set(langs).values());
   }, [reportData]);
@@ -50,9 +50,9 @@ export const DialectReportView = ({
     let filteredData = reportData;
     if (params.getAll("language").length) {
       const filteredArray = Array.from(
-        reportData.implementations.entries()
+        reportData.implementations.entries(),
       ).filter(([, data]) =>
-        params.getAll("language").includes(data.metadata.language)
+        params.getAll("language").includes(data.metadata.language),
       );
       filteredData = { ...reportData, implementations: new Map(filteredArray) };
     }

--- a/frontend/src/DialectReportView.tsx
+++ b/frontend/src/DialectReportView.tsx
@@ -5,7 +5,7 @@ import RunInfoSection from "./components/RunInfo/RunInfoSection";
 // @ts-ignore
 import SummarySection from "./components/Summary/SummarySection";
 import { useMemo } from "react";
-import { ReportData } from "./data/parseReportData.ts";
+import { ReportData, Case } from "./data/parseReportData.ts";
 import { FilterSection } from "./components/FilterSection.tsx";
 import { useSearchParams } from "./hooks/useSearchParams.ts";
 
@@ -23,22 +23,26 @@ export const DialectReportView = ({
     return Array.from(new Set(langs).values());
   }, [reportData]);
 
-  const registries = Array.from(reportData.cases.values()).filter(
-    (value) => value.registry && value.registry.$vocabulary
-  );
-  const vocabularies = useMemo(() => {
-    const registries = Array.from(reportData.cases.values()).filter(
-      (value) => value.registry
-    )
-    const regs = Object.values(registries.map((reg) => reg.registry)[0]).filter(
-      (reg) => reg.$vocabulary
-    );
+  const Cases: Map<number, Case> = reportData.cases;
+  const vocabularies: string[] = useMemo(() => {
+    const vocabSet: Set<string> = new Set();
 
-    const vocabs = regs.map((vocab) => {
-      let arr = Object.keys(vocab.$vocabulary);
-      return arr.map(val => val.split("/").pop());
-    });
-    return Array.from(new Set([].concat(...vocabs)).values());
+    Array.from(Cases.values())
+      .filter((value) => !!value.registry)
+      .forEach((value) => {
+        const registry = value.registry!;
+        Object.keys(registry).forEach((url) => {
+          const vocabObject = (registry[url] as any).$vocabulary;
+          if (vocabObject) {
+            Object.keys(vocabObject).forEach((key) => {
+              const segments = key.split("/");
+              vocabSet.add(segments[segments.length - 1]);
+            });
+          }
+        });
+      });
+
+    return Array.from(vocabSet);
   }, [reportData]);
 
   console.log(vocabularies);

--- a/frontend/src/DialectReportView.tsx
+++ b/frontend/src/DialectReportView.tsx
@@ -18,18 +18,37 @@ export const DialectReportView = ({
 
   const languages = useMemo(() => {
     const langs = Array.from(reportData.implementations.values()).map(
-      (impl) => impl.metadata.language,
+      (impl) => impl.metadata.language
     );
     return Array.from(new Set(langs).values());
   }, [reportData]);
 
+  const registries = Array.from(reportData.cases.values()).filter(
+    (value) => value.registry && value.registry.$vocabulary
+  );
+  const vocabularies = useMemo(() => {
+    const registries = Array.from(reportData.cases.values()).filter(
+      (value) => value.registry
+    )
+    const regs = Object.values(registries.map((reg) => reg.registry)[0]).filter(
+      (reg) => reg.$vocabulary
+    );
+
+    const vocabs = regs.map((vocab) => {
+      let arr = Object.keys(vocab.$vocabulary);
+      return arr.map(val => val.split("/").pop());
+    });
+    return Array.from(new Set([].concat(...vocabs)).values());
+  }, [reportData]);
+
+  console.log(vocabularies);
   const filteredData = useMemo(() => {
     let filteredData = reportData;
     if (params.getAll("language").length) {
       const filteredArray = Array.from(
-        reportData.implementations.entries(),
+        reportData.implementations.entries()
       ).filter(([, data]) =>
-        params.getAll("language").includes(data.metadata.language),
+        params.getAll("language").includes(data.metadata.language)
       );
       filteredData = { ...reportData, implementations: new Map(filteredArray) };
     }

--- a/frontend/src/components/FilterSection.tsx
+++ b/frontend/src/components/FilterSection.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { useSearchParams } from "../hooks/useSearchParams.ts";
 import { X } from "react-bootstrap-icons";
 import { mapLanguage } from "../data/mapLanguage.ts";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export const FilterSection = ({
   languages,
@@ -29,7 +29,7 @@ export const FilterSection = ({
             </div>
           </div>
           <div className="m-4" style={{ width: "20%" }}>
-            <VocabDropDown vocabularies={vocabularies} />
+            <VocabDropDown vocabularies={vocabularies} searchParams={params} />
           </div>
           <div className="m-4" style={{ width: "20%" }}>
             Keyword
@@ -80,29 +80,41 @@ const FilterChip = ({
   }
 };
 
-const VocabDropDown = ({ vocabularies }: { vocabularies: string[] }) => {
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+const VocabDropDown = ({
+  vocabularies,
+  searchParams,
+}: {
+  vocabularies: string[];
+  searchParams: URLSearchParams;
+}) => {
+  const [selectedVocabulary, setSelectedVocabulary] = useState<string | null>(
+    null
+  );
 
-  const handleSelect = (option: any) => {
-    setSelectedOption(option);
+  const handleSelect = (vocabulary: string) => {
+    const newParams = new URLSearchParams(searchParams);
+
+    if (selectedVocabulary === vocabulary) {
+      setSelectedVocabulary(null);
+      newParams.delete("vocabulary");
+    } else {
+      setSelectedVocabulary(vocabulary);
+
+      newParams.set("vocabulary", vocabulary);
+    }
   };
 
   return (
     <Dropdown onSelect={handleSelect}>
       <Dropdown.Toggle variant="primary">
-        {selectedOption || "Select a Vocabulary"}
+        {"Select a Vocabulary"}
       </Dropdown.Toggle>
       <Dropdown.Menu>
-        <Dropdown.Item
-          onClick={() => {
-            setSelectedOption("Select a Vocabulary");
-          }}
-        >
-          Reset
-        </Dropdown.Item>
-        {vocabularies.map((vocab) => (
-          <Dropdown.Item key={vocab} eventKey={vocab}>
-            {vocab}
+        {vocabularies.map((vocabulary) => (
+          <Dropdown.Item key={vocabulary} eventKey={vocabulary}>
+            <Link to={{ search: `?vocabulary=${vocabulary}` }}>
+              {vocabulary}
+            </Link>
           </Dropdown.Item>
         ))}
       </Dropdown.Menu>

--- a/frontend/src/components/FilterSection.tsx
+++ b/frontend/src/components/FilterSection.tsx
@@ -1,11 +1,17 @@
 import "./FilterSection.css";
-import { Badge, Card } from "react-bootstrap";
+import { Badge, Card, Dropdown } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { useSearchParams } from "../hooks/useSearchParams.ts";
 import { X } from "react-bootstrap-icons";
 import { mapLanguage } from "../data/mapLanguage.ts";
 
-export const FilterSection = ({ languages }: { languages: string[] }) => {
+export const FilterSection = ({
+  languages,
+  vocabularies,
+}: {
+  languages: string[];
+  vocabularies: string[];
+}) => {
   const params = useSearchParams();
 
   return (
@@ -13,10 +19,18 @@ export const FilterSection = ({ languages }: { languages: string[] }) => {
       <Card.Header>Filtering</Card.Header>
       <Card.Body>
         <Card.Title>Language</Card.Title>
-        <div className="d-flex flex-wrap gap-2 py-2">
-          {languages.map((lang) => (
-            <FilterChip key={lang} current={lang} searchParams={params} />
-          ))}
+        <div className="d-flex align-items-center">
+          <div className="d-flex" style={{ width: "50%" }}>
+            <div className="d-flex flex-wrap gap-2 py-2">
+              {languages.map((lang) => (
+                <FilterChip key={lang} current={lang} searchParams={params} />
+              ))}
+            </div>
+          </div>
+          <div style={{ width: "25%" }}>
+            <VocabDropDown vocabularies={vocabularies} />
+          </div>
+          <div style={{ width: "25%" }}>Keyword</div>
         </div>
       </Card.Body>
     </Card>
@@ -50,10 +64,28 @@ const FilterChip = ({
     newParams.append("language", current);
     return (
       <Link key={current} to={{ search: newParams.toString() }}>
-        <Badge pill bg="filter">
-          <div className="px-2">{mapLanguage(current)}</div>
+        <Badge
+          pill
+          bg="filter"
+          style={{ width: "80px" }}
+          className="justify-content-center"
+        >
+          <div className="text-center">{mapLanguage(current)}</div>
         </Badge>
       </Link>
     );
   }
+};
+
+const VocabDropDown = ({ vocabularies }: { vocabularies: string[] }) => {
+  return (
+    <Dropdown>
+      <Dropdown.Toggle className="">Select Vocabulary</Dropdown.Toggle>
+      <Dropdown.Menu>
+        {vocabularies.map((vocab) => (
+          <Dropdown.Item>{vocab}</Dropdown.Item>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
 };

--- a/frontend/src/components/FilterSection.tsx
+++ b/frontend/src/components/FilterSection.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { useSearchParams } from "../hooks/useSearchParams.ts";
 import { X } from "react-bootstrap-icons";
 import { mapLanguage } from "../data/mapLanguage.ts";
+import { useEffect, useState } from "react";
 
 export const FilterSection = ({
   languages,
@@ -27,10 +28,12 @@ export const FilterSection = ({
               ))}
             </div>
           </div>
-          <div style={{ width: "25%" }}>
+          <div className="m-4" style={{ width: "20%" }}>
             <VocabDropDown vocabularies={vocabularies} />
           </div>
-          <div style={{ width: "25%" }}>Keyword</div>
+          <div className="m-4" style={{ width: "20%" }}>
+            Keyword
+          </div>
         </div>
       </Card.Body>
     </Card>
@@ -78,12 +81,29 @@ const FilterChip = ({
 };
 
 const VocabDropDown = ({ vocabularies }: { vocabularies: string[] }) => {
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+
+  const handleSelect = (option: any) => {
+    setSelectedOption(option);
+  };
+
   return (
-    <Dropdown>
-      <Dropdown.Toggle className="">Select Vocabulary</Dropdown.Toggle>
+    <Dropdown onSelect={handleSelect}>
+      <Dropdown.Toggle variant="primary">
+        {selectedOption || "Select a Vocabulary"}
+      </Dropdown.Toggle>
       <Dropdown.Menu>
+        <Dropdown.Item
+          onClick={() => {
+            setSelectedOption("Select a Vocabulary");
+          }}
+        >
+          Reset
+        </Dropdown.Item>
         {vocabularies.map((vocab) => (
-          <Dropdown.Item>{vocab}</Dropdown.Item>
+          <Dropdown.Item key={vocab} eventKey={vocab}>
+            {vocab}
+          </Dropdown.Item>
         ))}
       </Dropdown.Menu>
     </Dropdown>

--- a/frontend/src/components/FilterSection.tsx
+++ b/frontend/src/components/FilterSection.tsx
@@ -88,7 +88,7 @@ const VocabDropDown = ({
   searchParams: URLSearchParams;
 }) => {
   const [selectedVocabulary, setSelectedVocabulary] = useState<string | null>(
-    null
+    null,
   );
 
   const handleSelect = (vocabulary: string) => {


### PR DESCRIPTION
# Work in Progress

**Note:** This PR is submitted early to get some feedback and suggestions for the ongoing work.

This pull request addresses [Issue #248](https://github.com/bowtie-json-schema/bowtie/issues/248). The primary goal is to create a cross-implementation page that displays compliance summaries across all implementations for a specific JSON Schema Vocabulary.

### Implemented Features

- Implemented the function to extract the names of vocabularies.
- Completed the placement of the dropdown menu (open to suggestions for alternative placements).


![image](https://github.com/bowtie-json-schema/bowtie/assets/113545196/f83242ee-fab7-429f-8eb6-01a7ce4f5e97)


![Search Query Logic](https://github.com/bowtie-json-schema/bowtie/assets/113545196/54660da3-32d2-44c6-924a-0559e7b6775b)


- Logic to add the search query for vocabulary has been implemented successfully.


In order to get more clarity I'm currently looking for some feedback/suggestions on how to proceed with filtering the `reportData` based on the selected vocabulary. Any suggestion would be really appreciated. :)



<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--708.org.readthedocs.build/en/708/

<!-- readthedocs-preview bowtie-json-schema end -->