### PR TITLE
fixes: #896, dont show about in report page

### DIFF
--- a/frontend/src/components/BowtieInfo/BowtieInfoSection.tsx
+++ b/frontend/src/components/BowtieInfo/BowtieInfoSection.tsx
@@ -4,7 +4,7 @@ const BowtieInfoSection = () => {
   // prettier-ignore
   const location = useLocation();
 
-  if (location.pathname === '/local-report') {
+  if (location.pathname === "/local-report") {
     return null;
   }
 
@@ -13,14 +13,22 @@ const BowtieInfoSection = () => {
       <div className="card-header">About Bowtie</div>
       <div className="card-body">
         <p>
-          Bowtie is tool for understanding and comparing implementations of the <a href={"https://json-schema.org/"}>{"JSON Schema specification"}</a> across all programming languages.
+          Bowtie is tool for understanding and comparing implementations of the{" "}
+          <a href={"https://json-schema.org/"}>{"JSON Schema specification"}</a>{" "}
+          across all programming languages.
         </p>
         <p>
-          The report below uses the <a href={"https://github.com/json-schema-org/JSON-Schema-Test-Suite"}>{"official JSON Schema Test Suite"}</a> to display bugs or functionality gaps in implementations.
+          The report below uses the{" "}
+          <a href={"https://github.com/json-schema-org/JSON-Schema-Test-Suite"}>
+            {"official JSON Schema Test Suite"}
+          </a>{" "}
+          to display bugs or functionality gaps in implementations.
         </p>
         <p>
-          You can also use Bowtie to get this information about your own schemas.
-          Find out how in <a href={"https://docs.bowtie.report/"}>{"Bowtie's documentation"}</a>.
+          You can also use Bowtie to get this information about your own
+          schemas. Find out how in{" "}
+          <a href={"https://docs.bowtie.report/"}>{"Bowtie's documentation"}</a>
+          .
         </p>
       </div>
     </div>

--- a/frontend/src/components/BowtieInfo/BowtieInfoSection.tsx
+++ b/frontend/src/components/BowtieInfo/BowtieInfoSection.tsx
@@ -1,5 +1,13 @@
+import { useLocation } from "react-router-dom";
+
 const BowtieInfoSection = () => {
   // prettier-ignore
+  const location = useLocation();
+
+  if (location.pathname === '/local-report') {
+    return null;
+  }
+
   return (
     <div className="card mx-auto mb-3" id="bowtie-info">
       <div className="card-header">About Bowtie</div>


### PR DESCRIPTION
Fixes: #896 

The About section has been condinitionally rendered according to the above issue.

The component now returns null if it is being rendered in /local-report else renders else where

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--937.org.readthedocs.build/en/937/

<!-- readthedocs-preview bowtie-json-schema end -->