### PR TITLE
Add tests to check that we emit valid markdown

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -2,6 +2,7 @@ file:.#egg=bowtie-json-schema
 -r requirements.txt
 hypothesis
 jsonschema
+markdown-it-py==3.0.0
 pytest
 pytest-asyncio==0.21.1
 pytest-icdiff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -90,6 +90,7 @@ jsonschema-specifications==2023.12.1
 markdown-it-py==3.0.0
     # via
     #   -r requirements.txt
+    #   -r test-requirements.in
     #   diagnostic
     #   rich
 mdurl==0.1.2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,7 @@
 from contextlib import asynccontextmanager
 from io import BytesIO
+from markdown_it import MarkdownIt
+from markdown_it.tree import SyntaxTreeNode
 from pathlib import Path
 from pprint import pformat
 from textwrap import dedent, indent
@@ -959,6 +961,36 @@ async def test_smoke_markdown(envsonschema):
 
 
 @pytest.mark.asyncio
+async def test_smoke_valid_markdown(envsonschema):
+    stdout, stderr = await bowtie(
+        "smoke",
+        "--format",
+        "markdown",
+        "-i",
+        envsonschema,
+        exit_code=-1,  # because indeed envsonschema gets answers wrong.
+    )
+    parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
+    tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
+    print(tokens)
+    assert (
+        tokens
+        == """
+        <root>
+  <bullet_list>
+    <list_item>
+      <paragraph>
+        <inline>
+          <text>
+    <list_item>
+      <paragraph>
+        <inline>
+          <text>
+        """.strip()
+    ), stderr
+
+
+@pytest.mark.asyncio
 async def test_smoke_json(envsonschema):
     jsonout, stderr = await bowtie(
         "smoke",
@@ -1135,6 +1167,97 @@ async def test_info_markdown(envsonschema):
         ]
         """,
     )
+    assert stderr == ""
+
+
+@pytest.mark.asyncio
+async def test_info_valid_markdown(envsonschema):
+    stdout, stderr = await bowtie(
+        "info",
+        "--format",
+        "markdown",
+        "-i",
+        envsonschema,
+    )
+    parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
+    tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
+    assert tokens == (
+        """
+        <root>
+  <paragraph>
+    <inline>
+      <text>
+      <strong>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <strong>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <strong>
+        <text>
+      <text>
+      <link href='https://github.com/bowtie-json-schema/bowtie'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <strong>
+        <text>
+      <text>
+      <link href='https://github.com/bowtie-json-schema/bowtie/issues'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <strong>
+        <text>
+      <text>
+      <link href='https://github.com/bowtie-json-schema/bowtie'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <strong>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <link href='https://json-schema.org/draft/2020-12/schema'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <link href='https://json-schema.org/draft/2019-09/schema'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <link href='http://json-schema.org/draft-07/schema#'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <link href='http://json-schema.org/draft-06/schema#'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <link href='http://json-schema.org/draft-04/schema#'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+      <link href='http://json-schema.org/draft-03/schema#'>
+        <text>
+      <text>
+      <softbreak>
+      <text>
+        """
+    ).strip()
     assert stderr == ""
 
 
@@ -1496,6 +1619,79 @@ async def test_summary_show_failures_markdown(envsonschema, tmp_path):
 
         """,
     )
+
+
+@pytest.mark.asyncio
+async def test_summary_failures_valid_markdown(envsonschema, tmp_path):
+    tmp_path.joinpath("schema.json").write_text("{}")
+    tmp_path.joinpath("one.json").write_text("12")
+    tmp_path.joinpath("two.json").write_text("37")
+
+    validate_stdout, _ = await bowtie(
+        "validate",
+        "-i",
+        envsonschema,
+        "--expect",
+        "valid",
+        tmp_path / "schema.json",
+        tmp_path / "one.json",
+        tmp_path / "two.json",
+    )
+
+    stdout, stderr = await bowtie(
+        "summary",
+        "--format",
+        "markdown",
+        "--show",
+        "failures",
+        stdin=validate_stdout,
+    )
+    parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
+    tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
+    assert stderr == ""
+    assert tokens == (
+        """
+        <root>
+  <heading>
+    <inline>
+      <text>
+  <table>
+    <thead>
+      <tr>
+        <th style='text-align:center'>
+          <inline>
+            <text>
+        <th style='text-align:center'>
+          <inline>
+            <text>
+        <th style='text-align:center'>
+          <inline>
+            <text>
+        <th style='text-align:center'>
+          <inline>
+            <text>
+    <tbody>
+      <tr>
+        <td style='text-align:center'>
+          <inline>
+            <text>
+        <td style='text-align:center'>
+          <inline>
+            <text>
+        <td style='text-align:center'>
+          <inline>
+            <text>
+        <td style='text-align:center'>
+          <inline>
+            <text>
+  <paragraph>
+    <inline>
+      <text>
+      <strong>
+        <text>
+      <text>
+        """
+    ).strip()
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,5 @@
 from contextlib import asynccontextmanager
 from io import BytesIO
