### PR TITLE
Update kmp-json-schema-validator version

### DIFF
--- a/implementations/kotlin-kmp-json-schema-validator/gradle/libs.versions.toml
+++ b/implementations/kotlin-kmp-json-schema-validator/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.9.22"
-json-schema-validator = "0.0.7"
+json-schema-validator = "0.0.8"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/BowtieSampsonSchemaValidatorLauncher.kt
+++ b/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/BowtieSampsonSchemaValidatorLauncher.kt
@@ -3,6 +3,7 @@ import io.github.optimumcode.json.schema.JsonSchema
 import io.github.optimumcode.json.schema.JsonSchemaLoader
 import io.github.optimumcode.json.schema.SchemaType
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -21,6 +22,7 @@ fun main() {
             ignoreUnknownKeys = true
             prettyPrint = false
             encodeDefaults = true
+            classDiscriminatorMode = ClassDiscriminatorMode.NONE
         }
         val processor = BowtieSampsonSchemaValidatorLauncher(outputWriter, json)
         input.lines().forEach {

--- a/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/Responses.kt
+++ b/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/Responses.kt
@@ -1,8 +1,5 @@
-import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 @Serializable
 class StartResponse(
@@ -55,7 +52,7 @@ sealed class RunResponse {
     ) : RunResponse()
 }
 
-@Serializable(with = TestResultSerializer::class)
+@Serializable
 sealed class TestResult {
 
     @Serializable
@@ -82,15 +79,3 @@ class ErrorContext(
     val traceback: String? = null,
     val stderr: String? = null,
 )
-
-private class TestResultSerializer : JsonContentPolymorphicSerializer<TestResult>(TestResult::class) {
-    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<TestResult> {
-        require(element is JsonObject) { "command must be an object" }
-        return when {
-            "valid" in element -> TestResult.Executed.serializer()
-            "skipped" in element -> TestResult.Skipped.serializer()
-            "errored" in element -> TestResult.ExecutionError.serializer()
-            else -> error("unknown object type")
-        }
-    }
-}

--- a/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/TestFilters.kt
+++ b/implementations/kotlin-kmp-json-schema-validator/src/main/kotlin/TestFilters.kt
@@ -30,10 +30,6 @@ object TestFilterDraft7 : TestFilter {
 }
 
 object TestFilterDraft201909 : TestFilter {
-    private val IGNORED_CASES_WITH_CUSTOM_META_SCHEMA: Set<String> = hashSetOf(
-        "schema that uses custom metaschema with with no validation vocabulary",
-        "ignore unrecognized optional vocabulary",
-    )
 
     private val IGNORE_CASES_WITH_MIN_CONTAINS_ZERO = setOf(
         "minContains = 0 with no maxContains",
@@ -42,8 +38,6 @@ object TestFilterDraft201909 : TestFilter {
     override fun shouldSkipCase(caseDescription: String): String? {
         return when {
             caseDescription.endsWith(" format") -> "the format keyword is not yet supported"
-            caseDescription in IGNORED_CASES_WITH_CUSTOM_META_SCHEMA ->
-                "vocabulary from custom meta-schemas is not supported yet"
             caseDescription in IGNORE_CASES_WITH_MIN_CONTAINS_ZERO ->
                 "'minContains' does not affect contains work - at least one element must match 'contains' schema"
             else -> null
@@ -62,16 +56,10 @@ object TestFilterDraft201909 : TestFilter {
 }
 
 object TestFilterDraft202012 : TestFilter {
-    private val IGNORED_CASES_WITH_CUSTOM_META_SCHEMA: Set<String> = hashSetOf(
-        "schema that uses custom metaschema with with no validation vocabulary",
-        "ignore unrecognized optional vocabulary",
-    )
 
     override fun shouldSkipCase(caseDescription: String): String? {
         return when {
             caseDescription.endsWith(" format") -> "the format keyword is not yet supported"
-            caseDescription in IGNORED_CASES_WITH_CUSTOM_META_SCHEMA ->
-                "vocabulary from custom meta-schemas is not supported yet"
             else -> null
         }
     }


### PR DESCRIPTION
The library now supports custom meta schemes with vocabulary configuration