### PR TITLE
fix-#333: add extra info on UI

### DIFF
--- a/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
+++ b/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
@@ -121,6 +121,22 @@ const ReportComponent: React.FC<{ implementation: Implementation }> = ({
                   </ul>
                 </td>
               </tr>
+              {implementation.links && !!implementation.links.length && 
+              <tr>
+                <th>Additional Links:</th>
+                <td>
+                  <ul>
+                    {implementation.links.map(({description, url}, index: number ) => 
+                      <li key={index}>
+                        <Link to={url ?? ''}>
+                          {description}
+                        </Link>
+                      </li>
+                     )}
+                  </ul>
+                </td>
+              </tr>
+              }
             </tbody>
           </Table>
         </Card.Body>

--- a/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
+++ b/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
@@ -121,22 +121,22 @@ const ReportComponent: React.FC<{ implementation: Implementation }> = ({
                   </ul>
                 </td>
               </tr>
-              {implementation.links && !!implementation.links.length && 
-              <tr>
-                <th>Additional Links:</th>
-                <td>
-                  <ul>
-                    {implementation.links.map(({description, url}, index: number ) => 
-                      <li key={index}>
-                        <Link to={url ?? ''}>
-                          {description}
-                        </Link>
-                      </li>
-                     )}
-                  </ul>
-                </td>
-              </tr>
-              }
+              {implementation.links && !!implementation.links.length && (
+                <tr>
+                  <th>Additional Links:</th>
+                  <td>
+                    <ul>
+                      {implementation.links.map(
+                        ({ description, url }, index: number) => (
+                          <li key={index}>
+                            <Link to={url ?? ""}>{description}</Link>
+                          </li>
+                        ),
+                      )}
+                    </ul>
+                  </td>
+                </tr>
+              )}
             </tbody>
           </Table>
         </Card.Body>

--- a/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
+++ b/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
@@ -121,7 +121,7 @@ const ReportComponent: React.FC<{ implementation: Implementation }> = ({
                   </ul>
                 </td>
               </tr>
-              {implementation.links && !!implementation.links.length && (
+              {implementation.links?.length && (
                 <tr>
                   <th>Additional Links:</th>
                   <td>


### PR DESCRIPTION
fix #333: Added code to Implementation Info page to display Additional Links (URLs) provided by JSON schema implementers.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--879.org.readthedocs.build/en/879/

<!-- readthedocs-preview bowtie-json-schema end -->