### PR TITLE
Add filter-dialects subcommand

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -150,7 +150,10 @@ class ImplementationSubcommand(Protocol):
 SILENT = _report.Reporter(write=lambda **_: None)  # type: ignore[reportUnknownArgumentType])
 
 
-def implementation_subcommand(reporter: _report.Reporter = SILENT, default_implementations: Set[str] = Implementation.known()):
+def implementation_subcommand(
+    reporter: _report.Reporter = SILENT,
+    default_implementations: Set[str] = Implementation.known(),
+):
     """
     Define a Bowtie subcommand which starts up some implementations.
 
@@ -193,7 +196,7 @@ def implementation_subcommand(reporter: _report.Reporter = SILENT, default_imple
 
                     running.append(implementation)
 
-                if running or len(default_implementations)==0:
+                if running or len(default_implementations) == 0:
                     exit_code |= await fn(implementations=running, **kw) or 0
                 else:
                     exit_code |= _EX_CONFIG
@@ -990,7 +993,7 @@ async def filter_implementations(
             click.echo(each.name.removeprefix(f"{IMAGE_REPOSITORY}/"))
 
 
-@implementation_subcommand(default_implementations=frozenset()) # type: ignore[reportArgumentType]
+@implementation_subcommand(default_implementations=frozenset())  # type: ignore[reportArgumentType]
 @click.option(
     "--dialect",
     "-d",
@@ -999,9 +1002,7 @@ async def filter_implementations(
     default=Dialect.known(),
     metavar="URI_OR_NAME",
     multiple=True,
-    help=(
-        "Filter from the given list of dialects only."
-    ),
+    help=("Filter from the given list of dialects only."),
 )
 @click.option(
     "--latest",
@@ -1039,15 +1040,15 @@ async def filter_dialects(
     """
     for dialect in sorted(dialects, reverse=True):
         if dialect.supported_by_all(*implementations) and (
-            (boolean_schemas and dialect.has_boolean_schemas) or
-            (no_boolean_schemas and not dialect.has_boolean_schemas) or
-            not (boolean_schemas or no_boolean_schemas)
+            (boolean_schemas and dialect.has_boolean_schemas)
+            or (no_boolean_schemas and not dialect.has_boolean_schemas)
+            or not (boolean_schemas or no_boolean_schemas)
         ):
             click.echo(dialect.uri)
-            if(latest):
+            if latest:
                 break
 
-            
+
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @FORMAT
 async def info(implementations: Iterable[Implementation], format: _F):

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -150,7 +150,7 @@ class ImplementationSubcommand(Protocol):
 SILENT = _report.Reporter(write=lambda **_: None)  # type: ignore[reportUnknownArgumentType])
 
 
