### PR TITLE
Removing metadata duplication and some more UI Tests

### DIFF
--- a/frontend/src/DialectReportView.tsx
+++ b/frontend/src/DialectReportView.tsx
@@ -22,7 +22,7 @@ export const DialectReportView = ({
   const params = useSearchParams();
   const languages = useMemo(() => {
     const langs = Object.values(reportData.runInfo.implementations).map(
-      (impl) => impl.language
+      (impl) => impl.language,
     );
     return Array.from(new Set(langs).values());
   }, [reportData]);
@@ -33,11 +33,11 @@ export const DialectReportView = ({
 
     if (selectedLanguages.length > 0) {
       const filteredReportArray = Array.from(
-        reportData.implementationsResults.entries()
+        reportData.implementationsResults.entries(),
       ).filter(([id]) =>
         selectedLanguages.includes(
-          reportData.runInfo.implementations[id].language
-        )
+          reportData.runInfo.implementations[id].language,
+        ),
       );
       filteredData.implementationsResults = new Map(filteredReportArray);
     }
@@ -53,7 +53,7 @@ export const DialectReportView = ({
     return filterOtherImplementations(
       allImplementationsData,
       availableLanguages,
-      filteredReportData.implementationsResults
+      filteredReportData.implementationsResults,
     );
   }, [
     params,
@@ -81,10 +81,10 @@ export const DialectReportView = ({
 const filterOtherImplementations = (
   allImplementationsData: Record<string, Implementation>,
   langs: string[],
-  filteredReportImplementationsMap: Map<string, ImplementationResults>
+  filteredReportImplementationsMap: Map<string, ImplementationResults>,
 ): Record<string, Implementation> => {
   const filteredOtherImplementationsArray = Object.entries(
-    allImplementationsData
+    allImplementationsData,
   )
     .filter(([, impl]) => langs.includes(impl.language))
     .filter(([key]) => !filteredReportImplementationsMap.has(key));

--- a/frontend/src/DialectReportView.tsx
+++ b/frontend/src/DialectReportView.tsx
@@ -4,7 +4,7 @@ import SummarySection from "./components/Summary/SummarySection";
 import { useMemo } from "react";
 import {
   Implementation,
-  ImplementationData,
+  ImplementationResults,
   ReportData,
 } from "./data/parseReportData.ts";
 import { FilterSection } from "./components/FilterSection.tsx";
@@ -21,8 +21,8 @@ export const DialectReportView = ({
 }) => {
   const params = useSearchParams();
   const languages = useMemo(() => {
-    const langs = Array.from(reportData.implementations.values()).map(
-      (impl) => impl.metadata.language,
+    const langs = Object.values(reportData.runInfo.implementations).map(
+      (impl) => impl.language
     );
     return Array.from(new Set(langs).values());
   }, [reportData]);
@@ -33,11 +33,13 @@ export const DialectReportView = ({
 
     if (selectedLanguages.length > 0) {
       const filteredReportArray = Array.from(
-        reportData.implementations.entries(),
-      ).filter(([, data]) =>
-        selectedLanguages.includes(data.metadata.language),
+        reportData.implementationsResults.entries()
+      ).filter(([id]) =>
+        selectedLanguages.includes(
+          reportData.runInfo.implementations[id].language
+        )
       );
-      filteredData.implementations = new Map(filteredReportArray);
+      filteredData.implementationsResults = new Map(filteredReportArray);
     }
 
     return filteredData;
@@ -51,13 +53,13 @@ export const DialectReportView = ({
     return filterOtherImplementations(
       allImplementationsData,
       availableLanguages,
-      filteredReportData.implementations,
+      filteredReportData.implementationsResults
     );
   }, [
     params,
     allImplementationsData,
     languages,
-    filteredReportData.implementations,
+    filteredReportData.implementationsResults,
   ]);
 
   return (
@@ -79,10 +81,10 @@ export const DialectReportView = ({
 const filterOtherImplementations = (
   allImplementationsData: Record<string, Implementation>,
   langs: string[],
-  filteredReportImplementationsMap: Map<string, ImplementationData>,
+  filteredReportImplementationsMap: Map<string, ImplementationResults>
 ): Record<string, Implementation> => {
   const filteredOtherImplementationsArray = Object.entries(
-    allImplementationsData,
+    allImplementationsData
   )
     .filter(([, impl]) => langs.includes(impl.language))
     .filter(([key]) => !filteredReportImplementationsMap.has(key));

--- a/frontend/src/components/Cases/CaseItem.tsx
+++ b/frontend/src/components/Cases/CaseItem.tsx
@@ -33,7 +33,7 @@ const CaseContent = ({
   implementationsResults,
 }: CaseProps) => {
   const [instance, setInstance] = useState<SetStateAction<unknown>>(
-    caseData.tests[0].instance
+    caseData.tests[0].instance,
   );
   const [activeRow, setActiveRow] = useState<SetStateAction<unknown>>(0);
 
@@ -118,8 +118,8 @@ const CaseItem = ({
           implementations={implementations}
           implementationsResults={implementationsResults}
           schemaDisplayRef={schemaDisplayRef}
-        />
-      )
+        />,
+      ),
     );
   }, [seq, caseData, implementations, implementationsResults]);
   return (

--- a/frontend/src/components/Cases/CaseItem.tsx
+++ b/frontend/src/components/Cases/CaseItem.tsx
@@ -13,14 +13,16 @@ import { mapLanguage } from "../../data/mapLanguage";
 import {
   Case,
   CaseResult,
-  ImplementationData,
+  Implementation,
+  ImplementationResults,
 } from "../../data/parseReportData";
 
 interface CaseProps {
   seq: number;
   caseData: Case;
   schemaDisplayRef?: RefObject<HTMLDivElement>;
-  implementations: ImplementationData[];
+  implementations: Implementation[];
+  implementationsResults: ImplementationResults[];
 }
 
 const CaseContent = ({
@@ -28,9 +30,10 @@ const CaseContent = ({
   schemaDisplayRef,
   caseData,
   implementations,
+  implementationsResults,
 }: CaseProps) => {
   const [instance, setInstance] = useState<SetStateAction<unknown>>(
-    caseData.tests[0].instance,
+    caseData.tests[0].instance
   );
   const [activeRow, setActiveRow] = useState<SetStateAction<unknown>>(0);
 
@@ -48,15 +51,12 @@ const CaseContent = ({
                 <td
                   className="text-center"
                   scope="col"
-                  key={
-                    implementation.metadata.name +
-                    implementation.metadata.language
-                  }
+                  key={implementation.name + implementation.language}
                 >
                   <div className="flex-column d-flex">
-                    <b>{implementation.metadata.name}</b>
+                    <b>{implementation.name}</b>
                     <small className="text-muted">
-                      {mapLanguage(implementation.metadata.language)}
+                      {mapLanguage(implementation.language)}
                     </small>
                   </div>
                 </td>
@@ -82,8 +82,8 @@ const CaseContent = ({
                 <td>
                   <p className="m-0">{test.description}</p>
                 </td>
-                {implementations.map((impl, i) => {
-                  const caseResults = impl.cases.get(seq);
+                {implementationsResults.map((implResult, i) => {
+                  const caseResults = implResult.cases.get(seq);
                   const result: CaseResult =
                     caseResults !== undefined
                       ? caseResults[index]
@@ -99,7 +99,12 @@ const CaseContent = ({
   );
 };
 
-const CaseItem = ({ seq, caseData, implementations }: CaseProps) => {
+const CaseItem = ({
+  seq,
+  caseData,
+  implementations,
+  implementationsResults,
+}: CaseProps) => {
   const [content, setContent] = useState(<></>);
   const [, startTransition] = useTransition();
   const schemaDisplayRef = useRef<HTMLDivElement>(null);
@@ -111,11 +116,12 @@ const CaseItem = ({ seq, caseData, implementations }: CaseProps) => {
           seq={seq}
           caseData={caseData}
           implementations={implementations}
+          implementationsResults={implementationsResults}
           schemaDisplayRef={schemaDisplayRef}
-        />,
-      ),
+        />
+      )
     );
-  }, [seq, caseData, implementations]);
+  }, [seq, caseData, implementations, implementationsResults]);
   return (
     <Accordion.Item ref={schemaDisplayRef} eventKey={seq.toString()}>
       <Accordion.Header>{caseData.description}</Accordion.Header>

--- a/frontend/src/components/Cases/CasesSection.tsx
+++ b/frontend/src/components/Cases/CasesSection.tsx
@@ -4,10 +4,10 @@ import { Accordion } from "react-bootstrap";
 
 const CasesSection = ({ reportData }: { reportData: ReportData }) => {
   const implementationsResults = Array.from(
-    reportData.implementationsResults.values()
+    reportData.implementationsResults.values(),
   );
   const implementations = implementationsResults.map(
-    (implResult) => reportData.runInfo.implementations[implResult.id]
+    (implResult) => reportData.runInfo.implementations[implResult.id],
   );
 
   return (

--- a/frontend/src/components/Cases/CasesSection.tsx
+++ b/frontend/src/components/Cases/CasesSection.tsx
@@ -3,7 +3,13 @@ import CaseItem from "./CaseItem";
 import { Accordion } from "react-bootstrap";
 
 const CasesSection = ({ reportData }: { reportData: ReportData }) => {
-  const implementations = Array.from(reportData.implementations.values());
+  const implementationsResults = Array.from(
+    reportData.implementationsResults.values()
+  );
+  const implementations = implementationsResults.map(
+    (implResult) => reportData.runInfo.implementations[implResult.id]
+  );
+
   return (
     <Accordion id="cases">
       {Array.from(reportData.cases.entries()).map(([seq, caseData], index) => (
@@ -12,6 +18,7 @@ const CasesSection = ({ reportData }: { reportData: ReportData }) => {
           seq={seq}
           caseData={caseData}
           implementations={implementations}
+          implementationsResults={implementationsResults}
         />
       ))}
     </Accordion>

--- a/frontend/src/components/Modals/DetailsButtonModal.tsx
+++ b/frontend/src/components/Modals/DetailsButtonModal.tsx
@@ -1,59 +1,67 @@
 import { Button, Modal } from "react-bootstrap";
 import { mapLanguage } from "../../data/mapLanguage";
-import { Case, ImplementationData } from "../../data/parseReportData";
+import {
+  Case,
+  Implementation,
+  ImplementationResults,
+} from "../../data/parseReportData";
 import SchemaDisplay from "../Cases/SchemaDisplay";
 
 export const DetailsButtonModal = ({
   show,
   handleClose,
   cases,
+  implementationResults,
   implementation,
 }: {
   show: boolean;
   handleClose: () => void;
   cases: Map<number, Case>;
-  implementation: ImplementationData;
+  implementationResults: ImplementationResults;
+  implementation: Implementation;
 }) => {
   const failedResults: JSX.Element[] = [];
-  Array.from(implementation.cases.entries()).forEach(([seq, results]) => {
-    const caseData = cases.get(seq)!;
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i];
-      if (result.state === "successful") {
-        continue;
-      }
+  Array.from(implementationResults.cases.entries()).forEach(
+    ([seq, results]) => {
+      const caseData = cases.get(seq)!;
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        if (result.state === "successful") {
+          continue;
+        }
 
-      let message;
-      if (result.state === "skipped" || result.state === "errored") {
-        message = implementation.cases.get(seq)![i].message!;
-      } else if (result.valid) {
-        message = "Unexpectedly valid";
-      } else {
-        message = "Unexpectedly invalid";
+        let message;
+        if (result.state === "skipped" || result.state === "errored") {
+          message = implementationResults.cases.get(seq)![i].message!;
+        } else if (result.valid) {
+          message = "Unexpectedly valid";
+        } else {
+          message = "Unexpectedly invalid";
+        }
+        const borderClass =
+          result.state === "skipped" ? "border-warning" : "border-danger";
+        failedResults.push(
+          <DetailItem
+            key={`${seq}-${i}`}
+            title={caseData.description}
+            description={caseData.tests[i].description}
+            schema={caseData.schema}
+            instance={caseData.tests[i].instance}
+            message={message}
+            borderClass={borderClass}
+          />
+        );
       }
-      const borderClass =
-        result.state === "skipped" ? "border-warning" : "border-danger";
-      failedResults.push(
-        <DetailItem
-          key={`${seq}-${i}`}
-          title={caseData.description}
-          description={caseData.tests[i].description}
-          schema={caseData.schema}
-          instance={caseData.tests[i].instance}
-          message={message}
-          borderClass={borderClass}
-        />,
-      );
     }
-  });
+  );
   return (
     <Modal show={show} onHide={handleClose} fullscreen={true}>
       <Modal.Header closeButton>
         <Modal.Title>
           <label className="me-1">Unsuccessful Tests:</label>
-          <b>{implementation.metadata.name}</b>
+          <b>{implementation.name}</b>
           <small className="text-muted ps-2">
-            {mapLanguage(implementation.metadata.language)}
+            {mapLanguage(implementation.language)}
           </small>
         </Modal.Title>
       </Modal.Header>

--- a/frontend/src/components/Modals/DetailsButtonModal.tsx
+++ b/frontend/src/components/Modals/DetailsButtonModal.tsx
@@ -49,10 +49,10 @@ export const DetailsButtonModal = ({
             instance={caseData.tests[i].instance}
             message={message}
             borderClass={borderClass}
-          />
+          />,
         );
       }
-    }
+    },
   );
   return (
     <Modal show={show} onHide={handleClose} fullscreen={true}>

--- a/frontend/src/components/Summary/ImplementationRow.tsx
+++ b/frontend/src/components/Summary/ImplementationRow.tsx
@@ -3,20 +3,26 @@ import { useState } from "react";
 import { DetailsButtonModal } from "../Modals/DetailsButtonModal";
 import { mapLanguage } from "../../data/mapLanguage";
 import { NavLink, useNavigate } from "react-router-dom";
-import { Case, ImplementationData } from "../../data/parseReportData";
+import {
+  Case,
+  Implementation,
+  ImplementationResults,
+} from "../../data/parseReportData";
 
 const ImplementationRow = ({
   cases,
+  implementationResults,
   implementation,
 }: {
   cases: Map<number, Case>;
-  implementation: ImplementationData;
+  implementationResults: ImplementationResults;
+  implementation: Implementation;
   key: number;
   index: number;
 }) => {
   const [showDetails, setShowDetails] = useState(false);
   const navigate = useNavigate();
-  const implementationPath = getImplementationPath(implementation);
+  const implementationPath = getImplementationPath(implementationResults);
 
   return (
     <tr>
@@ -26,40 +32,40 @@ const ImplementationRow = ({
         scope="row"
       >
         <NavLink to={`/implementations/${implementationPath}`}>
-          {implementation.metadata.name}
+          {implementation.name}
         </NavLink>
         <small className="text-muted ps-1">
-          {mapLanguage(implementation.metadata.language)}
+          {mapLanguage(implementation.language)}
         </small>
       </th>
       <td className="align-middle d-none d-sm-table-cell">
         <small className="font-monospace text-muted">
-          {implementation.metadata.version ?? ""}
+          {implementation.version ?? ""}
         </small>
       </td>
 
       <td className="text-center align-middle">
-        {implementation.erroredCases}
+        {implementationResults.erroredCases}
       </td>
       <td className="text-center align-middle">
-        {implementation.skippedTests}
+        {implementationResults.skippedTests}
       </td>
       <td className="text-center align-middle details-required">
-        {implementation.failedTests + implementation.erroredTests}
+        {implementationResults.failedTests + implementationResults.erroredTests}
         <div className="hover-details text-center">
           <p>
-            <b>failed</b>: &nbsp;{implementation.failedTests}
+            <b>failed</b>: &nbsp;{implementationResults.failedTests}
           </p>
           <p>
-            <b>errored</b>: &nbsp;{implementation.erroredTests}
+            <b>errored</b>: &nbsp;{implementationResults.erroredTests}
           </p>
         </div>
       </td>
 
       <td className="align-middle p-0">
-        {implementation.failedTests +
-          implementation.erroredTests +
-          implementation.skippedTests >
+        {implementationResults.failedTests +
+          implementationResults.erroredTests +
+          implementationResults.skippedTests >
           0 && (
           <button
             type="button"
@@ -74,14 +80,15 @@ const ImplementationRow = ({
         show={showDetails}
         handleClose={() => setShowDetails(false)}
         cases={cases}
+        implementationResults={implementationResults}
         implementation={implementation}
       />
     </tr>
   );
 };
 
-const getImplementationPath = (implementation: ImplementationData) => {
-  const pathSegment = implementation.id.split("/");
+const getImplementationPath = (implResult: ImplementationResults) => {
+  const pathSegment = implResult.id.split("/");
   return pathSegment[pathSegment.length - 1];
 };
 

--- a/frontend/src/components/Summary/SummaryTable.tsx
+++ b/frontend/src/components/Summary/SummaryTable.tsx
@@ -68,7 +68,7 @@ const SummaryTable = ({ reportData }: { reportData: ReportData }) => {
                 a.skippedTests -
                 b.failedTests -
                 b.erroredTests -
-                b.skippedTests
+                b.skippedTests,
             )
             .map((implResults, index) => (
               <ImplementationRow

--- a/frontend/src/components/Summary/SummaryTable.tsx
+++ b/frontend/src/components/Summary/SummaryTable.tsx
@@ -60,7 +60,7 @@ const SummaryTable = ({ reportData }: { reportData: ReportData }) => {
           </tr>
         </thead>
         <tbody className="table-group-divider">
-          {Array.from(reportData.implementations.values())
+          {Array.from(reportData.implementationsResults.values())
             .sort(
               (a, b) =>
                 a.failedTests +
@@ -68,12 +68,15 @@ const SummaryTable = ({ reportData }: { reportData: ReportData }) => {
                 a.skippedTests -
                 b.failedTests -
                 b.erroredTests -
-                b.skippedTests,
+                b.skippedTests
             )
-            .map((implementation, index) => (
+            .map((implResults, index) => (
               <ImplementationRow
                 cases={reportData.cases}
-                implementation={implementation}
+                implementationResults={implResults}
+                implementation={
+                  reportData.runInfo.implementations[implResults.id]
+                }
                 key={index}
                 index={index}
               />

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -60,6 +60,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runInfo.implementations[tag("envsonschema")];
+    console.log(report);
     const testCase = report.cases.get(1);
 
     // FIXME: Remove Seqs + duplication all over from the UI's representation

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -59,7 +59,7 @@ describe("parseReportData", () => {
 
     const report = fromSerialized(lines);
 
-    const metadata = report.implementations.get(tag("envsonschema"))?.metadata;
+    const metadata = report.runInfo.implementations[tag("envsonschema")];
     const testCase = report.cases.get(1);
 
     // FIXME: Remove Seqs + duplication all over from the UI's representation

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -114,4 +114,175 @@ describe("parseReportData", () => {
       didFailFast: false,
     });
   });
+
+  test("multiple test cases", async () => {
+    let lines: string;
+    const tempdir = await mkdtemp(join(tmpdir(), "bowtie-ui-tests-"));
+
+    try {
+      const schema = join(tempdir, "cases.json");
+      const case1 = {
+        description: "case1",
+        schema: {
+          additionalProperties: { type: "boolean" },
+          properties: { bar: {}, foo: {} },
+        },
+        tests: [
+          {
+            description: "one",
+            instance: { foo: 1 },
+            valid: true,
+          },
+          {
+            description: "two",
+            instance: { foo: 1, bar: 2, quux: true },
+            valid: true,
+          },
+          {
+            description: "three",
+            instance: { foo: 1, bar: 2, quux: 12 },
+            valid: false,
+          },
+        ],
+      };
+      const case2 = {
+        description: "case2",
+        schema: {
+          additionalProperties: { type: "boolean" },
+        },
+        tests: [
+          {
+            description: "one",
+            instance: { foo: true },
+            valid: true,
+          },
+          {
+            description: "two",
+            instance: { foo: 1 },
+            valid: false,
+          },
+        ],
+      };
+      const case3 = {
+        description: "case3",
+        schema: {
+          allOf: [
+            { $ref: "https://example.com/schema-with-anchor#foo" },
+            { then: { $id: "http://example.com/ref/then", type: "integer" } },
+          ],
+        },
+        tests: [
+          {
+            description: "one",
+            instance: "foo",
+            valid: false,
+          },
+          {
+            description: "two",
+            instance: 12,
+            valid: true,
+          },
+        ],
+      };
+      const jsonData = `${JSON.stringify(case1)}\n${JSON.stringify(
+        case2
+      )}\n${JSON.stringify(case3)}`;
+      await writeFile(schema, jsonData);
+
+      lines = bowtie(["run", "-i", tag("envsonschema"), "-D", "7", schema]);
+    } finally {
+      await rm(tempdir, { recursive: true });
+    }
+
+    const report = fromSerialized(lines);
+
+    const metadata = report.runInfo.implementations[tag("envsonschema")];
+    const testCase1 = report.cases.get(1);
+    const testCase2 = report.cases.get(2);
+    const testCase3 = report.cases.get(3);
+
+    expect(report).toStrictEqual({
+      runInfo: {
+        started: report.runInfo.started,
+        bowtie_version: report.runInfo.bowtie_version,
+        dialect: Dialect.withName("draft7").uri,
+        implementations: {
+          [tag("envsonschema")]: {
+            name: "envsonschema",
+            language: "python",
+            dialects: metadata?.dialects,
+            homepage: metadata?.homepage,
+            issues: metadata?.issues,
+            source: metadata?.source,
+            links: metadata?.links,
+          },
+        },
+        metadata: {},
+      },
+      implementationsResults: new Map([
+        [
+          tag("envsonschema"),
+          {
+            erroredCases: 0,
+            erroredTests: 0,
+            skippedTests: 0,
+            failedTests: 4,
+
+            id: tag("envsonschema"),
+            cases: new Map([
+              [
+                1,
+                [
+                  { state: "failed", valid: false },
+                  { state: "failed", valid: false },
+                  { state: "successful", valid: false },
+                ],
+              ],
+              [
+                2,
+                [
+                  { state: "failed", valid: false },
+                  { state: "successful", valid: false },
+                ],
+              ],
+              [
+                3,
+                [
+                  { state: "successful", valid: false },
+                  { state: "failed", valid: false },
+                ],
+              ],
+            ]),
+          },
+        ],
+      ]),
+      cases: new Map([
+        [
+          1,
+          {
+            description: testCase1?.description,
+            schema: testCase1?.schema,
+            tests: testCase1?.tests,
+          },
+        ],
+        [
+          2,
+          {
+            description: testCase2?.description,
+            schema: testCase2?.schema,
+            tests: testCase2?.tests,
+          },
+        ],
+        [
+          3,
+          {
+            description: testCase3?.description,
+            schema: testCase3?.schema,
+            tests: testCase3?.tests,
+          },
+        ],
+      ]),
+      didFailFast: false,
+    });
+  });
 });

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -60,7 +60,6 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runInfo.implementations[tag("envsonschema")];
-    console.log(report);
     const testCase = report.cases.get(1);
 
     // FIXME: Remove Seqs + duplication all over from the UI's representation
@@ -82,7 +81,7 @@ describe("parseReportData", () => {
         },
         metadata: {},
       },
-      implementations: new Map([
+      implementationsResults: new Map([
         [
           tag("envsonschema"),
           {

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -185,7 +185,7 @@ describe("parseReportData", () => {
         ],
       };
       const jsonData = `${JSON.stringify(case1)}\n${JSON.stringify(
-        case2
+        case2,
       )}\n${JSON.stringify(case3)}`;
       await writeFile(schema, jsonData);
 

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -91,15 +91,6 @@ describe("parseReportData", () => {
             failedTests: 1,
 
             id: tag("envsonschema"),
-            metadata: {
-              name: "envsonschema",
-              language: "python",
-              dialects: metadata?.dialects,
-              homepage: metadata?.homepage,
-              issues: metadata?.issues,
-              source: metadata?.source,
-              links: metadata?.links,
-            },
             cases: new Map([[1, [{ state: "failed", valid: false }]]]),
           },
         ],

--- a/frontend/src/data/parseReportData.ts
+++ b/frontend/src/data/parseReportData.ts
@@ -4,7 +4,7 @@
 export const fromSerialized = (jsonl: string): ReportData => {
   const lines = jsonl.trim().split(/\r?\n/);
   return parseReportData(
-    lines.map((line) => JSON.parse(line) as Record<string, unknown>)
+    lines.map((line) => JSON.parse(line) as Record<string, unknown>),
   );
 };
 
@@ -12,7 +12,7 @@ export const fromSerialized = (jsonl: string): ReportData => {
  * Parse a report from some deserialized JSON objects.
  */
 export const parseReportData = (
-  lines: Record<string, unknown>[]
+  lines: Record<string, unknown>[],
 ): ReportData => {
   const runInfoData = lines[0] as unknown as RunInfo;
   const implementationEntries = Object.entries(runInfoData.implementations);
@@ -31,7 +31,7 @@ export const parseReportData = (
       skippedTests: 0,
       failedTests: 0,
       erroredTests: 0,
-    })
+    }),
   );
 
   let didFailFast = false;
@@ -41,7 +41,7 @@ export const parseReportData = (
     } else if (line.implementation) {
       const caseData = caseMap.get(line.seq as number)!;
       const implementationResults = implementationsResultsMap.get(
-        line.implementation as string
+        line.implementation as string,
       )!;
       if (line.caught !== undefined) {
         const context = line.context as Record<string, unknown>;
@@ -54,7 +54,7 @@ export const parseReportData = (
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "errored",
             message: errorMessage,
-          })
+          }),
         );
       } else if (line.skipped) {
         implementationResults.skippedTests += caseData.tests.length;
@@ -63,7 +63,7 @@ export const parseReportData = (
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "skipped",
             message: line.message as string,
-          })
+          }),
         );
       } else if (line.implementation) {
         const caseResults: CaseResult[] = (
@@ -115,14 +115,14 @@ export const parseReportData = (
 };
 
 export const parseImplementationData = (
-  loaderData: Record<string, ReportData>
+  loaderData: Record<string, ReportData>,
 ) => {
   let allImplementations: Record<string, Implementation> = {};
   const dialectCompliance: Record<string, Record<string, Partial<Totals>>> = {};
 
   for (const [key, value] of Object.entries(loaderData)) {
     dialectCompliance[key] = calculateImplementationTotal(
-      value.implementationsResults
+      value.implementationsResults,
     );
     allImplementations = {
       ...allImplementations,
@@ -136,7 +136,7 @@ export const parseImplementationData = (
         if (
           !Object.prototype.hasOwnProperty.call(
             allImplementations[implementation],
-            "results"
+            "results",
           )
         ) {
           allImplementations[implementation].results = {};
@@ -149,7 +149,7 @@ export const parseImplementationData = (
 };
 
 const calculateImplementationTotal = (
-  implementationsResults: Map<string, ImplementationResults>
+  implementationsResults: Map<string, ImplementationResults>,
 ) => {
   const implementationResult: Record<string, Partial<Totals>> = {};
 
@@ -167,7 +167,7 @@ const calculateImplementationTotal = (
 export const calculateTotals = (data: ReportData): Totals => {
   const totalTests = Array.from(data.cases.values()).reduce(
     (prev, curr) => prev + curr.tests.length,
-    0
+    0,
   );
   return Array.from(data.implementationsResults.values()).reduce(
     (prev, curr) => ({
@@ -183,7 +183,7 @@ export const calculateTotals = (data: ReportData): Totals => {
       skippedTests: 0,
       failedTests: 0,
       erroredTests: 0,
-    }
+    },
   );
 };
 

--- a/frontend/src/data/parseReportData.ts
+++ b/frontend/src/data/parseReportData.ts
@@ -4,7 +4,7 @@
 export const fromSerialized = (jsonl: string): ReportData => {
   const lines = jsonl.trim().split(/\r?\n/);
   return parseReportData(
-    lines.map((line) => JSON.parse(line) as Record<string, unknown>),
+    lines.map((line) => JSON.parse(line) as Record<string, unknown>)
   );
 };
 
@@ -12,7 +12,7 @@ export const fromSerialized = (jsonl: string): ReportData => {
  * Parse a report from some deserialized JSON objects.
  */
 export const parseReportData = (
-  lines: Record<string, unknown>[],
+  lines: Record<string, unknown>[]
 ): ReportData => {
   const runInfoData = lines[0] as unknown as RunInfo;
   const implementationEntries = Object.entries(runInfoData.implementations);
@@ -31,7 +31,7 @@ export const parseReportData = (
       skippedTests: 0,
       failedTests: 0,
       erroredTests: 0,
-    }),
+    })
   );
 
   let didFailFast = false;
@@ -40,30 +40,30 @@ export const parseReportData = (
       caseMap.set(line.seq as number, line.case as Case);
     } else if (line.implementation) {
       const caseData = caseMap.get(line.seq as number)!;
-      const implementationData = implementationsResultsMap.get(
-        line.implementation as string,
+      const implementationResults = implementationsResultsMap.get(
+        line.implementation as string
       )!;
       if (line.caught !== undefined) {
         const context = line.context as Record<string, unknown>;
         const errorMessage: string = (context?.message ??
           context?.stderr) as string;
-        implementationData.erroredCases++;
-        implementationData.erroredTests += caseData.tests.length;
-        implementationData.cases.set(
+        implementationResults.erroredCases++;
+        implementationResults.erroredTests += caseData.tests.length;
+        implementationResults.cases.set(
           line.seq as number,
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "errored",
             message: errorMessage,
-          }),
+          })
         );
       } else if (line.skipped) {
-        implementationData.skippedTests += caseData.tests.length;
-        implementationData.cases.set(
+        implementationResults.skippedTests += caseData.tests.length;
+        implementationResults.cases.set(
           line.seq as number,
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "skipped",
             message: line.message as string,
-          }),
+          })
         );
       } else if (line.implementation) {
         const caseResults: CaseResult[] = (
@@ -72,13 +72,13 @@ export const parseReportData = (
           if (res.errored) {
             const context = res.context as Record<string, unknown>;
             const errorMessage = context?.message ?? context?.stderr;
-            implementationData.erroredTests++;
+            implementationResults.erroredTests++;
             return {
               state: "errored",
               message: errorMessage as string | undefined,
             };
           } else if (res.skipped) {
-            implementationData.skippedTests++;
+            implementationResults.skippedTests++;
             return {
               state: "skipped",
               message: res.message as string | undefined,
@@ -91,7 +91,7 @@ export const parseReportData = (
                 valid: res.valid as boolean | undefined,
               };
             } else {
-              implementationData.failedTests++;
+              implementationResults.failedTests++;
               return {
                 state: "failed",
                 valid: res.valid as boolean | undefined,
@@ -99,7 +99,7 @@ export const parseReportData = (
             }
           }
         });
-        implementationData.cases.set(line.seq as number, caseResults);
+        implementationResults.cases.set(line.seq as number, caseResults);
       } else if (line.did_fail_fast !== undefined) {
         didFailFast = line.did_fail_fast as boolean;
       }
@@ -115,14 +115,14 @@ export const parseReportData = (
 };
 
 export const parseImplementationData = (
-  loaderData: Record<string, ReportData>,
+  loaderData: Record<string, ReportData>
 ) => {
   let allImplementations: Record<string, Implementation> = {};
   const dialectCompliance: Record<string, Record<string, Partial<Totals>>> = {};
 
   for (const [key, value] of Object.entries(loaderData)) {
     dialectCompliance[key] = calculateImplementationTotal(
-      value.implementationsResults,
+      value.implementationsResults
     );
     allImplementations = {
       ...allImplementations,
@@ -136,7 +136,7 @@ export const parseImplementationData = (
         if (
           !Object.prototype.hasOwnProperty.call(
             allImplementations[implementation],
-            "results",
+            "results"
           )
         ) {
           allImplementations[implementation].results = {};
@@ -149,7 +149,7 @@ export const parseImplementationData = (
 };
 
 const calculateImplementationTotal = (
-  implementationsResults: Map<string, ImplementationResults>,
+  implementationsResults: Map<string, ImplementationResults>
 ) => {
   const implementationResult: Record<string, Partial<Totals>> = {};
 
@@ -167,7 +167,7 @@ const calculateImplementationTotal = (
 export const calculateTotals = (data: ReportData): Totals => {
   const totalTests = Array.from(data.cases.values()).reduce(
     (prev, curr) => prev + curr.tests.length,
-    0,
+    0
   );
   return Array.from(data.implementationsResults.values()).reduce(
     (prev, curr) => ({
@@ -183,7 +183,7 @@ export const calculateTotals = (data: ReportData): Totals => {
       skippedTests: 0,
       failedTests: 0,
       erroredTests: 0,
-    },
+    }
   );
 };
 

--- a/frontend/src/data/parseReportData.ts
+++ b/frontend/src/data/parseReportData.ts
@@ -4,7 +4,7 @@
 export const fromSerialized = (jsonl: string): ReportData => {
   const lines = jsonl.trim().split(/\r?\n/);
   return parseReportData(
-    lines.map((line) => JSON.parse(line) as Record<string, unknown>)
+    lines.map((line) => JSON.parse(line) as Record<string, unknown>),
   );
 };
 
@@ -12,7 +12,7 @@ export const fromSerialized = (jsonl: string): ReportData => {
  * Parse a report from some deserialized JSON objects.
  */
 export const parseReportData = (
-  lines: Record<string, unknown>[]
+  lines: Record<string, unknown>[],
 ): ReportData => {
   const runInfoData = lines[0] as unknown as RunInfo;
   const implementationEntries = Object.entries(runInfoData.implementations);
@@ -31,7 +31,7 @@ export const parseReportData = (
       skippedTests: 0,
       failedTests: 0,
       erroredTests: 0,
-    })
+    }),
   );
 
   let didFailFast = false;
@@ -41,7 +41,7 @@ export const parseReportData = (
     } else if (line.implementation) {
       const caseData = caseMap.get(line.seq as number)!;
       const implementationData = implementationsResultsMap.get(
-        line.implementation as string
+        line.implementation as string,
       )!;
       if (line.caught !== undefined) {
         const context = line.context as Record<string, unknown>;
@@ -54,7 +54,7 @@ export const parseReportData = (
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "errored",
             message: errorMessage,
-          })
+          }),
         );
       } else if (line.skipped) {
         implementationData.skippedTests += caseData.tests.length;
@@ -63,7 +63,7 @@ export const parseReportData = (
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "skipped",
             message: line.message as string,
-          })
+          }),
         );
       } else if (line.implementation) {
         const caseResults: CaseResult[] = (
@@ -115,14 +115,14 @@ export const parseReportData = (
 };
 
 export const parseImplementationData = (
-  loaderData: Record<string, ReportData>
+  loaderData: Record<string, ReportData>,
 ) => {
   let allImplementations: Record<string, Implementation> = {};
   const dialectCompliance: Record<string, Record<string, Partial<Totals>>> = {};
 
   for (const [key, value] of Object.entries(loaderData)) {
     dialectCompliance[key] = calculateImplementationTotal(
-      value.implementationsResults
+      value.implementationsResults,
     );
     allImplementations = {
       ...allImplementations,
@@ -136,7 +136,7 @@ export const parseImplementationData = (
         if (
           !Object.prototype.hasOwnProperty.call(
             allImplementations[implementation],
-            "results"
+            "results",
           )
         ) {
           allImplementations[implementation].results = {};
@@ -149,7 +149,7 @@ export const parseImplementationData = (
 };
 
 const calculateImplementationTotal = (
-  implementationsResults: Map<string, ImplementationResults>
+  implementationsResults: Map<string, ImplementationResults>,
 ) => {
   const implementationResult: Record<string, Partial<Totals>> = {};
 
@@ -167,7 +167,7 @@ const calculateImplementationTotal = (
 export const calculateTotals = (data: ReportData): Totals => {
   const totalTests = Array.from(data.cases.values()).reduce(
     (prev, curr) => prev + curr.tests.length,
-    0
+    0,
   );
   return Array.from(data.implementationsResults.values()).reduce(
     (prev, curr) => ({
@@ -183,7 +183,7 @@ export const calculateTotals = (data: ReportData): Totals => {
       skippedTests: 0,
       failedTests: 0,
       erroredTests: 0,
-    }
+    },
   );
 };
 


### PR DESCRIPTION
Fixes #997 

> implementation metadata duplicated twice, including once mixed in with counts which are used for counting the number of tests with various outcomes. We should remove this duplication

@Julian I have removed the metadata duplication from the **counts** as you mentioned above (you can check in the `parseReportData.test.ts` code). Adding some more UI tests is still in progress. But would like to hear out your opinion on these changes because this small tweak has called out for lot of refactoring.  

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--999.org.readthedocs.build/en/999/

<!-- readthedocs-preview bowtie-json-schema end -->