### PR TITLE
Save older build reports separately to track changes

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -26,7 +26,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         with:
           workflow: report.yml
-          branch: test-workflow
+          branch: main
           name: report
           path: report/previous
 

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -19,7 +19,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  store-prev-reports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download previous test report from local artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: report
+          path: previous
+
+      - name: Upload previous test report to previous folder in artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: report
+          path: |
+            previous/
+
   test:
+    needs: store-prev-reports
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -19,26 +19,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  store-prev-reports:
+  download-prev-reports:
     runs-on: ubuntu-latest
     steps:
-      - name: Download previous latest test report
+      - name: Download previous test report from local artifact
         uses: dawidd6/action-download-artifact@v3
         with:
           workflow: report.yml
-          branch: main
+          branch: test-workflow
           name: report
           path: report/previous
 
-      - name: Upload previous test report to "previous" folder in artifact
+      - name: Remove already existing previous folder to prevent recursive folders
+        run: rm -rf report/previous/previous
+
+      - name: Upload previous test report to temporary artifact
         uses: actions/upload-artifact@v3
         with:
-          name: report
+          name: prev-report
           path: |
             report/
 
   test:
-    needs: store-prev-reports
+    needs: download-prev-reports
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -82,8 +85,25 @@ jobs:
             ${{ matrix.version }}.json
             badges/
 
-  deploy-frontend:
+  store-prev-reports:
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download previous test report from temp artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: prev-report
+          path: report/
+
+      - name: Upload previous test report to previous folder in artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: report
+          path: |
+            report/
+
+  deploy-frontend:
+    needs: store-prev-reports
     uses: ./.github/workflows/deploy-frontend.yml
     with:
       report_artifact_in_scope: true

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -22,18 +22,20 @@ jobs:
   store-prev-reports:
     runs-on: ubuntu-latest
     steps:
-      - name: Download previous test report from local artifact
-        uses: actions/download-artifact@v3
+      - name: Download previous latest test report
+        uses: dawidd6/action-download-artifact@v3
         with:
+          workflow: report.yml
+          branch: main
           name: report
-          path: previous
+          path: report/previous
 
-      - name: Upload previous test report to previous folder in artifact
+      - name: Upload previous test report to "previous" folder in artifact
         uses: actions/upload-artifact@v3
         with:
           name: report
           path: |
-            previous/
+            report/
 
   test:
     needs: store-prev-reports

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -26,7 +26,6 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         with:
           workflow: report.yml
-          branch: main
           name: report
           path: report/previous
 


### PR DESCRIPTION
This pull request addresses #448.

Incorporated the changes in workflow to store the previous reports in a separate folder

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--851.org.readthedocs.build/en/851/

<!-- readthedocs-preview bowtie-json-schema end -->