### PR TITLE
Add firstPublicationDate in Dialects and sorts compliance table in implementation page.

### DIFF
--- a/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
+++ b/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
@@ -27,8 +27,19 @@ const DialectCompliance: React.FC<{
             </tr>
           </thead>
           <tbody className="table-group-divider">
-            {Object.entries(implementation.results).map(
-              ([dialectName, result], index) => {
+            {Object.entries(implementation.results)
+              .sort(
+                (a, b) =>
+                  a[1].failedTests! +
+                    a[1].erroredTests! +
+                    a[1].skippedTests! -
+                    b[1].failedTests! -
+                    b[1].erroredTests! -
+                    b[1].skippedTests! ||
+                  +Dialect.forPath(b[0]).firstPublicationDate -
+                    +Dialect.forPath(a[0]).firstPublicationDate,
+              )
+              .map(([dialectName, result], index) => {
                 return (
                   <tr key={index}>
                     <td>{Dialect.forPath(dialectName).uri}</td>
@@ -37,8 +48,7 @@ const DialectCompliance: React.FC<{
                     <td className="text-center">{result.erroredTests}</td>
                   </tr>
                 );
-              },
-            )}
+              })}
           </tbody>
         </Table>
       </Card.Body>

--- a/frontend/src/data/Dialect.ts
+++ b/frontend/src/data/Dialect.ts
@@ -9,10 +9,16 @@ export default class Dialect {
   readonly path: string;
   readonly prettyName: string;
   readonly uri: string;
+  readonly firstPublicationDate: Date;
 
   private static all: Map<string, Dialect> = new Map<string, Dialect>();
 
-  constructor(path: string, prettyName: string, uri: string) {
+  constructor(
+    path: string,
+    prettyName: string,
+    uri: string,
+    firstPublicationDate: string,
+  ) {
     if (Dialect.all.has(path)) {
       throw new DialectError(`A "${path}" dialect already exists.`);
     }
@@ -21,6 +27,7 @@ export default class Dialect {
     this.path = path;
     this.prettyName = prettyName;
     this.uri = uri;
+    this.firstPublicationDate = new Date(firstPublicationDate);
   }
 
   async fetchReport(baseURI: URI) {
@@ -59,29 +66,35 @@ export const DRAFT202012 = new Dialect(
   "draft2020-12",
   "Draft 2020-12",
   "https://json-schema.org/draft/2020-12/schema",
+  "January 28, 2020",
 );
 export const DRAFT201909 = new Dialect(
   "draft2019-09",
   "Draft 2019-09",
   "https://json-schema.org/draft/2019-09/schema",
+  "September 17, 2019",
 );
 export const DRAFT7 = new Dialect(
   "draft7",
   "Draft 7",
   "http://json-schema.org/draft-07/schema#",
+  "November 19, 2017",
 );
 export const DRAFT6 = new Dialect(
   "draft6",
   "Draft 6",
   "http://json-schema.org/draft-06/schema#",
+  "April 21, 2017",
 );
 export const DRAFT4 = new Dialect(
   "draft4",
   "Draft 4",
   "http://json-schema.org/draft-04/schema#",
+  "January 31, 2013",
 );
 export const DRAFT3 = new Dialect(
   "draft3",
   "Draft 3",
   "http://json-schema.org/draft-03/schema#",
+  "November 22, 2010",
 );


### PR DESCRIPTION
The PR resolves issue #677 

Added firstPublicationDate in Dialects
Sorted compliance table in implementation page by compliance(fewer failed tests at the top) and break ties by publication date

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--723.org.readthedocs.build/en/723/

<!-- readthedocs-preview bowtie-json-schema end -->