### PR TITLE
Remove hardcoded paths / links to dialect reports

### DIFF
--- a/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
+++ b/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
@@ -56,11 +56,7 @@ const DialectCompliance: React.FC<{
                     <td>
                       <Link
                         className="mx-1"
-                        // FIXME: surely this shouldn't be hardcoded
-                        // Double FIXME: This should go to the
-                        // implementation-specific page, not the global dialect
-                        // one.
-                        to={`/dialects/${dialect.shortName}`}
+                        to={dialect.routePath}
                       >
                         <img
                           alt={dialect.prettyName}

--- a/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
+++ b/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
@@ -54,10 +54,7 @@ const DialectCompliance: React.FC<{
                     <td className="text-center">{result.skippedTests}</td>
                     <td className="text-center">{result.erroredTests}</td>
                     <td>
-                      <Link
-                        className="mx-1"
-                        to={dialect.routePath}
-                      >
+                      <Link className="mx-1" to={dialect.routePath}>
                         <img
                           alt={dialect.prettyName}
                           className="float-end"

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -97,10 +97,7 @@ const NavBar = () => {
                 <ul className="dropdown-menu">
                   {Dialect.newest_to_oldest().map((dialect) => (
                     <li key={dialect.shortName}>
-                      <NavLink
-                        className="dropdown-item"
-                        to={dialect.routePath}
-                      >
+                      <NavLink className="dropdown-item" to={dialect.routePath}>
                         {dialect.prettyName}
                       </NavLink>
                     </li>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -99,8 +99,7 @@ const NavBar = () => {
                     <li key={dialect.shortName}>
                       <NavLink
                         className="dropdown-item"
-                        // FIXME: surely this shouldn't be hardcoded
-                        to={`/dialects/${dialect.shortName}`}
+                        to={dialect.routePath}
                       >
                         {dialect.prettyName}
                       </NavLink>

--- a/frontend/src/components/OtherImplementations.tsx
+++ b/frontend/src/components/OtherImplementations.tsx
@@ -61,7 +61,7 @@ export const OtherImplementations = ({ otherImplementationsData }: Props) => {
                           </div>
                           <span className="text-body-secondary text-nowrap">
                             (latest supported dialect:{" "}
-                            <NavLink to={`/dialects/${latest.shortName}`}>
+                            <NavLink to={latest.routePath}>
                               {latest.prettyName}
                             </NavLink>
                             )

--- a/frontend/src/data/Dialect.test.ts
+++ b/frontend/src/data/Dialect.test.ts
@@ -8,6 +8,7 @@ describe("Dialect", () => {
       shortName: "draft7",
       prettyName: "Draft 7",
       firstPublicationDate: new Date("2017-11-19"),
+      routePath: "/dialects/draft7",
     });
   });
 });

--- a/frontend/src/data/Dialect.ts
+++ b/frontend/src/data/Dialect.ts
@@ -12,6 +12,7 @@ export default class Dialect {
   readonly prettyName: string;
   readonly uri: string;
   readonly firstPublicationDate: Date;
+  readonly routePath: string;
 
   private static all: Map<string, Dialect> = new Map<string, Dialect>();
 
@@ -30,6 +31,7 @@ export default class Dialect {
     this.prettyName = prettyName;
     this.uri = uri;
     this.firstPublicationDate = firstPublicationDate;
+    this.routePath = `/dialects/${shortName}`;
   }
 
   async fetchReport(baseURI: URI = siteURI) {


### PR DESCRIPTION
Fixes #962 by moving logic for creating dialect route paths into Dialect class itself, providing a single point of failure rather than multiple opportunities for errors in writing route paths for dialects. The paths are still technically hardcoded, but as mentioned by @harrel56 in #962, this is common practice.

In the process of this fix I did experiment quite a lot with TypeScript and what we can do as far as validating paths goes. I think there is a bigger project here that could be worked on over a larger time frame which allows for validation of paths and path parameters via TypeScript to prevent errors in specifying routes - along the lines of what is discussed [here](https://dev.to/0916dhkim/type-safe-usage-of-react-router-5c44). Since this is a bigger project that would introduce more complexity I would defer that to a new issue - I'm sure there is a debate to be had there whether it is actually worth it.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1021.org.readthedocs.build/en/1021/

<!-- readthedocs-preview bowtie-json-schema end -->