-from markdown_it import MarkdownIt
-from markdown_it.tree import SyntaxTreeNode
 from pathlib import Path
 from pprint import pformat
 from textwrap import dedent, indent
@@ -13,6 +11,8 @@ import sys
 import tarfile
 
 from aiodocker.exceptions import DockerError
+from markdown_it import MarkdownIt
+from markdown_it.tree import SyntaxTreeNode
 import pytest
 import pytest_asyncio
 
@@ -1181,8 +1181,10 @@ async def test_info_valid_markdown(envsonschema):
     )
     parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
     tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
-    assert tokens == (
-        """
+    assert (
+        tokens
+        == (
+            """
         <root>
   <paragraph>
     <inline>
@@ -1257,7 +1259,8 @@ async def test_info_valid_markdown(envsonschema):
       <softbreak>
       <text>
         """
-    ).strip()
+        ).strip()
+    )
     assert stderr == ""
 
 
@@ -1649,8 +1652,10 @@ async def test_summary_failures_valid_markdown(envsonschema, tmp_path):
     parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
     tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
     assert stderr == ""
-    assert tokens == (
-        """
+    assert (
+        tokens
+        == (
+            """
         <root>
   <heading>
     <inline>
@@ -1691,7 +1696,8 @@ async def test_summary_failures_valid_markdown(envsonschema, tmp_path):
         <text>
       <text>
         """
-    ).strip()
+        ).strip()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -970,7 +970,7 @@ async def test_smoke_valid_markdown(envsonschema):
         envsonschema,
         exit_code=-1,  # because indeed envsonschema gets answers wrong.
     )
-    parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
+    parsed_markdown = MarkdownIt("gfm-like", {"linkify": False}).parse(stdout)
     tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
     assert (
         tokens
@@ -1178,7 +1178,7 @@ async def test_info_valid_markdown(envsonschema):
         "-i",
         envsonschema,
     )
-    parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
+    parsed_markdown = MarkdownIt("gfm-like", {"linkify": False}).parse(stdout)
     tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
     assert (
         tokens
@@ -1648,7 +1648,7 @@ async def test_summary_failures_valid_markdown(envsonschema, tmp_path):
         "failures",
         stdin=validate_stdout,
     )
-    parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
+    parsed_markdown = MarkdownIt("gfm-like", {"linkify": False}).parse(stdout)
     tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
     assert stderr == ""
     assert (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1201,23 +1201,9 @@ async def test_info_valid_markdown(envsonschema):
       <strong>
         <text>
       <text>
-      <link href='https://github.com/bowtie-json-schema/bowtie'>
-        <text>
-      <text>
       <softbreak>
       <text>
       <strong>
-        <text>
-      <text>
-      <link href='https://github.com/bowtie-json-schema/bowtie/issues'>
-        <text>
-      <text>
-      <softbreak>
-      <text>
-      <strong>
-        <text>
-      <text>
-      <link href='https://github.com/bowtie-json-schema/bowtie'>
         <text>
       <text>
       <softbreak>
@@ -1227,33 +1213,20 @@ async def test_info_valid_markdown(envsonschema):
       <text>
       <softbreak>
       <text>
-      <link href='https://json-schema.org/draft/2020-12/schema'>
+      <strong>
         <text>
       <text>
       <softbreak>
       <text>
-      <link href='https://json-schema.org/draft/2019-09/schema'>
-        <text>
+      <softbreak>
       <text>
       <softbreak>
       <text>
-      <link href='http://json-schema.org/draft-07/schema#'>
-        <text>
+      <softbreak>
       <text>
       <softbreak>
       <text>
-      <link href='http://json-schema.org/draft-06/schema#'>
-        <text>
-      <text>
       <softbreak>
-      <text>
-      <link href='http://json-schema.org/draft-04/schema#'>
-        <text>
-      <text>
-      <softbreak>
-      <text>
-      <link href='http://json-schema.org/draft-03/schema#'>
-        <text>
       <text>
       <softbreak>
       <text>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -972,7 +972,6 @@ async def test_smoke_valid_markdown(envsonschema):
     )
     parsed_markdown = MarkdownIt("gfm-like").parse(stdout)
     tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)
-    print(tokens)
     assert (
         tokens
         == """


### PR DESCRIPTION
Closes #922.

Uses markdown-it-py with gfm and tries parsing the markdown to html. If the resultant token classes match our intended token classes, we get valid markdown.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1022.org.readthedocs.build/en/1022/

<!-- readthedocs-preview bowtie-json-schema end -->