### PR TITLE
Hide the details button on reports when there are no failures

### DIFF
--- a/frontend/src/components/Summary/ImplementationRow.tsx
+++ b/frontend/src/components/Summary/ImplementationRow.tsx
@@ -49,13 +49,13 @@ const ImplementationRow = ({
       </td>
 
       <td>
-        <button
+        {implementation.failedTests + implementation.erroredTests + implementation.skippedTests > 0 && <button
           type="button"
           className="btn btn-sm btn-primary"
           onClick={() => setShowDetails(true)}
         >
           Details
-        </button>
+        </button>}
       </td>
       <DetailsButtonModal
         show={showDetails}

--- a/frontend/src/components/Summary/ImplementationRow.tsx
+++ b/frontend/src/components/Summary/ImplementationRow.tsx
@@ -49,13 +49,18 @@ const ImplementationRow = ({
       </td>
 
       <td>
-        {implementation.failedTests + implementation.erroredTests + implementation.skippedTests > 0 && <button
-          type="button"
-          className="btn btn-sm btn-primary"
-          onClick={() => setShowDetails(true)}
-        >
-          Details
-        </button>}
+        {implementation.failedTests +
+          implementation.erroredTests +
+          implementation.skippedTests >
+          0 && (
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            onClick={() => setShowDetails(true)}
+          >
+            Details
+          </button>
+        )}
       </td>
       <DetailsButtonModal
         show={showDetails}


### PR DESCRIPTION
**This pull request solves #867.**

**Implementation:**
 Dont show the details button if the implementations has no errored, no skipped and no failed tests.

Screenshot:
<img width="965" alt="Screenshot 2024-02-13 at 9 59 55 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/da88fcdb-cc96-4839-a2d0-c31283b12586">


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--869.org.readthedocs.build/en/869/

<!-- readthedocs-preview bowtie-json-schema end -->