### PR TITLE
Fix java-json-schema-validator issues

### DIFF
--- a/implementations/java-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -145,7 +145,7 @@ public class BowtieJsonSchemaValidator {
       JsonMetaSchema metaSchema = jsonSchemaVersion.getInstance();
       JsonSchemaFactory.Builder factoryBuilder = JsonSchemaFactory
         .builder()
-        .schemaMappers(schemaMappers -> 
+        .schemaMappers(schemaMappers ->
           schemaMappers
             .mapPrefix("https://json-schema.org", "classpath:")
             .mapPrefix("http://json-schema.org", "classpath:"))


### PR DESCRIPTION
This fixes the issues it has running tests, for instance not being able to load https://json-schema.org/draft/2020-12/schema.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--811.org.readthedocs.build/en/811/

<!-- readthedocs-preview bowtie-json-schema end -->