### PR TITLE
Table styling modified

### DIFF
--- a/frontend/src/components/RunInfo/RunInfoSection.tsx
+++ b/frontend/src/components/RunInfo/RunInfoSection.tsx
@@ -16,11 +16,11 @@ const RunInfoSection = ({ runInfo }: { runInfo: RunInfo }) => {
         <table className="table table-sm table-hover">
           <thead>
             <tr>
-              <td className="align-top">Dialect</td>
+              <td className="align-top" style={{ width: "25%" }}>Dialect</td>
               <td>{runInfo.dialect}</td>
             </tr>
             <tr>
-              <td className="align-top">Ran</td>
+              <td className="align-top" style={{ width: "25%" }}>Ran</td>
               <td>{ranTime(runInfo.started)} ago</td>
             </tr>
           </thead>
@@ -35,7 +35,7 @@ const RunInfoSection = ({ runInfo }: { runInfo: RunInfo }) => {
                   if (typeof value === "string") {
                     return (
                       <tr key={label}>
-                        <td className="align-top">{label}</td>
+                        <td className="align-top" style={{ width: "25%" }}>{label}</td>
                         <td>{value}</td>
                       </tr>
                     );

--- a/frontend/src/components/RunInfo/RunInfoSection.tsx
+++ b/frontend/src/components/RunInfo/RunInfoSection.tsx
@@ -16,11 +16,11 @@ const RunInfoSection = ({ runInfo }: { runInfo: RunInfo }) => {
         <table className="table table-sm table-hover">
           <thead>
             <tr>
-              <td className="align-top" style={{ width: "25%" }}>Dialect</td>
+              <td className="align-top w-25">Dialect</td>
               <td>{runInfo.dialect}</td>
             </tr>
             <tr>
-              <td className="align-top" style={{ width: "25%" }}>Ran</td>
+              <td className="align-top w-25">Ran</td>
               <td>{ranTime(runInfo.started)} ago</td>
             </tr>
           </thead>
@@ -35,7 +35,7 @@ const RunInfoSection = ({ runInfo }: { runInfo: RunInfo }) => {
                   if (typeof value === "string") {
                     return (
                       <tr key={label}>
-                        <td className="align-top" style={{ width: "25%" }}>{label}</td>
+                        <td className="align-top w-25">{label}</td>
                         <td>{value}</td>
                       </tr>
                     );


### PR DESCRIPTION
Fixes: #931

## Details:
I've incorporated the following CSS style:
```css
style={{ width: "25%" }}
```
This style setting ensures a consistent 25% width, maintaining the aspect ratio across various screen dimensions.

## Screenshot:
![Screenshot (88)](https://github.com/bowtie-json-schema/bowtie/assets/94161758/9b4f1054-b182-4f08-953b-b746bfe0221a)


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--933.org.readthedocs.build/en/933/

<!-- readthedocs-preview bowtie-json-schema end -->