### PR TITLE
Speed up `bowtie filter-implementations` with no arguments

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -950,6 +950,7 @@ KNOWN_LANGUAGES = {
     *(i.partition("-")[0] for i in Implementation.known()),
 }
 
+
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @click.option(
     "--supports-dialect",
@@ -969,14 +970,14 @@ KNOWN_LANGUAGES = {
     "-l",
     "languages",
     type=click.Choice(sorted(KNOWN_LANGUAGES), case_sensitive=False),
-    callback=lambda ctx, _, value: ( # type: ignore[reportUnknownLambdaType]
+    callback=lambda ctx, _, value: (  # type: ignore[reportUnknownLambdaType]
         KNOWN_LANGUAGES
         if not value
-        and not ctx.params["dialects"] # type: ignore[reportUnknownMemberType]
-        and len(ctx.params["image_names"]) == len(Implementation.known()) # type: ignore[reportUnknownMemberType]
+        and not ctx.params["dialects"]  # type: ignore[reportUnknownMemberType]
+        and len(ctx.params["image_names"]) == len(Implementation.known())  # type: ignore[reportUnknownMemberType]
         else frozenset(
-            LANGUAGE_ALIASES.get(each, each) # type: ignore[reportUnknownArgumentType]
-            for each in value or KNOWN_LANGUAGES # type: ignore[reportUnknownArgumentType]
+            LANGUAGE_ALIASES.get(each, each)  # type: ignore[reportUnknownArgumentType]
+            for each in value or KNOWN_LANGUAGES  # type: ignore[reportUnknownArgumentType]
         )
     ),
     multiple=True,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -976,7 +976,7 @@ KNOWN_LANGUAGES = {
         and len(ctx.params["image_names"]) == len(Implementation.known()) # type: ignore[reportUnknownMemberType]
         else frozenset(
             LANGUAGE_ALIASES.get(each, each) # type: ignore[reportUnknownArgumentType]
-            for each in value # type: ignore[reportUnknownArgumentType]
+            for each in value or KNOWN_LANGUAGES # type: ignore[reportUnknownArgumentType]
         )
     ),
     multiple=True,
@@ -991,7 +991,7 @@ async def filter_implementations(
     """
     Output implementations matching a given criteria.
     """
-    if languages == KNOWN_LANGUAGES:
+    if not dialects and languages == KNOWN_LANGUAGES:
         for implementation in Implementation.known():
             click.echo(implementation)
         return

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -973,18 +973,18 @@ KNOWN_LANGUAGES = {
     callback=lambda ctx, _, value: (  # type: ignore[reportUnknownLambdaType]
         KNOWN_LANGUAGES
         if not value
-        and not ctx.params["dialects"]  # type: ignore[reportUnknownMemberType]
-        and len(ctx.params["image_names"]) == len(Implementation.known())  # type: ignore[reportUnknownMemberType]
         else frozenset(
             LANGUAGE_ALIASES.get(each, each)  # type: ignore[reportUnknownArgumentType]
-            for each in value or KNOWN_LANGUAGES  # type: ignore[reportUnknownArgumentType]
+            for each in value # type: ignore[reportUnknownArgumentType]
         )
     ),
     multiple=True,
     metavar="LANGUAGE",
     help="Only include implementations in the given programming language",
 )
+@click.pass_context
 async def filter_implementations(
+    ctx: click.Context,
     start: Callable[[], AsyncIterator[Implementation]],
     dialects: Sequence[Dialect],
     languages: Set[str],
@@ -992,9 +992,9 @@ async def filter_implementations(
     """
     Output implementations matching a given criteria.
     """
-    if languages == KNOWN_LANGUAGES:
-        for implementation in Implementation.known():
-            click.echo(implementation)
+    if not dialects and languages == KNOWN_LANGUAGES:
+        for implementation in ctx.params["image_names"]:
+            click.echo(implementation.split("/")[-1])
         return
 
     async for each in start():

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -970,7 +970,7 @@ KNOWN_LANGUAGES = {
     "-l",
     "languages",
     type=click.Choice(sorted(KNOWN_LANGUAGES), case_sensitive=False),
-    callback=lambda ctx, _, value: (  # type: ignore[reportUnknownLambdaType]
+    callback=lambda _, __, value: (  # type: ignore[reportUnknownLambdaType]
         KNOWN_LANGUAGES
         if not value
         else frozenset(

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -991,7 +991,7 @@ async def filter_implementations(
     """
     Output implementations matching a given criteria.
     """
-    if not dialects and languages == KNOWN_LANGUAGES:
+    if languages == KNOWN_LANGUAGES:
         for implementation in Implementation.known():
             click.echo(implementation)
         return

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,3 +5,4 @@ jsonschema
 pytest
 pytest-asyncio==0.21.1
 pytest-icdiff
+pexpect

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -42,6 +42,10 @@ click==8.1.7
     # via
     #   -r requirements.txt
     #   bowtie-json-schema
+colorama==0.4.6
+    # via
+    #   click
+    #   pytest
 cryptography==42.0.5
     # via
     #   -r requirements.txt
@@ -103,10 +107,14 @@ multidict==6.0.5
     #   yarl
 packaging==23.2
     # via pytest
+pexpect==4.9.0
+    # via -r test-requirements.in
 pluggy==1.4.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+ptyprocess==0.7.0
+    # via pexpect
 pycparser==2.21
     # via
     #   -r requirements.txt

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1279,8 +1279,7 @@ async def test_filter_implementations_no_arguments():
 
     try:
         stdout = [
-            byte.decode()
-            for byte in output_buffer.getvalue().splitlines()
+            byte.decode() for byte in output_buffer.getvalue().splitlines()
         ]
     except UnicodeDecodeError as err:
         stderr = str(err)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,8 +7,8 @@ import asyncio
 import json as _json
 import os
 import pty
-import select
 import re
+import select
 import sys
 import tarfile
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1266,8 +1266,6 @@ async def test_filter_implementations_no_arguments():
         stdout = child.before.decode().splitlines()
     except pexpect.exceptions.ExceptionPexpect as err:
         stderr = str(err)
-    except Exception as err:
-        stderr = str(err)
 
     expected = sorted(Implementation.known())
     assert (sorted(stdout), stderr) == (expected, "")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,6 +52,7 @@ async def bowtie(*argv, stdin: str = "", exit_code=0, json=False):
     if exit_code == -1:
         assert process.returncode != 0, decoded
     else:
+        print(stderr)
         assert process.returncode == exit_code, stderr
 
     if json:
@@ -1259,7 +1260,6 @@ async def test_filter_implementations_no_arguments():
     stdout, stderr = await bowtie(
         "filter-implementations",
     )
-    print(stderr)
     assert (
         sorted(stdout.splitlines()), stderr,
     ) == (Implementation.known(), "")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,7 +52,6 @@ async def bowtie(*argv, stdin: str = "", exit_code=0, json=False):
     if exit_code == -1:
         assert process.returncode != 0, decoded
     else:
-        print(stderr)
         assert process.returncode == exit_code, stderr
 
     if json:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ import pytest
 import pytest_asyncio
 
 from bowtie._commands import ErroredTest, TestResult
-from bowtie._core import Dialect, Test, TestCase, Implementation
+from bowtie._core import Dialect, Implementation, Test, TestCase
 from bowtie._report import EmptyReport, InvalidReport, Report
 
 Test.__test__ = TestCase.__test__ = TestResult.__test__ = (
@@ -1257,9 +1257,12 @@ async def test_info_unsuccessful_start(succeed_immediately):
 @pytest.mark.asyncio
 async def test_filter_implementations_no_arguments():
     stdout, stderr = await bowtie(
-        "filter-implementations"
+        "filter-implementations",
     )
-    assert (sorted(stdout.splitlines()), stderr) == (Implementation.known(), "")
+    print(stderr)
+    assert (
+        sorted(stdout.splitlines()), stderr,
+    ) == (Implementation.known(), "")
 
 @pytest.mark.asyncio
 async def test_filter_implementations_by_language(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1254,14 +1254,17 @@ async def test_info_unsuccessful_start(succeed_immediately):
     assert stdout.strip() in {"", "{}"}  # empty, but ignore if JSON or not
     assert "failed to start" in stderr.lower(), stderr
 
+
 @pytest.mark.asyncio
 async def test_filter_implementations_no_arguments():
     stdout, stderr = await bowtie(
         "filter-implementations",
     )
     assert (
-        sorted(stdout.splitlines()), stderr,
+        sorted(stdout.splitlines()),
+        stderr,
     ) == (Implementation.known(), "")
+
 
 @pytest.mark.asyncio
 async def test_filter_implementations_by_language(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ import pytest
 import pytest_asyncio
 
 from bowtie._commands import ErroredTest, TestResult
-from bowtie._core import Dialect, Test, TestCase
+from bowtie._core import Dialect, Test, TestCase, Implementation
 from bowtie._report import EmptyReport, InvalidReport, Report
 
 Test.__test__ = TestCase.__test__ = TestResult.__test__ = (
@@ -1254,6 +1254,12 @@ async def test_info_unsuccessful_start(succeed_immediately):
     assert stdout.strip() in {"", "{}"}  # empty, but ignore if JSON or not
     assert "failed to start" in stderr.lower(), stderr
 
+@pytest.mark.asyncio
+async def test_filter_implementations_no_arguments():
+    stdout, stderr = await bowtie(
+        "filter-implementations"
+    )
+    assert (sorted(stdout.splitlines()), stderr) == (Implementation.known(), "")
 
 @pytest.mark.asyncio
 async def test_filter_implementations_by_language(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1279,7 +1279,8 @@ async def test_filter_implementations_no_arguments():
 
     try:
         stdout = [
-            byte.decode() for byte in output_buffer.getvalue().splitlines()
+            byte.decode()
+            for byte in output_buffer.getvalue().splitlines()
         ]
     except UnicodeDecodeError as err:
         stderr = str(err)


### PR DESCRIPTION
https://github.com/bowtie-json-schema/bowtie/assets/68469605/03d0412f-a1a1-45d5-8990-c804c4e2e352

@Julian I am not sure why the test I wrote is failing though :(. Its some `process.returncode` of 78. Does it have something to do with the `ls implementations/` that's happening in the background ?. The command does work on the CLI without starting any Docker containers.

Also shouldn't we output directly without starting the containers even if it was just `bowtie filter-implementations -i python-jsonschema` with no arguments for e.g. ?

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1020.org.readthedocs.build/en/1020/

<!-- readthedocs-preview bowtie-json-schema end -->