### PR TITLE
code optimisation introduced an UI error #879

### DIFF
--- a/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
+++ b/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
@@ -121,7 +121,7 @@ const ReportComponent: React.FC<{ implementation: Implementation }> = ({
                   </ul>
                 </td>
               </tr>
-              {implementation.links?.length && (
+              {implementation.links && !!implementation.links.length && (
                 <tr>
                   <th>Additional Links:</th>
                   <td>


### PR DESCRIPTION
@harrel56, shortened version of code introduced a minor UI error, hence reverted to verbose code from previous version. See screenshots below.

Summarising from #879 here:
The shortened code, implementation.links?.length, leads to a UI bug (see the 0 displayed) when no additional Links are present:

<img width="954" alt="screen1" src="https://github.com/bowtie-json-schema/bowtie/assets/112953828/adbb269a-5508-4ae8-a09a-acb0053bd521">

The long form of code, implementation.links && !!implementation.links.length, meets the expected behavior:

<img width="951" alt="screen2" src="https://github.com/bowtie-json-schema/bowtie/assets/112953828/7f31bd27-ce02-4476-a6f0-1b8037833bac">

The shortened version seems to be printing the value of length when there is no link to display. I'll revert to the long form of code.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--882.org.readthedocs.build/en/882/

<!-- readthedocs-preview bowtie-json-schema end -->