### PR TITLE
Highlight the selected test case

### DIFF
--- a/frontend/src/components/Cases/CaseItem.tsx
+++ b/frontend/src/components/Cases/CaseItem.tsx
@@ -17,6 +17,7 @@ interface CaseProps {
 
 const CaseContent = ({ seq, caseData, implementations }: CaseProps) => {
   const [instance, setInstance] = useState<SetStateAction<unknown>>();
+  const [activeRow, setActiveRow] = useState<SetStateAction<unknown>>(-1);
 
   return (
     <>
@@ -49,7 +50,11 @@ const CaseContent = ({ seq, caseData, implementations }: CaseProps) => {
           </thead>
           <tbody>
             {caseData.tests.map((test, index) => (
-              <tr key={index} onClick={() => setInstance(test.instance)}>
+              <tr className={activeRow === index ? 'table-active' : ''} key={index} onClick={() => {
+                setInstance(test.instance)
+                setActiveRow(index)
+              }
+              }>
                 <td>
                   <p className="m-0">{test.description}</p>
                 </td>

--- a/frontend/src/components/Cases/CaseItem.tsx
+++ b/frontend/src/components/Cases/CaseItem.tsx
@@ -50,11 +50,14 @@ const CaseContent = ({ seq, caseData, implementations }: CaseProps) => {
           </thead>
           <tbody>
             {caseData.tests.map((test, index) => (
-              <tr className={activeRow === index ? 'table-active' : ''} key={index} onClick={() => {
-                setInstance(test.instance)
-                setActiveRow(index)
-              }
-              }>
+              <tr
+                className={activeRow === index ? "table-active" : ""}
+                key={index}
+                onClick={() => {
+                  setInstance(test.instance);
+                  setActiveRow(index);
+                }}
+              >
                 <td>
                   <p className="m-0">{test.description}</p>
                 </td>


### PR DESCRIPTION
**This pull request addresses #543.**

The goal is to highlight the test case which has been selected as currently it's impossible to tell which case is shown in the "instance" column.

**Implemented Enhancement:** 

Highlighted the selected test case in a greyish gradient so that it is distinguishable from the other test cases.

<img width="1273" alt="Screenshot 2024-02-05 at 8 12 14 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/515b3634-c9cf-4bf2-bb91-35ca1ee04f61">



<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--827.org.readthedocs.build/en/827/

<!-- readthedocs-preview bowtie-json-schema end -->