### PR TITLE
Populate the GitPod MOTD with Bowtie documentation

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,8 +8,12 @@ additionalRepositories:
   # TODO: referencing-suite and others, once Bowtie supports them
 
 tasks:
+  - name: Populate MOTD with documentation
+    init: sudo chown -R gitpod:gitpod /etc/motd && cp /workspace/bowtie/docs/gitpod-motd.txt /etc/motd
+
   - name: Install Bowtie
     init: python3 -m pip install -r requirements.txt -e . && pyenv rehash
 
   - name: Pull Bowtie Images
     init: for each in $(ls implementations); do docker pull ghcr.io/bowtie-json-schema/$each; done
+  

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,3 +16,6 @@ tasks:
 
   - name: Pull Bowtie Images
     init: for each in $(ls implementations); do docker pull ghcr.io/bowtie-json-schema/$each; done
+
+  - name: Open Bowtie Documentation by default in web-ui
+    init: gp open /workspace/bowtie/docs/gitpod-motd.txt

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,4 +16,3 @@ tasks:
 
   - name: Pull Bowtie Images
     init: for each in $(ls implementations); do docker pull ghcr.io/bowtie-json-schema/$each; done
-  

--- a/docs/gitpod-motd.txt
+++ b/docs/gitpod-motd.txt
@@ -1,0 +1,61 @@
+
+bowtie
+  A meta-validator for the JSON Schema specifications.
+
+  Bowtie gives you access to JSON Schema across every programming language and
+  implementation.
+
+  It lets you compare implementations to each other, or to known correct
+  results from the JSON Schema test suite.
+
+  If you don't know where to begin, ``bowtie validate`` (for checking what any
+  given implementations think of your schema) or ``bowtie suite`` (for running
+  the official test suite against implementations) are likely good places to
+  start.
+
+  Full documentation can also be found at https://docs.bowtie.report
+
+Usage:
+  bowtie [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --version                       Show the version and exit.
+  -L, --log-level [debug|info|warning|error|critical]
+                                  How verbose should Bowtie be?  [default:
+                                  (info)]
+  -h, --help                      Show this message and exit.
+
+Commands:
+  badges    Generate Bowtie badges from a previous run.
+  info      Retrieve a particular implementation (harness)'s metadata.
+  run       Run a sequence of cases provided on standard input.
+  smoke     Smoke test one or more implementations for basic correctness.
+  suite     Run test cases from the official JSON Schema test suite.
+  summary   Generate an (in-terminal) summary of a Bowtie run.
+  tui       Open a simple interactive TUI for executing Bowtie commands.
+  validate  Validate one or more instances under a given schema across...
+
+Examples:
+  1.  bowtie validate -i js-ajv -i js-hyperjump <(printf '{"type": "integer"}') <(printf 37) <(printf '"foo"')
+
+      Description:
+      Given some collection of implementations to check - here perhaps two Javascript
+      implementations - it takes a single schema and one or more instances to check
+      against it.
+
+  2.  bowtie suite -i lua-jsonschema
+       https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft7/type.json
+        | bowtie summary --show failures
+
+      Description:
+      To run the draft 7 type-keyword tests on the Lua jsonschema implementation
+
+  3.  bowtie suite $(ls /path/to/bowtie/implementations/ | sed 's/^| /-i /') 
+       https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft7 
+        | bowtie summary --show failures
+
+      Description:
+      The following will run all Draft 7 tests from the official test suite 
+      (which it will automatically retrieve) across all implementations supporting Draft 7, 
+      and generate an HTML report named bowtie-report.html in the current directory
+

--- a/docs/gitpod-motd.txt
+++ b/docs/gitpod-motd.txt
@@ -50,12 +50,11 @@ Examples:
       Description:
       To run the draft 7 type-keyword tests on the Lua jsonschema implementation
 
-  3.  bowtie suite $(ls /path/to/bowtie/implementations/ | sed 's/^| /-i /') 
-       https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft7 
+  3.  bowtie suite $(ls /path/to/bowtie/implementations/ | sed 's/^| /-i /')
+       https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft7
         | bowtie summary --show failures
 
       Description:
-      The following will run all Draft 7 tests from the official test suite 
-      (which it will automatically retrieve) across all implementations supporting Draft 7, 
+      The following will run all Draft 7 tests from the official test suite
+      (which it will automatically retrieve) across all implementations supporting Draft 7,
       and generate an HTML report named bowtie-report.html in the current directory
-


### PR DESCRIPTION
This pull request addresses #695.

The goal is to populate the Gitpod MOTD with Bowtie documentation showing some example commands as well for using Bowtie.

Implementation:
   1. Created a txt file containing the message to be shown in the MOTD in docs folder.
   2.  Added task in gitpod yml to copy this message to the workspace motd file.

Preview of ssh:

<img width="1043" alt="Screenshot 2024-02-06 at 2 01 33 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/951dad8c-3a65-4503-88cf-fb661c49370d">
<img width="1043" alt="Screenshot 2024-02-06 at 2 13 34 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/a7065dc0-70d9-4417-a1f4-84f687632991">

Preview of web-ui:

<img width="1710" alt="Screenshot 2024-02-06 at 2 32 44 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/792c708c-511c-4858-8fe0-9e89efe25715">


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--830.org.readthedocs.build/en/830/

<!-- readthedocs-preview bowtie-json-schema end -->