### PR TITLE
Update kotlin-kmp-json-schema-validator: validator now supports remote schemes

### DIFF
--- a/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/BowtieSampsonSchemaValidatorLauncher.kt
+++ b/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/BowtieSampsonSchemaValidatorLauncher.kt
@@ -1,8 +1,12 @@
 import io.github.optimumcode.json.schema.ErrorCollector
 import io.github.optimumcode.json.schema.JsonSchema
+import io.github.optimumcode.json.schema.JsonSchemaLoader
 import io.github.optimumcode.json.schema.SchemaType
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.InputStreamReader
@@ -91,7 +95,20 @@ class BowtieSampsonSchemaValidatorLauncher(
 
         @Suppress("detekt:TooGenericExceptionCaught")
         val schema = try {
-            JsonSchema.fromJsonElement(schemaDefinition, currentDialect)
+            JsonSchemaLoader.create()
+                .apply {
+                    currentDialect?.also(this::registerWellKnown)
+                    for ((uri, schema) in command.case.registry) {
+                        if (skipSchema(uri, schema)) {
+                            continue
+                        }
+                        try {
+                            register(schema, uri)
+                        } catch (ex: Exception) {
+                            throw RuntimeException("cannot register schema for URI '$uri'", ex)
+                        }
+                    }
+                }.fromJsonElement(schemaDefinition, currentDialect)
         } catch (ex: Exception) {
             writer.writeLine(
                 json.encodeToString(
@@ -107,6 +124,19 @@ class BowtieSampsonSchemaValidatorLauncher(
             return
         }
         runCase(command, schema)
+    }
+
+    private fun skipSchema(uri: String, schema: JsonElement): Boolean {
+        if (uri.contains("draft4", ignoreCase = true)) {
+            // skip draft4 schemas
+            return true
+        }
+        // ignore schemas for unsupported drafts
+        return schema is JsonObject
+            && schema["\$schema"]
+                ?.jsonPrimitive
+                ?.content
+                .let { it != null && SchemaType.find(it) == null }
     }
 
     private fun runCase(command: Command.Run, schema: JsonSchema) {

--- a/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/BowtieSampsonSchemaValidatorLauncher.kt
+++ b/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/BowtieSampsonSchemaValidatorLauncher.kt
@@ -132,8 +132,8 @@ class BowtieSampsonSchemaValidatorLauncher(
             return true
         }
         // ignore schemas for unsupported drafts
-        return schema is JsonObject
-            && schema["\$schema"]
+        return schema is JsonObject &&
+            schema["\$schema"]
                 ?.jsonPrimitive
                 ?.content
                 .let { it != null && SchemaType.find(it) == null }

--- a/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/TestFilters.kt
+++ b/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/TestFilters.kt
@@ -20,52 +20,19 @@ fun getFilter(schemaType: SchemaType?): TestFilter =
     }
 
 object TestFilterDraft7 : TestFilter {
-    /**
-     * All these cases are ignored because they contain remote refs
-     * Library does not support them yet.
-     */
-    private val IGNORED_CASES: Set<String> = hashSetOf(
-        "validate definition against metaschema",
-        "base URI change - change folder",
-        "base URI change - change folder in subschema",
-        "base URI change",
-        "retrieved nested refs resolve relative to their URI not \$id",
-        "\$ref to \$ref finds location-independent \$id",
-    )
 
     override fun shouldSkipCase(caseDescription: String): String? {
         return when {
             caseDescription.endsWith(" format") -> "the format keyword is not yet supported"
-            caseDescription in IGNORED_CASES || caseDescription.contains("remote ref") ->
-                "remote schema loading is not yet supported"
-
             else -> null
         }
     }
 }
 
 object TestFilterDraft201909 : TestFilter {
-    /**
-     * All these cases are ignored because they contain remote refs or meta schema
-     * Library does not support them yet.
-     */
-    private val IGNORED_CASES_WITH_REMOTE_REF: Set<String> = hashSetOf(
-        "invalid anchors",
-        "Invalid use of fragments in location-independent \$id",
-        "Valid use of empty fragments in location-independent \$id",
-        "Unnormalized \$ids are allowed but discouraged",
-        "URN base URI with f-component",
-        "remote HTTP ref with different \$id",
-        "remote HTTP ref with different URN \$id",
-        "remote HTTP ref with nested absolute ref",
-        "\$ref to \$ref finds detached \$anchor",
+    private val IGNORED_CASES_WITH_CUSTOM_META_SCHEMA: Set<String> = hashSetOf(
         "schema that uses custom metaschema with with no validation vocabulary",
         "ignore unrecognized optional vocabulary",
-        "validate definition against metaschema",
-        "retrieved nested refs resolve relative to their URI not \$id",
-        "base URI change - change folder in subschema",
-        "base URI change - change folder",
-        "base URI change",
     )
 
     private val IGNORE_CASES_WITH_MIN_CONTAINS_ZERO = setOf(
@@ -75,8 +42,8 @@ object TestFilterDraft201909 : TestFilter {
     override fun shouldSkipCase(caseDescription: String): String? {
         return when {
             caseDescription.endsWith(" format") -> "the format keyword is not yet supported"
-            caseDescription in IGNORED_CASES_WITH_REMOTE_REF || caseDescription.contains("remote ref") ->
-                "remote schema loading and meta schemas are not yet supported"
+            caseDescription in IGNORED_CASES_WITH_CUSTOM_META_SCHEMA ->
+                "vocabulary from custom meta-schemas is not supported yet"
             caseDescription in IGNORE_CASES_WITH_MIN_CONTAINS_ZERO ->
                 "'minContains' does not affect contains work - at least one element must match 'contains' schema"
             else -> null
@@ -95,39 +62,16 @@ object TestFilterDraft201909 : TestFilter {
 }
 
 object TestFilterDraft202012 : TestFilter {
-    /**
-     * All these cases are ignored because they contain remote refs or meta schema
-     * Library does not support them yet.
-     */
-    private val IGNORED_CASES_WITH_REMOTE_REF: Set<String> = hashSetOf(
-        "invalid anchors",
-        "Invalid use of fragments in location-independent \$id",
-        "Valid use of empty fragments in location-independent \$id",
-        "Unnormalized \$ids are allowed but discouraged",
-        "URN base URI with f-component",
-        "remote HTTP ref with different \$id",
-        "remote HTTP ref with different URN \$id",
-        "remote HTTP ref with nested absolute ref",
-        "\$ref to \$ref finds detached \$anchor",
+    private val IGNORED_CASES_WITH_CUSTOM_META_SCHEMA: Set<String> = hashSetOf(
         "schema that uses custom metaschema with with no validation vocabulary",
         "ignore unrecognized optional vocabulary",
-        "validate definition against metaschema",
-        "retrieved nested refs resolve relative to their URI not \$id",
-        "base URI change - change folder in subschema",
-        "base URI change - change folder",
-        "base URI change",
-        "strict-tree schema, guards against misspelled properties",
-        "tests for implementation dynamic anchor and reference link",
-        "\$ref and \$dynamicAnchor are independent of order - \$defs first",
-        "\$ref and \$dynamicAnchor are independent of order - \$ref first",
-        "\$ref to \$dynamicRef finds detached \$dynamicAnchor",
     )
 
     override fun shouldSkipCase(caseDescription: String): String? {
         return when {
             caseDescription.endsWith(" format") -> "the format keyword is not yet supported"
-            caseDescription in IGNORED_CASES_WITH_REMOTE_REF || caseDescription.contains("remote ref") ->
-                "remote schema loading and meta schemas are not yet supported"
+            caseDescription in IGNORED_CASES_WITH_CUSTOM_META_SCHEMA ->
+                "vocabulary from custom meta-schemas is not supported yet"
             else -> null
         }
     }


### PR DESCRIPTION
Added support for referencing remote schemes

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--808.org.readthedocs.build/en/808/

<!-- readthedocs-preview bowtie-json-schema end -->