### PR TITLE
Doctesting examples in the documentation

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -28,6 +28,28 @@ The `bowtie validate <cli:validate>` subcommand can be used to test arbitrary sc
 
 Given some collection of implementations to check -- here perhaps two Javascript implementations -- it takes a single schema and one or more instances to check against it:
 
+.. testcode:: *
+
+    bowtie_validate = 'bowtie validate -i js-ajv -i js-hyperjump <(printf \'{"type": "integer"}\') <(printf 37) <(printf \'"foo"\') | bowtie summary --format pretty'
+    print(asyncio.run(run_command(command=bowtie_validate)))
+
+.. testoutput:: *
+   :options: +NORMALIZE_WHITESPACE
+
+                                         Bowtie
+    ┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ Schema              ┃                                                        ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                     │                                                        │
+    │                     │                                 hyperjump-json-sche…   │
+    │ {                   │   Instance   ajv (javascript)   (javascript)           │
+    │   "type": "integer" │  ────────────────────────────────────────────────────  │
+    │ }                   │   37         valid              valid                  │
+    │                     │   "foo"      invalid            invalid                │
+    │                     │                                                        │
+    └─────────────────────┴────────────────────────────────────────────────────────┘
+                                      2 tests ran
+
 .. code:: sh
 
     $ bowtie validate -i js-ajv -i js-hyperjump <(printf '{"type": "integer"}') <(printf 37) <(printf '"foo"')
@@ -41,20 +63,19 @@ For summarizing the results in the terminal however, the above command when summ
 .. code:: sh
 
     $ bowtie validate -i js-ajv -i js-hyperjump <(printf '{"type": "integer"}') <(printf 37) <(printf '"foo"') | bowtie summary
-    2023-11-02 15:43.10 [debug    ] Will speak                     dialect=https://json-schema.org/draft/2020-12/schema
-    2023-11-02 15:43.10 [info     ] Finished                       count=1
-                                            Bowtie
-    ┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃ Schema              ┃                                                              ┃
-    ┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │                     │                                                              │
-    │ {                   │   Instance   ajv (javascript)   hyperjump-jsv (javascript)   │
-    │   "type": "integer" │  ──────────────────────────────────────────────────────────  │
-    │ }                   │   37         valid              valid                        │
-    │                     │   "foo"      invalid            invalid                      │
-    │                     │                                                              │
-    └─────────────────────┴──────────────────────────────────────────────────────────────┘
-                                        2 tests ran
+                                         Bowtie
+    ┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ Schema              ┃                                                        ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │                     │                                                        │
+    │                     │                                 hyperjump-json-sche…   │
+    │ {                   │   Instance   ajv (javascript)   (javascript)           │
+    │   "type": "integer" │  ────────────────────────────────────────────────────  │
+    │ }                   │   37         valid              valid                  │
+    │                     │   "foo"      invalid            invalid                │
+    │                     │                                                        │
+    └─────────────────────┴────────────────────────────────────────────────────────┘
+                                      2 tests ran
 
 
 Running a Single Test Suite File
@@ -62,9 +83,32 @@ Running a Single Test Suite File
 
 To run the draft 7 ``type``-keyword tests on the Lua ``jsonschema`` implementation, run:
 
+.. testcode:: *
+
+    single_test_suite = 'bowtie suite -i lua-jsonschema https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft7/type.json | bowtie summary --show failures --format pretty'
+    print(asyncio.run(run_command(command=single_test_suite)))
+
+.. testoutput:: *
+   :options: +NORMALIZE_WHITESPACE
+
+                        Bowtie
+    ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┓
+    ┃ Implementation   ┃ Skips ┃ Errors ┃ Failures ┃
+    ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━┩
+    │ jsonschema (lua) │ 0     │ 0      │ 2        │
+    └──────────────────┴───────┴────────┴──────────┘
+                    80 tests ran
+
 .. code:: sh
 
     $ bowtie suite -i lua-jsonschema https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft7/type.json | bowtie summary --show failures
+                        Bowtie
+    ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┓
+    ┃ Implementation   ┃ Skips ┃ Errors ┃ Failures ┃
+    ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━┩
+    │ jsonschema (lua) │ 0     │ 0      │ 2        │
+    └──────────────────┴───────┴────────┴──────────┘
+                    80 tests ran
 
 
 Running the Official Suite Across All Implementations
