### PR TITLE
Copy button is now going to it's initial state, 7 seconds after copying

### DIFF
--- a/frontend/src/components/CopyToClipboard.tsx
+++ b/frontend/src/components/CopyToClipboard.tsx
@@ -13,7 +13,13 @@ function CopyToClipboard({ textToCopy }: CopyProps) {
 
   const handleCopy = () => {
     navigator.clipboard.writeText(textToCopy).then(
-      () => setCopied(true),
+      () => {
+        setCopied(true);
+        // Reset 'copied' state after 5 seconds
+        setTimeout(() => {
+          setCopied(false);
+        }, 3000);
+      },
       () => setCopied(false),
     );
   };
@@ -32,6 +38,7 @@ function CopyToClipboard({ textToCopy }: CopyProps) {
           variant="outline-primary"
           className="btn mt-0 me-0"
           onClick={handleCopy}
+          disabled={copied} // Disable the button while it's copied
         >
           {copied ? <Check /> : <Clipboard />}
         </Button>

--- a/frontend/src/components/CopyToClipboard.tsx
+++ b/frontend/src/components/CopyToClipboard.tsx
@@ -17,7 +17,7 @@ function CopyToClipboard({ textToCopy }: CopyProps) {
         setCopied(true);
         setTimeout(() => {
           setCopied(false);
-        }, 3000);
+        }, 7000);
       },
       () => setCopied(false),
     );

--- a/frontend/src/components/CopyToClipboard.tsx
+++ b/frontend/src/components/CopyToClipboard.tsx
@@ -15,7 +15,7 @@ function CopyToClipboard({ textToCopy }: CopyProps) {
     navigator.clipboard.writeText(textToCopy).then(
       () => {
         setCopied(true);
-        // Reset 'copied' state after 5 seconds
+        // Reset 'copied' state after 3 seconds
         setTimeout(() => {
           setCopied(false);
         }, 3000);

--- a/frontend/src/components/CopyToClipboard.tsx
+++ b/frontend/src/components/CopyToClipboard.tsx
@@ -15,7 +15,6 @@ function CopyToClipboard({ textToCopy }: CopyProps) {
     navigator.clipboard.writeText(textToCopy).then(
       () => {
         setCopied(true);
-        // Reset 'copied' state after 3 seconds
         setTimeout(() => {
           setCopied(false);
         }, 3000);
@@ -38,7 +37,7 @@ function CopyToClipboard({ textToCopy }: CopyProps) {
           variant="outline-primary"
           className="btn mt-0 me-0"
           onClick={handleCopy}
-          disabled={copied} // Disable the button while it's copied
+          disabled={copied}
         >
           {copied ? <Check /> : <Clipboard />}
         </Button>


### PR DESCRIPTION
Fixes: https://github.com/bowtie-json-schema/bowtie/issues/945

Copy button is now going to it's initial state, 3 seconds after copying

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--949.org.readthedocs.build/en/949/

<!-- readthedocs-preview bowtie-json-schema end -->