### PR TITLE
Add max height to schema and instance displays

### DIFF
--- a/frontend/src/components/Cases/SchemaDisplay.tsx
+++ b/frontend/src/components/Cases/SchemaDisplay.tsx
@@ -1,5 +1,9 @@
 import CopyToClipboard from "../CopyToClipboard";
 
+const schemaStyle = {
+  maxHeight: "30em",
+};
+
 const SchemaDisplay = ({
   schema,
   instance,
@@ -22,7 +26,9 @@ const SchemaDisplay = ({
             </div>
           </div>
           <div className="card-body">
-            <pre id="schema-code">{schemaFormatted}</pre>
+            <pre id="schema-code" style={schemaStyle}>
+              {schemaFormatted}
+            </pre>
           </div>
         </div>
         <div className="col-4 border-start ps-0">
@@ -35,7 +41,9 @@ const SchemaDisplay = ({
             </div>
           </div>
           <div id="instance-info" className="card-body">
-            <pre id="schema-code">{instanceFormatted}</pre>
+            <pre id="schema-code" style={schemaStyle}>
+              {instanceFormatted}
+            </pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Resolves https://github.com/bowtie-json-schema/bowtie/issues/544.

Here's how it looks:
![image](https://github.com/bowtie-json-schema/bowtie/assets/46278840/428702bf-dfb9-4226-bc59-0bf35e49dc28)

I wasn't able to find a way to do this with just bootstrap so I added CSS to it. I'm not sure if it's better to keep it inline or extract it into a separate file (since the codebase seems to contain a mix of both) but it made sense to me to keep it inline for just one line of CSS. Happy to adjust the height if desired.


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--923.org.readthedocs.build/en/923/

<!-- readthedocs-preview bowtie-json-schema end -->