@@ -72,9 +116,68 @@ Running the Official Suite Across All Implementations
 
 The following will run all Draft 7 tests from the `official test suite`_ (which it will automatically retrieve) across all implementations supporting Draft 7, showing a summary of any test failures.
 
+.. testcode:: *
+
+    draft7_tests = "bowtie suite $(ls implementations/ | sed 's/^/\\-i /') https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft7 | bowtie summary --show failures --format pretty"
+    print(asyncio.run(run_command(command=draft7_tests)))
+
+.. testoutput:: *
+   :options: +NORMALIZE_WHITESPACE
+
+                                        Bowtie
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┓
+    ┃ Implementation                                   ┃ Skips ┃ Errors ┃ Failures ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━┩
+    │ boon (rust)                                      │ 0     │ 0      │ 0        │
+    │ io.openapiprocessor.json-schema-validator (java) │ 0     │ 0      │ 0        │
+    │ json-schema-validator (java)                     │ 0     │ 0      │ 0        │
+    │ json_schemer (ruby)                              │ 0     │ 0      │ 0        │
+    │ jsonschema (python)                              │ 0     │ 0      │ 0        │
+    │ jsonschema (go)                                  │ 0     │ 0      │ 0        │
+    │ kmp-json-schema-validator (kotlin)               │ 0     │ 0      │ 0        │
+    │ JsonSchema.Net (dotnet)                          │ 1     │ 0      │ 0        │
+    │ jsonschema (javascript)                          │ 0     │ 10     │ 0        │
+    │ hyperjump-json-schema (javascript)               │ 11    │ 0      │ 0        │
+    │ jsonschema (rust)                                │ 0     │ 12     │ 6        │
+    │ opis-json-schema (php)                           │ 0     │ 20     │ 2        │
+    │ vscode-json-language-service (typescript)        │ 0     │ 0      │ 49       │
+    │ gojsonschema (go)                                │ 0     │ 20     │ 35       │
+    │ jsonschema (lua)                                 │ 0     │ 63     │ 21       │
+    │ jsonschemafriend (java)                          │ 0     │ 78     │ 6        │
+    │ valijson (c++)                                   │ 0     │ 67     │ 17       │
+    │ fastjsonschema (python)                          │ 0     │ 67     │ 31       │
+    │ ajv (javascript)                                 │ 0     │ 131    │ 8        │
+    └──────────────────────────────────────────────────┴───────┴────────┴──────────┘
+                                    906 tests ran
+
 .. code:: sh
 
     $ bowtie suite $(ls /path/to/bowtie/implementations/ | sed 's/^| /-i /') https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft7 | bowtie summary --show failures
+                                        Bowtie
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┓
+    ┃ Implementation                                   ┃ Skips ┃ Errors ┃ Failures ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━┩
+    │ boon (rust)                                      │ 0     │ 0      │ 0        │
+    │ io.openapiprocessor.json-schema-validator (java) │ 0     │ 0      │ 0        │
+    │ json-schema-validator (java)                     │ 0     │ 0      │ 0        │
+    │ json_schemer (ruby)                              │ 0     │ 0      │ 0        │
+    │ jsonschema (python)                              │ 0     │ 0      │ 0        │
+    │ jsonschema (go)                                  │ 0     │ 0      │ 0        │
+    │ kmp-json-schema-validator (kotlin)               │ 0     │ 0      │ 0        │
+    │ JsonSchema.Net (dotnet)                          │ 1     │ 0      │ 0        │
+    │ jsonschema (javascript)                          │ 0     │ 10     │ 0        │
+    │ hyperjump-json-schema (javascript)               │ 11    │ 0      │ 0        │
+    │ jsonschema (rust)                                │ 0     │ 12     │ 6        │
+    │ opis-json-schema (php)                           │ 0     │ 20     │ 2        │
+    │ vscode-json-language-service (typescript)        │ 0     │ 0      │ 49       │
+    │ gojsonschema (go)                                │ 0     │ 20     │ 35       │
+    │ jsonschema (lua)                                 │ 0     │ 63     │ 21       │
+    │ jsonschemafriend (java)                          │ 0     │ 78     │ 6        │
+    │ valijson (c++)                                   │ 0     │ 67     │ 17       │
+    │ fastjsonschema (python)                          │ 0     │ 67     │ 31       │
+    │ ajv (javascript)                                 │ 0     │ 131    │ 8        │
+    └──────────────────────────────────────────────────┴───────┴────────┴──────────┘
+                                    906 tests ran
 
 
 Running Test Suite Tests From Local Checkouts
