### PR TITLE
Update skipped tests for MJS validator

### DIFF
--- a/implementations/scala-mjs-validator/Harness.scala
+++ b/implementations/scala-mjs-validator/Harness.scala
@@ -15,9 +15,7 @@ class Harness {
     "escaped pointer ref" -> NOT_IMPLEMENTED,
     "empty tokens in $ref json-pointer" -> NOT_IMPLEMENTED,
     "schema that uses custom metaschema with with no validation vocabulary" -> NOT_IMPLEMENTED,
-    "small multiple of large integer" -> NOT_IMPLEMENTED,
-    "$ref to $ref finds detached $anchor" -> NOT_IMPLEMENTED,
-    "$ref to $dynamicRef finds detached $dynamicAnchor" -> NOT_IMPLEMENTED
+    "small multiple of large integer" -> NOT_IMPLEMENTED
   )
 
   // List of specific tests of a case that are not supported


### PR DESCRIPTION
Some tests were skipped as a leftover artifact due to restrictions in an older version that are already resolved in the current MJS version (v0.1.0).

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--832.org.readthedocs.build/en/832/

<!-- readthedocs-preview bowtie-json-schema end -->