### PR TITLE
Padding and Schema & Instance issue fixed

### DIFF
--- a/frontend/src/components/Cases/SchemaDisplay.tsx
+++ b/frontend/src/components/Cases/SchemaDisplay.tsx
@@ -14,9 +14,9 @@ const SchemaDisplay = ({
   const schemaFormatted = JSON.stringify(schema, null, 2);
   const instanceFormatted = JSON.stringify(instance, null, 2);
   return (
-    <div className="card mb-3 mw-100">
+    <div className="card mb-3 mw-100 overflow-auto">
       <div className="row">
-        <div className="col-8 pe-0">
+        <div className="col-6 pe-0">
           <div className="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom">
             <small className="font-monospace text-body-secondary text-uppercase">
               Schema
@@ -31,7 +31,7 @@ const SchemaDisplay = ({
             </pre>
           </div>
         </div>
-        <div className="col-4 border-start ps-0">
+        <div className="col-6 border-start ps-0">
           <div className="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom">
             <small className="font-monospace text-body-secondary text-uppercase">
               Instance


### PR DESCRIPTION
Fixes: #930
 
## Details:
1. Changed padding from `p-4` to `p-2`, and it almost looks good on both, mobile and desktop mode. 
2. Also made the container scrollable by adding `overflow-auto`

## Screenshots:
![Screenshot (94)](https://github.com/bowtie-json-schema/bowtie/assets/94161758/5cac4a9a-2424-4c94-8edf-791ac4b13bcc)
![Screenshot (95)](https://github.com/bowtie-json-schema/bowtie/assets/94161758/4ac12fd1-cf9e-4d68-82bb-443af41f4f42)
![Screenshot (92)](https://github.com/bowtie-json-schema/bowtie/assets/94161758/3152674e-249c-4b57-8ab9-dbbeb951fbeb)
![Screenshot (93)](https://github.com/bowtie-json-schema/bowtie/assets/94161758/8f9782a3-2f07-4af7-be28-22a62c093dbe)

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--934.org.readthedocs.build/en/934/

<!-- readthedocs-preview bowtie-json-schema end -->