### PR TITLE
Hide the implementation version column in mobile UI

### DIFF
--- a/frontend/src/components/Summary/ImplementationRow.tsx
+++ b/frontend/src/components/Summary/ImplementationRow.tsx
@@ -32,7 +32,7 @@ const ImplementationRow = ({
           {mapLanguage(implementation.metadata.language)}
         </small>
       </th>
-      <td className="align-middle">
+      <td className="align-middle d-none d-sm-table-cell">
         <small className="font-monospace text-muted">
           {implementation.metadata.version ?? ""}
         </small>


### PR DESCRIPTION
Fixes #935 

![image](https://github.com/bowtie-json-schema/bowtie/assets/119167601/4a81085e-7d68-498f-b5f9-7720e639bcd4)

Removed implementation version column from mobile view .
