### PR TITLE
Update unsupported tests of MJS

### DIFF
--- a/implementations/scala-mjs-validator/Harness.scala
+++ b/implementations/scala-mjs-validator/Harness.scala
@@ -23,7 +23,10 @@ class Harness {
   // List of specific tests of a case that are not supported
   val UNSUPPORTED_TESTS: Map[String, TestSkip] = Map(
     "minLength validation" -> TestSkip("one supplementary Unicode code point is not long enough", NOT_IMPLEMENTED),
-    "maxLength validation" -> TestSkip("two supplementary Unicode code points is long enough", NOT_IMPLEMENTED)
+    "maxLength validation" -> TestSkip("two supplementary Unicode code points is long enough", NOT_IMPLEMENTED),
+    // The above two tests were renamed to the following two tests. We keep the old names for backward compatibility.
+    "minLength validation" -> TestSkip("one grapheme is not long enough", NOT_IMPLEMENTED),
+    "maxLength validation" -> TestSkip("two graphemes is long enough", NOT_IMPLEMENTED)
   )
 
   def operate(line: String) = {


### PR DESCRIPTION
Two tests containing Unicode code points were renamed in the draft 2020-12 Test Suite. MJS does currently not support Unicode. This adds the new names to the set of unsupported tests.

For backwards-compatibility with older version of the draft 2020-12 Test Suite, we keep the previous names of the tests.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--769.org.readthedocs.build/en/769/

<!-- readthedocs-preview bowtie-json-schema end -->