@@ -93,10 +196,22 @@ Checking An Implementation Functions On Basic Input
 If you wish to verify that a particular implementation works on your machine (e.g. if you suspect a problem with the container image, or otherwise aren't seeing results), you can run `bowtie smoke <cli:smoke>`.
 E.g., to verify the Golang ``jsonschema`` implementation is functioning, you can run:
 
+.. testcode:: *
+
+    smoke_go_jsonschema = "bowtie smoke -i go-jsonschema --format pretty"
+    print(asyncio.run(run_command(command=smoke_go_json)))
+
+.. testoutput:: *
+   :options: +NORMALIZE_WHITESPACE
+
+    · allow-everything: ✓✓✓✓✓✓
+    · allow-nothing: ✓✓✓✓✓✓
+
 .. code:: sh
 
    $ bowtie smoke -i go-jsonschema
-
+    · allow-everything: ✓✓✓✓✓✓
+    · allow-nothing: ✓✓✓✓✓✓
 
 Reference
 ---------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -28,6 +28,21 @@ The `bowtie validate <cli:validate>` subcommand can be used to test arbitrary sc
 
 Given some collection of implementations to check -- here perhaps two Javascript implementations -- it takes a single schema and one or more instances to check against it:
 
+.. testsetup:: *
+
+    import asyncio
+
+    async def run_command(command: str = ""):
+        process = await asyncio.create_subprocess_shell(
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            executable='/bin/bash'
+        )
+        stdout, _ = await process.communicate()
+        return stdout.decode()
+
 .. testcode:: *
 
     bowtie_validate = 'bowtie validate -i js-ajv -i js-hyperjump <(printf \'{"type": "integer"}\') <(printf 37) <(printf \'"foo"\') | bowtie summary --format pretty'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,20 +38,6 @@ extensions = [
     "sphinxcontrib.spelling",
     "sphinxext.opengraph",
 ]
-doctest_global_setup = """
-import asyncio
-
-async def run_command(command: str = ""):
-    process = await asyncio.create_subprocess_shell(
-        command,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        executable='/bin/bash'
-    )
-    stdout, _ = await process.communicate()
-    return stdout.decode()
-"""
 
 pygments_style = "lovelace"
 pygments_dark_style = "one-dark"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,20 @@ extensions = [
     "sphinxcontrib.spelling",
     "sphinxext.opengraph",
 ]
+doctest_global_setup = '''
+import asyncio
+
+async def run_command(command: str = ""):
+    process = await asyncio.create_subprocess_shell(
+        command,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        executable='/bin/bash'
+    )
+    stdout, _ = await process.communicate()
+    return stdout.decode()
+'''
 
 pygments_style = "lovelace"
 pygments_dark_style = "one-dark"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinxcontrib.spelling",
     "sphinxext.opengraph",
 ]
-doctest_global_setup = '''
+doctest_global_setup = """
 import asyncio
 
 async def run_command(command: str = ""):
@@ -51,7 +51,7 @@ async def run_command(command: str = ""):
     )
     stdout, _ = await process.communicate()
     return stdout.decode()
-'''
+"""
 
 pygments_style = "lovelace"
 pygments_dark_style = "one-dark"


### PR DESCRIPTION
Fixes #12 

@Julian one assumption I have made here is to reflect the doctested output in the documentation page so it is in sync with the latest output that `bowtie` commands will produce.

Just one problem I have is with this example of [local checkouts](https://docs.bowtie.report/en/latest/cli/#running-test-suite-tests-from-local-checkouts). Not sure how to doctest it :(. Perhaps just using the `https` test suite url ?

For this PR I have referenced the official Sphinx Documentation for doctesting in `.rst` files:
https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html