### PR TITLE
add --format markdown to commands

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -21,7 +21,6 @@ from rich.table import Column, Table
 from rich.text import Text
 from trogon import tui  # type: ignore[reportMissingTypeStubs]
 import click
-import markdown
 import referencing_loaders
 import rich
 import structlog
@@ -450,9 +449,9 @@ def _failure_table_in_markdown(
 
     markdown_table = _convert_table_to_markdown(columns, rows)
     return (
-        markdown.markdown("# Bowtie Failures Summary")
+        "# Bowtie Failures Summary"
         + markdown_table
-        + markdown.markdown(f"{report.total_tests} {test} ran\n")
+        + f"**{report.total_tests} {test} ran**\n"
     )
 
 
@@ -536,12 +535,12 @@ def _validation_results_table_in_markdown(
 
     for idx, row_data in enumerate(rows_data):
         final_content += (
-            markdown.markdown(f"### {idx+1}. Schema:\n {row_data[0]}") + "\n\n"
+            (f"### {idx+1}. Schema:\n {row_data[0]}\n\n")
         )
-        final_content += markdown.markdown("### Results:")
+        final_content += "### Results:"
         final_content += row_data[1]
 
-    return str(final_content)
+    return final_content
 
 
 @cache
@@ -758,11 +757,8 @@ async def info(implementations: Iterable[Implementation], format: _F):
                 )
             case "markdown":
                 click.echo(
-                    "\n".join(
-                        markdown.markdown(
-                            f"**{k}**: {json.dumps(v, indent=2)}",
-                        )
-                        for k, v in metadata
+                    "\n".join
+                        (f"**{k}**: {json.dumps(v, indent=2)}" for k, v in metadata
                     ),
                 )
 
@@ -812,11 +808,7 @@ async def smoke(
                         echo(f"  · {case.description}: {result.dots()}")
 
                     case "markdown":
-                        echo(
-                            markdown.markdown(
-                                f"* {case.description}: {result.dots()}",
-                            ),
-                        )
+                        echo(f"* {case.description}: {result.dots()}")
 
         match format:
             case "json":
@@ -827,8 +819,8 @@ async def smoke(
                 echo(f"\n{message}", file=sys.stderr)
 
             case "markdown":
-                message = "❌ some failures" if exit_code else "✅ all passed"
-                echo(markdown.markdown(f"\n{message}"), file=sys.stderr)
+                message = "**❌ some failures**" if exit_code else "**✅ all passed**"
+                echo(f"\n{message}", file=sys.stderr)
 
     return exit_code
 

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -22,7 +22,7 @@ from rich.text import Text
 from trogon import tui  # type: ignore[reportMissingTypeStubs]
 import click
 import markdown
-import pandas as pd
+import pandas as pd  # type: ignore[reportMissingTypeStubs]
 import referencing_loaders
 import rich
 import structlog
@@ -398,11 +398,9 @@ def _failure_table(
 
 def _failure_table_in_markdown(
     report: _report.Report,
-    results: Iterable[
-        tuple[TestCase, Iterable[tuple[Test, Mapping[str, AnyTestResult]]]],
-    ],
+    results: list[tuple[ImplementationInfo, Unsuccessful]],
 ):
-    main_df_data = []
+    main_df_data: list[list[str]] = []
     test = "tests" if report.total_tests != 1 else "test"
 
     main_table_columns = [
@@ -426,7 +424,7 @@ def _failure_table_in_markdown(
     main_df = pd.DataFrame(main_df_data, columns=main_table_columns)
     return (
         "# Bowtie Failures Summary\n\n"
-        + main_df.to_markdown(index=False)
+        + str(main_df.to_markdown(index=False))  # type: ignore[reportUnknownMemberType]
         + "\n\n"
         + f"{report.total_tests} {test} ran\n"
     )
@@ -480,7 +478,7 @@ def _validation_results_table_in_markdown(
         tuple[TestCase, Iterable[tuple[Test, Mapping[str, AnyTestResult]]]],
     ],
 ):
-    rows_data = []
+    rows_data: list[list[str | None]] = []
     final_content = ""
 
     inner_table_columns = ["Instance"]
@@ -491,7 +489,7 @@ def _validation_results_table_in_markdown(
     )
 
     for case, test_results in results:
-        inner_df_data = []
+        inner_df_data: list[list[str]] = []
         for test, test_result in test_results:
             inner_df_data.append(
                 [
@@ -504,7 +502,7 @@ def _validation_results_table_in_markdown(
             )
 
         inner_df = pd.DataFrame(inner_df_data, columns=inner_table_columns)
-        inner_markdown_table = inner_df.to_markdown(index=False)
+        inner_markdown_table = inner_df.to_markdown(index=False)  # type: ignore[reportMissingTypeStubs]
         schema_name = json.dumps(case.schema, indent=2)
         row_data = [schema_name, inner_markdown_table]
         rows_data.append(row_data)
@@ -514,10 +512,10 @@ def _validation_results_table_in_markdown(
             markdown.markdown(f"### {idx+1}. Schema:\n {row_data[0]}") + "\n\n"
         )
         final_content += markdown.markdown("### Results:") + "\n\n"
-        final_content += row_data[1]
+        final_content += str(row_data[1])
         final_content += "\n\n"
 
-    return final_content
+    return str(final_content)
 
 
 @cache

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -373,27 +373,33 @@ def summary(input: TextIO, format: _F, show: str):
 
 
 def _convert_table_to_markdown(
-    columns: list[Any], 
-    rows: list[list[Any]]
+    columns: list[Any],
+    rows: list[list[Any]],
 ):
-    widths = [max(len(line[i]) for line in columns) for i in range(len(columns))]
+    widths = [
+        max(len(line[i]) for line in columns) for i in range(len(columns))
+    ]
     rows = [[elt.center(w) for elt, w in zip(line, widths)] for line in rows]
 
-    header = '| ' + ' | '.join(columns) + ' |'
-    border_left   =  '|:'
-    border_center = ':|:'
-    border_right  = ':|'
-    
-    separator = border_left + border_center.join(['-'*w for w in widths]) + border_right
+    header = "| " + " | ".join(columns) + " |"
+    border_left = "|:"
+    border_center = ":|:"
+    border_right = ":|"
+
+    separator = (
+        border_left
+        + border_center.join(["-" * w for w in widths])
+        + border_right
+    )
 
     # body of the table
-    body = [''] * len(rows)  # empty string list that we fill after
+    body = [""] * len(rows)  # empty string list that we fill after
     for idx, line in enumerate(rows):
         # for each line, change the body at the correct index
-        body[idx] = '| ' + ' | '.join(line) + ' |'
-    body = '\n'.join(body)
+        body[idx] = "| " + " | ".join(line) + " |"
+    body = "\n".join(body)
 
-    return '\n\n' + header + '\n' + separator + '\n' + body + '\n\n'
+    return "\n\n" + header + "\n" + separator + "\n" + body + "\n\n"
 
 
 def _failure_table(
@@ -521,7 +527,8 @@ def _validation_results_table_in_markdown(
                 ],
             )
         inner_markdown_table = _convert_table_to_markdown(
-            inner_table_columns, inner_table_rows
+            inner_table_columns,
+            inner_table_rows,
         )
         schema_name = json.dumps(case.schema, indent=2)
         row_data = [schema_name, inner_markdown_table]

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -11,8 +11,6 @@ import json
 import logging
 import os
 import sys
-import markdown
-import pandas as pd
 
 from aiodocker import Docker
 from attrs import asdict
@@ -23,6 +21,8 @@ from rich.table import Column, Table
 from rich.text import Text
 from trogon import tui  # type: ignore[reportMissingTypeStubs]
 import click
+import markdown
+import pandas as pd
 import referencing_loaders
 import rich
 import structlog
@@ -404,26 +404,33 @@ def _failure_table_in_markdown(
 ):
     main_df_data = []
     test = "tests" if report.total_tests != 1 else "test"
-    
+
     main_table_columns = [
-        "Implementation", 
+        "Implementation",
         "Skips",
         "Errors",
-        "Failures"
+        "Failures",
     ]
 
     for each, unsuccessful in results:
-        main_df_data.append([
-            f"{each.name} ({each.language})",
-            str(unsuccessful.skipped),
-            str(unsuccessful.errored),
-            str(unsuccessful.failed),
-        ])
+        main_df_data.append(
+            [
+                f"{each.name} ({each.language})",
+                str(unsuccessful.skipped),
+                str(unsuccessful.errored),
+                str(unsuccessful.failed),
+            ]
+        )
 
     # Convert DataFrame to Markdown format
     main_df = pd.DataFrame(main_df_data, columns=main_table_columns)
     markdown_table = main_df.to_markdown(index=False)
-    markdown_table = "# Bowtie Failures Summary\n\n" + markdown_table + "\n\n" + f"{report.total_tests} {test} ran\n"
+    markdown_table = (
+        "# Bowtie Failures Summary\n\n"
+        + markdown_table
+        + "\n\n"
+        + f"{report.total_tests} {test} ran\n"
+    )
     return markdown_table
 
 
@@ -481,17 +488,19 @@ def _validation_results_table_in_markdown(
     inner_table_columns = ["Instance"]
     implementations = report.implementations
     for implementation in implementations:
-        inner_table_columns.append(f"{implementation.name} ({implementation.language})")
+        inner_table_columns.append(
+            f"{implementation.name} ({implementation.language})"
+        )
 
     for case, test_results in results:
         inner_df_data = []
         for test, test_result in test_results:
             inner_row_data = [
-                json.dumps(test.instance), 
+                json.dumps(test.instance),
                 *(
                     test_result[each.id].description
                     for each in implementations
-                )
+                ),
             ]
             inner_df_data.append(inner_row_data)
 
@@ -502,8 +511,10 @@ def _validation_results_table_in_markdown(
         rows_data.append(row_data)
 
     for idx, row_data in enumerate(rows_data):
-        final_content += markdown.markdown(f"### {idx+1}. Schema:\n {row_data[0]}") + '\n\n'
-        final_content += markdown.markdown(f"### Results:") + '\n\n'
+        final_content += (
+            markdown.markdown(f"### {idx+1}. Schema:\n {row_data[0]}") + "\n\n"
+        )
+        final_content += markdown.markdown("### Results:") + "\n\n"
         final_content += row_data[1]
         final_content += "\n\n"
 
@@ -725,9 +736,11 @@ async def info(implementations: Iterable[Implementation], format: _F):
             case "markdown":
                 click.echo(
                     "\n".join(
-                        markdown.markdown(f"**{k}**: {json.dumps(v, indent=2)}")
+                        markdown.markdown(
+                            f"**{k}**: {json.dumps(v, indent=2)}"
+                        )
                         for k, v in metadata
-                    )
+                    ),
                 ),
 
 
@@ -776,7 +789,11 @@ async def smoke(
                         echo(f"  · {case.description}: {result.dots()}")
 
                     case "markdown":
-                        echo(markdown.markdown(f"* {case.description}: {result.dots()}"))
+                        echo(
+                            markdown.markdown(
+                                f"* {case.description}: {result.dots()}"
+                            )
+                        )
 
         match format:
             case "json":

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -534,9 +534,7 @@ def _validation_results_table_in_markdown(
         rows_data.append(row_data)
 
     for idx, row_data in enumerate(rows_data):
-        final_content += (
-            (f"### {idx+1}. Schema:\n {row_data[0]}\n\n")
-        )
+        final_content += f"### {idx+1}. Schema:\n {row_data[0]}\n\n"
         final_content += "### Results:"
         final_content += row_data[1]
 
@@ -757,8 +755,9 @@ async def info(implementations: Iterable[Implementation], format: _F):
                 )
             case "markdown":
                 click.echo(
-                    "\n".join
-                        (f"**{k}**: {json.dumps(v, indent=2)}" for k, v in metadata
+                    "\n".join(
+                        f"**{k}**: {json.dumps(v, indent=2)}"
+                        for k, v in metadata
                     ),
                 )
 
@@ -819,7 +818,11 @@ async def smoke(
                 echo(f"\n{message}", file=sys.stderr)
 
             case "markdown":
-                message = "**❌ some failures**" if exit_code else "**✅ all passed**"
+                message = (
+                    "**❌ some failures**"
+                    if exit_code
+                    else "**✅ all passed**"
+                )
                 echo(f"\n{message}", file=sys.stderr)
 
     return exit_code

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -421,7 +421,7 @@ def _failure_table_in_markdown(
         )
 
     # Convert DataFrame to Markdown format
-    main_df = pd.DataFrame(main_df_data, columns=main_table_columns)
+    main_df = pd.DataFrame(main_df_data, columns=main_table_columns)  # type: ignore[reportArgumentType]
     return (
         "# Bowtie Failures Summary\n\n"
         + str(main_df.to_markdown(index=False))  # type: ignore[reportUnknownMemberType]
@@ -501,7 +501,7 @@ def _validation_results_table_in_markdown(
                 ],
             )
 
-        inner_df = pd.DataFrame(inner_df_data, columns=inner_table_columns)
+        inner_df = pd.DataFrame(inner_df_data, columns=inner_table_columns)  # type: ignore[reportArgumentType]
         inner_markdown_table = inner_df.to_markdown(index=False)  # type: ignore[reportMissingTypeStubs]
         schema_name = json.dumps(case.schema, indent=2)
         row_data = [schema_name, inner_markdown_table]

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -419,19 +419,17 @@ def _failure_table_in_markdown(
                 str(unsuccessful.skipped),
                 str(unsuccessful.errored),
                 str(unsuccessful.failed),
-            ]
+            ],
         )
 
     # Convert DataFrame to Markdown format
     main_df = pd.DataFrame(main_df_data, columns=main_table_columns)
-    markdown_table = main_df.to_markdown(index=False)
-    markdown_table = (
+    return (
         "# Bowtie Failures Summary\n\n"
-        + markdown_table
+        + main_df.to_markdown(index=False)
         + "\n\n"
         + f"{report.total_tests} {test} ran\n"
     )
-    return markdown_table
 
 
 def _validation_results_table(
@@ -487,22 +485,23 @@ def _validation_results_table_in_markdown(
 
     inner_table_columns = ["Instance"]
     implementations = report.implementations
-    for implementation in implementations:
-        inner_table_columns.append(
-            f"{implementation.name} ({implementation.language})"
-        )
+    inner_table_columns.extend(
+        f"{implementation.name} ({implementation.language})"
+        for implementation in implementations
+    )
 
     for case, test_results in results:
         inner_df_data = []
         for test, test_result in test_results:
-            inner_row_data = [
-                json.dumps(test.instance),
-                *(
-                    test_result[each.id].description
-                    for each in implementations
-                ),
-            ]
-            inner_df_data.append(inner_row_data)
+            inner_df_data.append(
+                [
+                    json.dumps(test.instance),
+                    *(
+                        test_result[each.id].description
+                        for each in implementations
+                    ),
+                ],
+            )
 
         inner_df = pd.DataFrame(inner_df_data, columns=inner_table_columns)
         inner_markdown_table = inner_df.to_markdown(index=False)
@@ -737,11 +736,11 @@ async def info(implementations: Iterable[Implementation], format: _F):
                 click.echo(
                     "\n".join(
                         markdown.markdown(
-                            f"**{k}**: {json.dumps(v, indent=2)}"
+                            f"**{k}**: {json.dumps(v, indent=2)}",
                         )
                         for k, v in metadata
                     ),
-                ),
+                )
 
 
 @implementation_subcommand()  # type: ignore[reportArgumentType]
@@ -791,8 +790,8 @@ async def smoke(
                     case "markdown":
                         echo(
                             markdown.markdown(
-                                f"* {case.description}: {result.dots()}"
-                            )
+                                f"* {case.description}: {result.dots()}",
+                            ),
                         )
 
         match format:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,7 @@ dependencies = [
   "trogon>=0.4.0",
   "typing-extensions; python_version<'3.11'",
   "url.py",
-  "markdown",
-  "pandas",
-  "tabulate"
+  "markdown"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dependencies = [
   "trogon>=0.4.0",
   "typing-extensions; python_version<'3.11'",
   "url.py",
+  "markdown",
+  "pandas",
+  "tabulate"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ dependencies = [
   "structlog",
   "trogon>=0.4.0",
   "typing-extensions; python_version<'3.11'",
-  "url.py",
-  "markdown"
+  "url.py"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "structlog",
   "trogon>=0.4.0",
   "typing-extensions; python_version<'3.11'",
-  "url.py"
+  "url.py",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -806,12 +806,8 @@ async def test_smoke_markdown(envsonschema):
         dedent(stdout)
         == dedent(
             """
-            <ul>
-            <li>allow-everything: ✗✗✗✗✗✗</li>
-            </ul>
-            <ul>
-            <li>allow-nothing: ✓✓✓✓✓✓</li>
-            </ul>
+            * allow-everything: ✗✗✗✗✗✗
+            * allow-nothing: ✓✓✓✓✓✓
         """,
         ).lstrip("\n")
     ), stderr
@@ -937,19 +933,19 @@ async def test_info_markdown(envsonschema):
     )
     assert stdout == dedent(
         """\
-        <p><strong>name</strong>: "envsonschema"</p>
-        <p><strong>language</strong>: "python"</p>
-        <p><strong>homepage</strong>: "https://github.com/bowtie-json-schema/bowtie"</p>
-        <p><strong>issues</strong>: "https://github.com/bowtie-json-schema/bowtie/issues"</p>
-        <p><strong>source</strong>: "https://github.com/bowtie-json-schema/bowtie"</p>
-        <p><strong>dialects</strong>: [
+        **name**: "envsonschema"
+        **language**: "python"
+        **homepage**: "https://github.com/bowtie-json-schema/bowtie"
+        **issues**: "https://github.com/bowtie-json-schema/bowtie/issues"
+        **source**: "https://github.com/bowtie-json-schema/bowtie"
+        **dialects**: [
           "https://json-schema.org/draft/2020-12/schema",
           "https://json-schema.org/draft/2019-09/schema",
           "http://json-schema.org/draft-07/schema#",
           "http://json-schema.org/draft-06/schema#",
           "http://json-schema.org/draft-04/schema#",
           "http://json-schema.org/draft-03/schema#"
-        ]</p>
+        ]
         """,
     )
     assert stderr == ""
@@ -1111,13 +1107,14 @@ async def test_summary_show_failures_markdown(envsonschema, tmp_path):
     assert stderr == ""
     assert stdout == dedent(
         """\
-        <h1>Bowtie Failures Summary</h1>
+        # Bowtie Failures Summary
 
         | Implementation | Skips | Errors | Failures |
         |:-:|:-:|:-:|:-:|
         | envsonschema (python) | 0 | 0 | 2 |
 
-        <p>2 tests ran</p>
+        **2 tests ran**
+
         """,
     )
 


### PR DESCRIPTION
**This pull request addresses #831.**

The goal is to add markdown formatter to commands for interoperability with other human-reader-targeted tooling.

### Implemented Enhancement:

Added --format option: markdown to be able to give output in markdown format for commands such as bowtie summary, bowtie info, bowtie smoke, etc.

### Output images:

**1. bowtie summary with show failures**
<img width="1710" alt="Screenshot 2024-02-08 at 10 54 09 AM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/d0afb051-ebb7-4156-afc1-68842e4b8cff">

**2. bowtie summary with results**
<img width="1710" alt="Screenshot 2024-02-08 at 10 49 04 AM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/cf98d0ad-8e82-4e18-b77c-22cdc28cf3bb">
**3. bowtie info**
<img width="1710" alt="Screenshot 2024-02-08 at 10 53 10 AM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/5656a62f-27bc-4758-99fb-eceac31f3371">

**4. bowtie smoke** 
<img width="1710" alt="Screenshot 2024-02-08 at 10 52 35 AM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/c466f75b-ebe1-4573-9cca-f334c4ab1249">




<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--839.org.readthedocs.build/en/839/

<!-- readthedocs-preview bowtie-json-schema end -->