### PR TITLE
Add Support for Syntax Highlighting using jsonschema_lexer

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -17,8 +17,8 @@ import sys
 from aiodocker import Docker
 from attrs import asdict
 from diagnostic import DiagnosticError
-from jsonschema_lexer.lexer import ( # type: ignore[reportMissingTypeStubs]
-    JSONSchemaLexer,  
+from jsonschema_lexer.lexer import (  # type: ignore[reportMissingTypeStubs]
+    JSONSchemaLexer,
 )
 from pygments.lexers.data import (  # type: ignore[reportMissingTypeStubs]
     JsonLexer,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -17,8 +17,11 @@ import sys
 from aiodocker import Docker
 from attrs import asdict
 from diagnostic import DiagnosticError
-from jsonschema_lexer.lexer import (
-    JSONSchemaLexer,  # type: ignore[reportMissingTypeStubs]
+from jsonschema_lexer.lexer import ( # type: ignore[reportMissingTypeStubs]
+    JSONSchemaLexer,  
+)
+from pygments.lexers.data import (  # type: ignore[reportMissingTypeStubs]
+    JsonLexer,
 )
 from referencing.jsonschema import EMPTY_REGISTRY
 from rich import box, console, panel
@@ -62,6 +65,7 @@ _EX_NOINPUT = getattr(os, "EX_NOINPUT", 1)
 
 IMAGE_REPOSITORY = "ghcr.io/bowtie-json-schema"
 
+JSON_LEXER = JsonLexer()
 JSON_SCHEMA_LEXER = JSONSchemaLexer()
 
 FORMAT = click.option(
@@ -528,7 +532,7 @@ def _validation_results_table(
             subtable.add_row(
                 Syntax(
                     json.dumps(test.instance),
-                    lexer=JSON_SCHEMA_LEXER,
+                    lexer=JSON_LEXER,
                     background_color="default",
                     word_wrap=True,
                 ),

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -21,6 +21,8 @@ from referencing.jsonschema import EMPTY_REGISTRY
 from rich import box, console, panel
 from rich.table import Column, Table
 from rich.text import Text
+from rich.syntax import Syntax
+from jsonschema_lexer.lexer import JSONSchemaLexer  # type: ignore[reportMissingTypeStubs]
 from url import URL, RelativeURLWithoutBase
 import click
 import referencing_loaders
@@ -57,6 +59,8 @@ _EX_NOINPUT = getattr(os, "EX_NOINPUT", 1)
 
 
 IMAGE_REPOSITORY = "ghcr.io/bowtie-json-schema"
+
+JSON_SCHEMA_LEXER = JSONSchemaLexer()
 
 FORMAT = click.option(
     "--format",
@@ -520,14 +524,24 @@ def _validation_results_table(
 
         for test, test_result in test_results:
             subtable.add_row(
-                Text(json.dumps(test.instance)),
-                *(
-                    Text(test_result[each.id].description)
-                    for each in implementations
+                Syntax(
+                    json.dumps(test.instance),
+                    lexer=JSON_SCHEMA_LEXER,
+                    background_color="default",
+                    word_wrap=True,
                 ),
+                *(Text(test_result[each.id].description) for each in implementations),
             )
 
-        table.add_row(json.dumps(case.schema, indent=2), subtable)
+        table.add_row(
+            Syntax(
+                json.dumps(case.schema, indent=2),
+                lexer=JSON_SCHEMA_LEXER,
+                background_color="default",
+                word_wrap=True,
+            ),
+            subtable,
+        )
         table.add_section()
 
     return table

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -17,7 +17,7 @@ import sys
 from aiodocker import Docker
 from attrs import asdict
 from diagnostic import DiagnosticError
-from jsonschema_lexer.lexer import (  # type: ignore[reportMissingTypeStubs]
+from jsonschema_lexer import (  # type: ignore[reportMissingTypeStubs]
     JSONSchemaLexer,
 )
 from pygments.lexers.data import (  # type: ignore[reportMissingTypeStubs]
@@ -65,8 +65,6 @@ _EX_NOINPUT = getattr(os, "EX_NOINPUT", 1)
 
 IMAGE_REPOSITORY = "ghcr.io/bowtie-json-schema"
 
-JSON_LEXER = JsonLexer()
-JSON_SCHEMA_LEXER = JSONSchemaLexer()
 
 FORMAT = click.option(
     "--format",
@@ -532,7 +530,7 @@ def _validation_results_table(
             subtable.add_row(
                 Syntax(
                     json.dumps(test.instance),
-                    lexer=JSON_LEXER,
+                    lexer=JsonLexer(),
                     background_color="default",
                     word_wrap=True,
                 ),
@@ -545,7 +543,7 @@ def _validation_results_table(
         table.add_row(
             Syntax(
                 json.dumps(case.schema, indent=2),
-                lexer=JSON_SCHEMA_LEXER,
+                lexer=JSONSchemaLexer(str(report.metadata.dialect.uri)),
                 background_color="default",
                 word_wrap=True,
             ),

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -17,12 +17,14 @@ import sys
 from aiodocker import Docker
 from attrs import asdict
 from diagnostic import DiagnosticError
+from jsonschema_lexer.lexer import (
+    JSONSchemaLexer,  # type: ignore[reportMissingTypeStubs]
+)
 from referencing.jsonschema import EMPTY_REGISTRY
 from rich import box, console, panel
+from rich.syntax import Syntax
 from rich.table import Column, Table
 from rich.text import Text
-from rich.syntax import Syntax
-from jsonschema_lexer.lexer import JSONSchemaLexer  # type: ignore[reportMissingTypeStubs]
 from url import URL, RelativeURLWithoutBase
 import click
 import referencing_loaders
@@ -530,7 +532,10 @@ def _validation_results_table(
                     background_color="default",
                     word_wrap=True,
                 ),
-                *(Text(test_result[each.id].description) for each in implementations),
+                *(
+                    Text(test_result[each.id].description)
+                    for each in implementations
+                ),
             )
 
         table.add_row(

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -65,7 +65,6 @@ _EX_NOINPUT = getattr(os, "EX_NOINPUT", 1)
 
 IMAGE_REPOSITORY = "ghcr.io/bowtie-json-schema"
 
-
 FORMAT = click.option(
     "--format",
     "-f",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
   "diagnostic",
   "github3.py",
   "jsonschema>=4.19.0",
+  "jsonschema_lexer",
   "referencing>=0.31.0",
   "referencing-loaders>=0.4.2",
   "rich",
@@ -60,7 +61,6 @@ dependencies = [
   "structlog",
   "typing-extensions; python_version<'3.11'",
   "url.py",
-  "jsonschema_lexer",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
   "structlog",
   "typing-extensions; python_version<'3.11'",
   "url.py",
+  "jsonschema_lexer",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ idna==3.6
     #   yarl
 jsonschema==4.21.1
     # via bowtie-json-schema (pyproject.toml)
-jsonschema-lexer==0.1.0
+jsonschema-lexer==0.2.0
     # via bowtie-json-schema (pyproject.toml)
 jsonschema-specifications==2023.12.1
     # via jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,8 @@ idna==3.6
     #   yarl
 jsonschema==4.21.1
     # via bowtie-json-schema (pyproject.toml)
+jsonschema-lexer==0.1.0
+    # via bowtie-json-schema (pyproject.toml)
 jsonschema-specifications==2023.12.1
     # via jsonschema
 markdown-it-py==3.0.0
@@ -57,7 +59,9 @@ multidict==6.0.5
 pycparser==2.21
     # via cffi
 pygments==2.17.2
-    # via rich
+    # via
+    #   jsonschema-lexer
+    #   rich
 pyjwt==2.8.0
     # via github3-py
 python-dateutil==2.8.2


### PR DESCRIPTION
Closes #863.

The goal was to support syntax highlighting for schemas and instances in bowtie's cli.

**Implementation**
Created a custom lexer that understands JSON schema dialect. The lexer has already been published and can be installed using `pip install jsonschema_lexer`. Using this lexer, its pretty easy to add syntax highlighting support using rich's syntax module.

**Comparison of output**

**- Output now looks like:**

<img width="1159" alt="Screenshot 2024-02-29 at 7 13 44 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/b112a165-0eb6-4442-a975-76535e141c27">

**- Output before:**

<img width="1159" alt="Screenshot 2024-02-29 at 7 14 18 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/a3db2a6e-1531-4ab2-ac23-e8e2d15813ce">



<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--975.org.readthedocs.build/en/975/

<!-- readthedocs-preview bowtie-json-schema end -->