-def implementation_subcommand(reporter: _report.Reporter = SILENT):
+def implementation_subcommand(reporter: _report.Reporter = SILENT, default_implementations: Set[str] = Implementation.known()):
     """
     Define a Bowtie subcommand which starts up some implementations.
 
@@ -193,7 +193,7 @@ def implementation_subcommand(reporter: _report.Reporter = SILENT):
 
                     running.append(implementation)
 
-                if running:
+                if running or len(default_implementations)==0:
                     exit_code |= await fn(implementations=running, **kw) or 0
                 else:
                     exit_code |= _EX_CONFIG
@@ -207,7 +207,7 @@ def implementation_subcommand(reporter: _report.Reporter = SILENT):
             "image_names",
             type=_Image(),
             default=lambda: (
-                Implementation.known()
+                default_implementations
                 if sys.stdin.isatty()
                 else [line.strip() for line in sys.stdin]
             ),
@@ -990,6 +990,64 @@ async def filter_implementations(
             click.echo(each.name.removeprefix(f"{IMAGE_REPOSITORY}/"))
 
 
+@implementation_subcommand(default_implementations=frozenset()) # type: ignore[reportArgumentType]
+@click.option(
+    "--dialect",
+    "-d",
+    "dialects",
+    type=_Dialect(),
+    default=Dialect.known(),
+    metavar="URI_OR_NAME",
+    multiple=True,
+    help=(
+        "Filter from the given list of dialects only."
+    ),
+)
+@click.option(
+    "--latest",
+    "-l",
+    "latest",
+    is_flag=True,
+    default=False,
+    help="Show only the latest dialect.",
+)
+@click.option(
+    "--boolean-schemas",
+    "-b",
+    "boolean_schemas",
+    is_flag=True,
+    default=False,
+    help="Show only dialects which do support boolean schemas.",
+)
+@click.option(
+    "--no-boolean-schemas",
+    "-nb",
+    "no_boolean_schemas",
+    is_flag=True,
+    default=False,
+    help="Show only dialects which do not support boolean schemas.",
+)
+async def filter_dialects(
+    implementations: Iterable[Implementation],
+    dialects: Sequence[Dialect],
+    latest: bool,
+    boolean_schemas: bool,
+    no_boolean_schemas: bool,
+):
+    """
+    Output dialects matching a given criteria.
+    """
+    for dialect in sorted(dialects, reverse=True):
+        if dialect.supported_by_all(*implementations) and (
+            (boolean_schemas and dialect.has_boolean_schemas) or
+            (no_boolean_schemas and not dialect.has_boolean_schemas) or
+            not (boolean_schemas or no_boolean_schemas)
+        ):
+            click.echo(dialect.uri)
+            if(latest):
+                break
+
+            
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @FORMAT
 async def info(implementations: Iterable[Implementation], format: _F):

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -148,9 +148,11 @@ class Dialect:
                 "$ref": str(self.uri),
             },
         )
-    
+
     def supported_by_all(self, *implementations: Implementation):
-        return all(implementation.supports(self) for implementation in implementations)
+        return all(
+            implementation.supports(self) for implementation in implementations
+        )
 
 
 @frozen

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -148,6 +148,9 @@ class Dialect:
                 "$ref": str(self.uri),
             },
         )
+    
+    def supported_by_all(self, *implementations: Implementation):
+        return all(implementation.supports(self) for implementation in implementations)
 
 
 @frozen

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1347,7 +1347,9 @@ async def test_filter_dialects():
     stdout, stderr = await bowtie(
         "filter-dialects",
     )
-    dialects_supported = "\n".join([str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True)])
+    dialects_supported = "\n".join(
+        [str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True)]
+    )
     assert (stdout.strip(), stderr) == (f"{dialects_supported}", "")
 
 
@@ -1363,7 +1365,7 @@ async def test_filter_dialects_latest_dialect():
 
 @pytest.mark.asyncio
 async def test_filter_dialects_supporting_implementation(
-    only_draft3
+    only_draft3,
 ):
     stdout, stderr = await bowtie(
         "filter-dialects",
@@ -1371,7 +1373,10 @@ async def test_filter_dialects_supporting_implementation(
         only_draft3,
     )
     print(stdout)
-    assert (stdout.strip(), stderr) == ("http://json-schema.org/draft-03/schema#", "")
+    assert (stdout.strip(), stderr) == (
+        "http://json-schema.org/draft-03/schema#",
+        "",
+    )
 
 
 @pytest.mark.asyncio
@@ -1380,7 +1385,13 @@ async def test_filter_dialects_boolean_schemas():
         "filter-dialects",
         "-b",
     )
-    boolean_schemas = "\n".join([str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True) if dialect.has_boolean_schemas])
+    boolean_schemas = "\n".join(
+        [
+            str(dialect.uri)
+            for dialect in sorted(Dialect.known(), reverse=True)
+            if dialect.has_boolean_schemas
+        ]
+    )
     assert (stdout.strip(), stderr) == (f"{boolean_schemas}", "")
 
 
@@ -1390,7 +1401,13 @@ async def test_filter_dialects_non_boolean_schemas():
         "filter-dialects",
         "-nb",
     )
-    non_boolean_schemas = "\n".join([str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True) if not dialect.has_boolean_schemas])
+    non_boolean_schemas = "\n".join(
+        [
+            str(dialect.uri)
+            for dialect in sorted(Dialect.known(), reverse=True)
+            if not dialect.has_boolean_schemas
+        ]
+    )
     assert (stdout.strip(), stderr) == (f"{non_boolean_schemas}", "")
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1349,10 +1349,9 @@ async def test_filter_dialects():
     )
     dialects_supported = "\n".join(
         [
-            str(dialect.uri) 
-            for dialect in 
-            sorted(Dialect.known(), reverse=True)
-        ]
+            str(dialect.uri)
+            for dialect in sorted(Dialect.known(), reverse=True)
+        ],
     )
     assert (stdout.strip(), stderr) == (f"{dialects_supported}", "")
 
@@ -1392,7 +1391,7 @@ async def test_filter_dialects_boolean_schemas():
             str(dialect.uri)
             for dialect in sorted(Dialect.known(), reverse=True)
             if dialect.has_boolean_schemas
-        ]
+        ],
     )
     assert (stdout.strip(), stderr) == (f"{boolean_schemas}", "")
 
@@ -1408,7 +1407,7 @@ async def test_filter_dialects_non_boolean_schemas():
             str(dialect.uri)
             for dialect in sorted(Dialect.known(), reverse=True)
             if not dialect.has_boolean_schemas
-        ]
+        ],
     )
     assert (stdout.strip(), stderr) == (f"{non_boolean_schemas}", "")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1343,6 +1343,58 @@ async def test_filter_implementations_stdin(
 
 
 @pytest.mark.asyncio
+async def test_filter_dialects():
+    stdout, stderr = await bowtie(
+        "filter-dialects",
+    )
+    dialects_supported = "\n".join([str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True)])
+    assert (stdout.strip(), stderr) == (f"{dialects_supported}", "")
+
+
+@pytest.mark.asyncio
+async def test_filter_dialects_latest_dialect():
+    stdout, stderr = await bowtie(
+        "filter-dialects",
+        "-l",
+    )
+    print(stdout)
+    assert (stdout.strip(), stderr) == (f"{max(Dialect.known()).uri}", "")
+
+
+@pytest.mark.asyncio
+async def test_filter_dialects_supporting_implementation(
+    only_draft3
+):
+    stdout, stderr = await bowtie(
+        "filter-dialects",
+        "-i",
+        only_draft3,
+    )
+    print(stdout)
+    assert (stdout.strip(), stderr) == ("http://json-schema.org/draft-03/schema#", "")
+
+
+@pytest.mark.asyncio
+async def test_filter_dialects_boolean_schemas():
+    stdout, stderr = await bowtie(
+        "filter-dialects",
+        "-b",
+    )
+    boolean_schemas = "\n".join([str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True) if dialect.has_boolean_schemas])
+    assert (stdout.strip(), stderr) == (f"{boolean_schemas}", "")
+
+
+@pytest.mark.asyncio
+async def test_filter_dialects_non_boolean_schemas():
+    stdout, stderr = await bowtie(
+        "filter-dialects",
+        "-nb",
+    )
+    non_boolean_schemas = "\n".join([str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True) if not dialect.has_boolean_schemas])
+    assert (stdout.strip(), stderr) == (f"{non_boolean_schemas}", "")
+
+
+@pytest.mark.asyncio
 async def test_validate(envsonschema, tmp_path):
     tmp_path.joinpath("schema.json").write_text("{}")
     tmp_path.joinpath("a.json").write_text("12")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1348,7 +1348,11 @@ async def test_filter_dialects():
         "filter-dialects",
     )
     dialects_supported = "\n".join(
-        [str(dialect.uri) for dialect in sorted(Dialect.known(), reverse=True)]
+        [
+            str(dialect.uri) 
+            for dialect in 
+            sorted(Dialect.known(), reverse=True)
+        ]
     )
     assert (stdout.strip(), stderr) == (f"{dialects_supported}", "")
 
@@ -1359,7 +1363,6 @@ async def test_filter_dialects_latest_dialect():
         "filter-dialects",
         "-l",
     )
-    print(stdout)
     assert (stdout.strip(), stderr) == (f"{max(Dialect.known()).uri}", "")
 
 
@@ -1372,7 +1375,6 @@ async def test_filter_dialects_supporting_implementation(
         "-i",
         only_draft3,
     )
-    print(stdout)
     assert (stdout.strip(), stderr) == (
         "http://json-schema.org/draft-03/schema#",
         "",


### PR DESCRIPTION
Closes #996.
 
The goal is to add a `filter-dialects` subcommand supporting filtering of dialects like `filter-implementations`.

Command features:

1. Dialects are always sorted from newest to oldest.

<img width="527" alt="Screenshot 2024-03-08 at 5 46 35 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/0aea3b6d-a1cf-4e87-9374-ff4fb013b5b1">
<p>
2. `bowtie filter-dialects --latest` returns only the latest dialect.

<img width="527" alt="Screenshot 2024-03-08 at 5 45 43 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/eaf39896-04cb-4f98-a40f-1e3f1516dccc">
<p>
3. `bowtie filter-dialects -i go-jsonschema` returns only the dialects supported by the implementation `go-jsonschema`.

<img width="527" alt="Screenshot 2024-03-08 at 5 46 06 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/6e87f255-af2c-490f-8703-0cbdf04839f8">
<p>
4. `bowtie filter-dialects --boolean-schemas` returns only the dialects which support boolean schemas.

<img width="527" alt="Screenshot 2024-03-08 at 5 45 18 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/2388eb45-3edc-4f92-8e6e-6dbf9d06ef53">
<p>
5. `bowtie filter-dialects --no-boolean-schemas` returns only the dialects which do not support boolean schemas.

<img width="527" alt="Screenshot 2024-03-08 at 5 45 29 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/75855708/83e7e47a-7b9b-49c6-a618-e2a5d3e57eb2">


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1002.org.readthedocs.build/en/1002/

<!-- readthedocs-preview bowtie-json-schema end -->