### PR TITLE
Instance copy button is now not overflowing in Mobile mode

### DIFF
--- a/frontend/src/components/Cases/SchemaDisplay.tsx
+++ b/frontend/src/components/Cases/SchemaDisplay.tsx
@@ -33,7 +33,7 @@ const SchemaDisplay = ({
         </div>
         <div className="col-4 border-start ps-0">
           <div className="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom">
-            <small className="font-monospace text-body-secondary text-uppercase">
+            <small className="font-monospace text-body-secondary text-uppercase pe-4">
               Instance
             </small>
             <div className="d-flex ms-auto">

--- a/frontend/src/components/Cases/SchemaDisplay.tsx
+++ b/frontend/src/components/Cases/SchemaDisplay.tsx
@@ -14,7 +14,7 @@ const SchemaDisplay = ({
   const schemaFormatted = JSON.stringify(schema, null, 2);
   const instanceFormatted = JSON.stringify(instance, null, 2);
   return (
-    <div className="card mb-3 mw-100">
+    <div className="card mb-3 mw-100 overflow-auto">
       <div className="row">
         <div className="col-8 pe-0">
           <div className="d-flex align-items-center highlight-toolbar ps-3 pe-2 py-1 border-0 border-top border-bottom">


### PR DESCRIPTION
Fixes: #943

Instance copy button is now not overflowing in Mobile mode
![Screenshot (100)](https://github.com/bowtie-json-schema/bowtie/assets/94161758/6ece01f6-3a7c-4d97-9250-5045e0257ddf)


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--950.org.readthedocs.build/en/950/

<!-- readthedocs-preview bowtie-json-schema end -->