### PR TITLE
Install the exact version of bowtie when creating report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
 
+    outputs:
+      version: ${{ steps.version.outputs.tag }}
+
     environment:
       name: PyPI
       url: https://pypi.org/p/bowtie-json-schema
@@ -144,8 +147,14 @@ jobs:
           files: |
             app/bowtie*
           generate_release_notes: true
+      - name: Current version
+        id: version
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
   report:
     needs: packaging
     uses: ./.github/workflows/report.yml
+    with:
+      bowtie-version: ${{ needs.packaging.outputs.version }}
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -6,6 +6,11 @@ on:
   release:
     types: [published]
   workflow_call:
+    inputs:
+      bowtie-version:
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
   schedule:
     # Every 6 hours, at 15 past the hour
@@ -65,6 +70,9 @@ jobs:
 
       - name: Install Bowtie
         uses: ./
+        with:
+          version: ${{ inputs.bowtie-version }}
+          installation-timeout: '60'
 
       - name: Generate a New Report
         run: |

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -10,7 +10,7 @@ on:
       bowtie-version:
         type: string
         required: false
-        default: ''
+        default: ""
   workflow_dispatch:
   schedule:
     # Every 6 hours, at 15 past the hour
@@ -72,7 +72,7 @@ jobs:
         uses: ./
         with:
           version: ${{ inputs.bowtie-version }}
-          installation-timeout: '60'
+          installation-timeout: "60"
 
       - name: Generate a New Report
         run: |

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -72,7 +72,8 @@ jobs:
         uses: ./
         with:
           version: ${{ inputs.bowtie-version }}
-          installation-timeout: "60"
+          installation-attempts: "5"
+          installation-wait-seconds: "10"
 
       - name: Generate a New Report
         run: |
@@ -102,6 +103,10 @@ jobs:
 
       - name: Install Bowtie
         uses: ./
+        with:
+          version: ${{ inputs.bowtie-version }}
+          installation-attempts: "5"
+          installation-wait-seconds: "10"
 
       - name: Generate implementations.json file
         run: |
@@ -123,6 +128,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Bowtie
         uses: ./
+        with:
+          version: ${{ inputs.bowtie-version }}
+          installation-attempts: "5"
+          installation-wait-seconds: "10"
 
       - name: Create our Site Structure
         run: mkdir site

--- a/action.yml
+++ b/action.yml
@@ -7,12 +7,12 @@ branding:
 inputs:
   version:
     required: false
-    description: 'bowtie version to be installed'
-    default: ''
+    description: "bowtie version to be installed"
+    default: ""
   installation-timeout:
     required: false
-    default: '0'
-    description: 'time in seconds to wait until the specified version is avaialble in PyPi'
+    default: "0"
+    description: "time in seconds to wait until the specified version is avaialble in PyPi"
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -9,10 +9,14 @@ inputs:
     required: false
     description: "bowtie version to be installed"
     default: ""
-  installation-timeout:
+  installation-attempts:
     required: false
-    default: "0"
-    description: "time in seconds to wait until the specified version is avaialble in PyPi"
+    default: "5"
+    description: "number of attempts to install bowtie with specified version if this version is not yet avaialble"
+  installation-wait-seconds:
+    required: false
+    default: "10"
+    description: "number of seconds to wait before performing the next installation attempt if current one has failed"
 
 runs:
   using: composite
@@ -30,28 +34,23 @@ runs:
 
     - name: "Install Bowtie ${{ inputs.version }}"
       if: inputs.version != ''
-      run: |
-        # because we don't need to fail if command returns non-zero exit code
-        set +e
-        end_time=$(date +%s --date "${{ inputs.installation-timeout }} seconds")
-        # copy output 5 to stdout
-        exec 5>&1
-        # copy command output to stdout to show to the user
-        command="pipx install --python "${{ steps.localpython.outputs.python-path }}" bowtie-json-schema==${{ inputs.version }} 2>&1"
-        output=$(bash -c "$command" | tee /dev/fd/5)
-        while [ $? -ne 0 ] && [ $(date +%s) -lt $end_time ]
-        do
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 10
+        max_attempts: ${{ inputs.installation-attempts }}
+        retry_wait_seconds: ${{ inputs.installation-wait-seconds }}
+        shell: bash
+        command: |
+          set +e # do not fail script if command returns non-zero exit code
+          set -o pipefail # keep exit code when using pipes
+          output=$(pipx install --python "${{ steps.localpython.outputs.python-path }}" bowtie-json-schema==${{ inputs.version }} 2>&1 | tee /dev/tty)
+          if [ $? -ne 0 ]; then
             grep 'No matching distribution found for bowtie-json-schema' <<< $output
             if [ $? -ne 0 ]; then
                 echo "Error during installation"
                 exit 1
             fi
-            sleep 5
-            echo "Retry installation"
-            output=$(bash -c "$command" | tee /dev/fd/5)
-        done
-        if [ $? -ne 0 ]; then
-            echo "Cannot install bowtie"
-            exit 2
-        fi
-      shell: bash
+            exit 42
+          fi
+        retry_on: error
+        retry_on_exit_code: 42

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       if: inputs.version == ''
       run: pipx install --python "${{ steps.localpython.outputs.python-path }}" bowtie-json-schema
       shell: bash
-    
+
     - name: "Install Bowtie ${{ inputs.version }}"
       if: inputs.version != ''
       run: |

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,15 @@ author: "Julian Berman"
 branding:
   icon: package
   color: blue
+inputs:
+  version:
+    required: false
+    description: 'bowtie version to be installed'
+    default: ''
+  installation-timeout:
+    required: false
+    default: '0'
+    description: 'time in seconds to wait until the specified version is avaialble in PyPi'
 
 runs:
   using: composite
@@ -14,6 +23,35 @@ runs:
         python-version: "3.10 - 3.11"
         update-environment: false
 
-    - name: "Install Bowtie"
+    - name: "Install latest Bowtie"
+      if: inputs.version == ''
       run: pipx install --python "${{ steps.localpython.outputs.python-path }}" bowtie-json-schema
+      shell: bash
+    
+    - name: "Install Bowtie ${{ inputs.version }}"
+      if: inputs.version != ''
+      run: |
+        # because we don't need to fail if command returns non-zero exit code
+        set +e
+        end_time=$(date +%s --date "${{ inputs.installation-timeout }} seconds")
+        # copy output 5 to stdout
+        exec 5>&1
+        # copy command output to stdout to show to the user
+        command="pipx install --python "${{ steps.localpython.outputs.python-path }}" bowtie-json-schema==${{ inputs.version }} 2>&1"
+        output=$(bash -c "$command" | tee /dev/fd/5)
+        while [ $? -ne 0 ] && [ $(date +%s) -lt $end_time ]
+        do
+            grep 'No matching distribution found for bowtie-json-schema' <<< $output
+            if [ $? -ne 0 ]; then
+                echo "Error during installation"
+                exit 1
+            fi
+            sleep 5
+            echo "Retry installation"
+            output=$(bash -c "$command" | tee /dev/fd/5)
+        done
+        if [ $? -ne 0 ]; then
+            echo "Cannot install bowtie"
+            exit 2
+        fi
       shell: bash


### PR DESCRIPTION
This PR adds the following parameters to bowtie action

- exact version to be installed. If not specified the latest available will be installed
- timeout in seconds to wait until the specified version becomes available

Resolves #955 

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--981.org.readthedocs.build/en/981/

<!-- readthedocs-preview bowtie-json-schema end -->