### PR TITLE
Show bowtie summary & bowtie smoke output in GITHUB_STEP_SUMMARY

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -76,7 +76,7 @@ jobs:
         # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Set DOCKER_HOST to find the image
-        run: echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV
+        run: echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV && echo "Hello World" >> $GITHUB_STEP_SUMMARY
 
       - name: Install Bowtie
         uses: ./

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Build
         id: build_image
@@ -73,14 +73,14 @@ jobs:
           image: ${{ matrix.image }}
           tags: latest ${{ github.sha }}
           archs: amd64, arm64
-        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Set DOCKER_HOST to find the image
         run: echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV
 
       - name: Install Bowtie
         uses: ./
-        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Smoke Test
         run: bowtie smoke -i "localhost/${{ steps.build_image.outputs.image-with-tag }}" --format markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -76,7 +76,7 @@ jobs:
         # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Set DOCKER_HOST to find the image
-        run: echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV && echo "Hello World" >> $GITHUB_STEP_SUMMARY
+        run: echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV
 
       - name: Install Bowtie
         uses: ./

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Build
         id: build_image
@@ -73,18 +73,18 @@ jobs:
           image: ${{ matrix.image }}
           tags: latest ${{ github.sha }}
           archs: amd64, arm64
-        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Set DOCKER_HOST to find the image
         run: echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> $GITHUB_ENV
 
       - name: Install Bowtie
         uses: ./
-        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Smoke Test
         run: bowtie smoke -i "localhost/${{ steps.build_image.outputs.image-with-tag }}" --format markdown >> $GITHUB_STEP_SUMMARY
-        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Publish
         id: push

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -83,8 +83,8 @@ jobs:
         if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Smoke Test
-        run: bowtie smoke -i "localhost/${{ steps.build_image.outputs.image-with-tag }}"
-        if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+        run: bowtie smoke -i "localhost/${{ steps.build_image.outputs.image-with-tag }}" --format markdown >> $GITHUB_STEP_SUMMARY
+        # if: steps.changes.outputs.impl == 'true' || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
 
       - name: Publish
         id: push

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -5,7 +5,6 @@ on:
     types: [published]
   workflow_call:
   workflow_dispatch:
-  pull_request:
   schedule:
     # Daily at 2:15
     - cron: "15 2 * * *"

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
   workflow_call:
   workflow_dispatch:
+  pull_request:
   schedule:
     # Daily at 2:15
     - cron: "15 2 * * *"
@@ -54,7 +55,7 @@ jobs:
       # Besides fixing that, probably we should atomically move files into place.
       - name: Check Report is Valid
         run: |
-          bowtie summary --show failures ${{ matrix.version }}.json
+          bowtie summary --show failures ${{ matrix.version }}.json --format markdown >> $GITHUB_STEP_SUMMARY
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This pull request addresses #850.

The goal is to emit the bowtie smoke output in images.yml workflow and bowtie summary output in report.yml workflow to the github actions summary.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--843.org.readthedocs.build/en/843/

<!-- readthedocs-preview bowtie-json-schema end -->