### PR TITLE
Fix possibility of misleading terminal output when smoke testing multiple implementations

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -847,11 +847,12 @@ async def smoke(
     for implementation in implementations:
         echo(f"Testing {implementation.name!r}...\n", file=sys.stderr)
         serializable: list[dict[str, Any]] = []
-
+        implementation_exit_code = 0
+        
         async for _, results in implementation.smoke():
             async for case, result in results:
                 if result.unsuccessful():
-                    exit_code |= _EX_DATAERR
+                    implementation_exit_code |= _EX_DATAERR
 
                 match format:
                     case "json":
@@ -873,16 +874,18 @@ async def smoke(
                 echo(json.dumps(serializable, indent=2))
 
             case "pretty":
-                message = "❌ some failures" if exit_code else "✅ all passed"
+                message = "❌ some failures" if implementation_exit_code else "✅ all passed"
                 echo(f"\n{message}", file=sys.stderr)
 
             case "markdown":
                 message = (
                     "**❌ some failures**"
-                    if exit_code
+                    if implementation_exit_code
                     else "**✅ all passed**"
                 )
                 echo(f"\n{message}", file=sys.stderr)
+        
+        exit_code |= implementation_exit_code
 
     return exit_code
 

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -848,7 +848,7 @@ async def smoke(
         echo(f"Testing {implementation.name!r}...\n", file=sys.stderr)
         serializable: list[dict[str, Any]] = []
         implementation_exit_code = 0
-        
+
         async for _, results in implementation.smoke():
             async for case, result in results:
                 if result.unsuccessful():
@@ -874,7 +874,11 @@ async def smoke(
                 echo(json.dumps(serializable, indent=2))
 
             case "pretty":
-                message = "❌ some failures" if implementation_exit_code else "✅ all passed"
+                message = (
+                    "❌ some failures"
+                    if implementation_exit_code
+                    else "✅ all passed"
+                )
                 echo(f"\n{message}", file=sys.stderr)
 
             case "markdown":
@@ -884,7 +888,7 @@ async def smoke(
                     else "**✅ all passed**"
                 )
                 echo(f"\n{message}", file=sys.stderr)
-        
+
         exit_code |= implementation_exit_code
 
     return exit_code

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -167,6 +167,38 @@ always_valid = shellplementation(  # I'm sorry future me.
     done
     """,  # noqa: E501
 )
+passes_smoke = shellplementation(
+    name="passes_smoke",
+    contents=r"""
+    read
+    printf '{"implementation": {"name": "passes-smoke", "language": "sh", "homepage": "urn:example", "issues": "urn:example", "source": "urn:example", "dialects": ["https://json-schema.org/draft/2020-12/schema"]}, "version": 1}\n'
+    read
+    printf '{"ok": true}\n'
+    while IFS= read -r input; do
+      [[ "$input" == '{"cmd": "stop"}' ]] && exit
+      echo $input | awk '{
+       seq = gensub(/.*"seq": ([^,]+).*/, "\\1", "g", $0);
+       tests = gensub(/.*"tests": \[([^]]+)\].*/, "\\1", "g", $0);
+       gsub(/}, \{/, "\n", tests);
+       count = split(tests, tests_array, ",");
+       result = sprintf("{\"seq\": %s, \"results\": [", seq);
+       for (i = 1; i <= count; i++) {
+         if(seq == "1"){
+            result = result "{\"valid\": true}";
+        }
+        else{
+            result = result "{\"valid\": false}";
+        }
+         if (i < count) {
+             result = result ",";
+         }
+       }
+       result = result "]}";
+       print result;
+      }'
+    done
+    """,  # noqa: E501
+)
 succeed_immediately = strimplementation(
     name="succeed",
     contents="ENTRYPOINT true",
@@ -974,6 +1006,46 @@ async def test_smoke_quiet(envsonschema):
         exit_code=-1,  # because indeed envsonschema gets answers wrong.
     )
     assert stdout == "", stderr
+
+
+@pytest.mark.asyncio
+async def test_smoke_multiple(envsonschema, passes_smoke):
+    stdout, stderr = await bowtie(
+        "smoke",
+        "--format",
+        "pretty",
+        "-i",
+        envsonschema,
+        "-i",
+        passes_smoke,
+        exit_code=-1,  # because indeed envsonschema gets answers wrong.
+    )
+    assert (
+        dedent(stderr) == dedent(
+            """
+            Testing 'bowtie-integration-tests/passes_smoke'...
+
+
+            ✅ all passed
+            Testing 'bowtie-integration-tests/envsonschema'...
+
+
+            ❌ some failures
+            """
+        ).lstrip("\n") 
+        or dedent(stderr) == dedent(
+            """
+            Testing 'bowtie-integration-tests/envsonschema'...
+
+
+            ❌ some failures            
+            Testing 'bowtie-integration-tests/passes_smoke'...
+
+
+            ✅ all passed
+            """
+        )
+    ), stdout
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1021,7 +1021,8 @@ async def test_smoke_multiple(envsonschema, passes_smoke):
         exit_code=-1,  # because indeed envsonschema gets answers wrong.
     )
     assert (
-        dedent(stderr) == dedent(
+        dedent(stderr)
+        == dedent(
             """
             Testing 'bowtie-integration-tests/passes_smoke'...
 
@@ -1031,19 +1032,20 @@ async def test_smoke_multiple(envsonschema, passes_smoke):
 
 
             ❌ some failures
-            """
-        ).lstrip("\n") 
-        or dedent(stderr) == dedent(
+            """,
+        ).lstrip("\n")
+        or dedent(stderr)
+        == dedent(
             """
             Testing 'bowtie-integration-tests/envsonschema'...
 
 
-            ❌ some failures            
+            ❌ some failures
             Testing 'bowtie-integration-tests/passes_smoke'...
 
 
             ✅ all passed
-            """
+            """,
         )
     ), stdout
 


### PR DESCRIPTION
Closes #913

Fixed the bug where wrong terminal output stating `❌ some failures` would be printed for all implementations irrespective of their results while smoke testing multiple implementations after one fails.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--914.org.readthedocs.build/en/914/

<!-- readthedocs-preview bowtie-json-schema end -->