### PR TITLE
[Docs] Added Instructions for building the documentations 

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -115,7 +115,7 @@ Feel free to file issues or pull requests as well if you wish something was bett
 Building the Documentation Locally
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The code for the documentation is in the ``docs/`` directory of our :org:`github repository <bowtie>`.
+The code for the documentation is in the :gh:`docs directory of the Bowtie repository <tree/main/docs>`.
 
 You can build the documentation locally by running:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -119,7 +119,7 @@ Feel free to file issues or pull requests as well if you wish something was bett
 
 The code for the documentation is in the :gh:`docs directory of the Bowtie repository <tree/main/docs>`.
 
-You can build the documentation locally by running the following command from the root of the repository:
+You can build the documentation locally by running the following command from the root of the repository
 
 .. code:: sh
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -119,7 +119,7 @@ Feel free to file issues or pull requests as well if you wish something was bett
 
 The code for the documentation is in the :gh:`docs directory of the Bowtie repository <tree/main/docs>`.
 
-You can build the documentation locally by running on the root of the repository:
+You can build the documentation locally by running following the command on the root of the repository:
 
 .. code:: sh
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -119,8 +119,7 @@ Feel free to file issues or pull requests as well if you wish something was bett
 
 The code for the documentation is in the :gh:`docs directory of the Bowtie repository <tree/main/docs>`.
 
-You can build the documentation locally by running following the command on the root of the repository:
-
+You can build the documentation locally by running the following command from the root of the repository:
 .. code:: sh
 
     $ nox -s "docs(dirhtml)" -- dirhtml

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -123,7 +123,7 @@ You can build the documentation locally by running:
 
     $ nox -s "docs(dirhtml)" -- dirhtml
 
-This will generate ``/dirhtml`` directory containing the documentation in html.
+which will generate a directory called ``dirhtml`` containing the built HTML.
 
 
 Improving the Contributor's Guide Itself

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -112,6 +112,19 @@ Documentation is written in `Sphinx-flavored reStructuredText <sphinx:index>`, s
 
 Feel free to file issues or pull requests as well if you wish something was better documented, as this too can help prioritize.
 
+Building the Documentation Locally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The code for the documentation is in the ``docs/`` directory of our :org:`github repository <bowtie>`.
+
+You can build the documentation locally by running:
+
+.. code:: sh
+
+    $ nox -s "docs(dirhtml)" -- dirhtml
+
+This will build the documentation into the ``/dirhtml`` directory.
+
 
 Improving the Contributor's Guide Itself
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -123,7 +123,7 @@ You can build the documentation locally by running:
 
     $ nox -s "docs(dirhtml)" -- dirhtml
 
-This will build the documentation into the ``/dirhtml`` directory.
+This will generate ``/dirhtml`` directory containing the documentation in html.
 
 
 Improving the Contributor's Guide Itself

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -112,12 +112,14 @@ Documentation is written in `Sphinx-flavored reStructuredText <sphinx:index>`, s
 
 Feel free to file issues or pull requests as well if you wish something was better documented, as this too can help prioritize.
 
-Building the Documentation Locally
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Building the Documentation Locally**
+
+
 
 The code for the documentation is in the :gh:`docs directory of the Bowtie repository <tree/main/docs>`.
 
-You can build the documentation locally by running:
+You can build the documentation locally by running on the root of the repository:
 
 .. code:: sh
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -120,6 +120,7 @@ Feel free to file issues or pull requests as well if you wish something was bett
 The code for the documentation is in the :gh:`docs directory of the Bowtie repository <tree/main/docs>`.
 
 You can build the documentation locally by running the following command from the root of the repository:
+
 .. code:: sh
 
     $ nox -s "docs(dirhtml)" -- dirhtml


### PR DESCRIPTION
# This new sections is added to build the documentation 
![image](https://github.com/bowtie-json-schema/bowtie/assets/63534268/6e0d429c-3876-459d-9ac0-a3aac4c024b9)

@Julian, I think there is some room for improvement, but I need your feedback on how to improve it 

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--967.org.readthedocs.build/en/967/

<!-- readthedocs-preview bowtie-json-schema end -->