### PR TITLE
In light of PR #1042 having tests for `prepareImplementationReport` (across all dialect compliances) won't hurt :)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: [--fix, lf]
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.3"
+    rev: "v0.3.4"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -106,7 +106,7 @@ repos:
         exclude: .*/json.lua
         args: ["--config-path", "implementations/lua-jsonschema/stylua.toml"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.1
+    rev: v18.1.2
     hooks:
       - name: clang-format (c/c++/c#/java implementations)
         id: clang-format

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -790,15 +790,17 @@ FAIL_FAST = click.option(
 )
 MAX_FAIL = click.option(
     "--max-fail",
+    metavar="COUNT",
     type=click.IntRange(min=1),
     callback=_disallow_fail_fast,
-    help="Fail immediately if N tests fail in total across implementations",
+    help="Fail immediately if x tests fail in total across implementations",
 )
 MAX_ERROR = click.option(
     "--max-error",
+    metavar="COUNT",
     type=click.IntRange(min=1),
     callback=_disallow_fail_fast,
-    help="Fail immediately if N errors occur in total across implementations",
+    help="Fail immediately if x errors occur in total across implementations",
 )
 SET_SCHEMA = click.option(
     "--set-schema",

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1302,7 +1302,10 @@ async def _run(
                     should_stop = True
 
             if should_stop:
-                reporter.failed_fast(seq_case=seq_case)
+                STDERR.print(
+                    "[bold yellow]Stopping -- the maximum number of "
+                    "unsuccessful tests was reached![/]",
+                )
                 break
         reporter.finished(did_fail_fast=should_stop)
         if count == 0:

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1296,8 +1296,8 @@ async def _run(
                 unsucessful += result.unsuccessful()
                 if (
                     max_fail
-                    and unsucessful.failed == max_fail
-                    or (max_error and unsucessful.errored == max_error)
+                    and unsucessful.failed >= max_fail
+                    or (max_error and unsucessful.errored >= max_error)
                 ):
                     should_stop = True
 

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -988,7 +988,7 @@ async def filter_implementations(
     """
     if not dialects and languages == KNOWN_LANGUAGES:
         for implementation in ctx.params["image_names"]:
-            click.echo(implementation.split("/")[-1])
+            click.echo(implementation.removeprefix(f"{IMAGE_REPOSITORY}/"))
         return
 
     async for each in start():

--- a/bowtie/_report.py
+++ b/bowtie/_report.py
@@ -98,11 +98,6 @@ class Reporter:
         )
         return CaseReporter(write=self._write, log=log)
 
-    def failed_fast(self, seq_case: SeqCase):
-        self._log.warning(
-            "Stopping -- the maximum number of unsuccessful tests was reached",
-        )
-
 
 @frozen
 class CaseReporter:

--- a/frontend/src/components/Cases/CaseItem.tsx
+++ b/frontend/src/components/Cases/CaseItem.tsx
@@ -84,7 +84,7 @@ const CaseContent = ({
                   <p className="m-0">{test.description}</p>
                 </td>
                 {implementationsResults.map((implResult, i) => {
-                  const caseResults = implResult.cases.get(seq);
+                  const caseResults = implResult.caseResults.get(seq);
                   const result: CaseResult =
                     caseResults !== undefined
                       ? caseResults[index]

--- a/frontend/src/components/Cases/CasesSection.tsx
+++ b/frontend/src/components/Cases/CasesSection.tsx
@@ -7,9 +7,9 @@ const CasesSection = ({ reportData }: { reportData: ReportData }) => {
   const implementationsResults = Array.from(
     reportData.implementationsResults.values(),
   );
-  const implementations = implementationsResults.map(
-    (implResult) => reportData.runMetadata.implementations.get(implResult.id)!,
-  );
+  const implementations = Array.from(
+    reportData.implementationsResults.keys(),
+  ).map((id) => reportData.runMetadata.implementations.get(id)!);
 
   return (
     <Accordion id="cases">

--- a/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
+++ b/frontend/src/components/ImplementationReportView/DialectCompliance.tsx
@@ -5,13 +5,12 @@ import Image from "react-bootstrap/Image";
 import Table from "react-bootstrap/Table";
 
 import { complianceBadgeFor } from "../../data/Badge";
-import Dialect from "../../data/Dialect";
-import { ImplementationDialectCompliance } from "../../data/parseReportData";
+import { ImplementationReport } from "../../data/parseReportData";
 
 const DialectCompliance: React.FC<{
-  implementationDialectCompliance: ImplementationDialectCompliance;
-}> = ({ implementationDialectCompliance }) => {
-  const { implementation, dialectCompliance } = implementationDialectCompliance;
+  implementationReport: ImplementationReport;
+}> = ({ implementationReport }) => {
+  const { implementation, dialectCompliance } = implementationReport;
 
   return (
     <Card className="mx-auto mb-3 col-md-9">
@@ -37,7 +36,7 @@ const DialectCompliance: React.FC<{
             </tr>
           </thead>
           <tbody className="table-group-divider">
-            {Object.entries(dialectCompliance)
+            {Array.from(dialectCompliance.entries())
               .sort(
                 (a, b) =>
                   a[1].failedTests! +
@@ -46,11 +45,9 @@ const DialectCompliance: React.FC<{
                     b[1].failedTests! -
                     b[1].erroredTests! -
                     b[1].skippedTests! ||
-                  +Dialect.withName(b[0]).firstPublicationDate -
-                    +Dialect.withName(a[0]).firstPublicationDate,
+                  +b[0].firstPublicationDate - +a[0].firstPublicationDate,
               )
-              .map(([dialectName, result], index) => {
-                const dialect = Dialect.withName(dialectName);
+              .map(([dialect, result], index) => {
                 return (
                   <tr key={index}>
                     <td>{dialect.prettyName}</td>

--- a/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
+++ b/frontend/src/components/ImplementationReportView/ImplementationReportView.tsx
@@ -1,50 +1,32 @@
 import Container from "react-bootstrap/Container";
 import Card from "react-bootstrap/Card";
 import Table from "react-bootstrap/Table";
-import { useLoaderData, useParams, Link, Navigate } from "react-router-dom";
+import { useLoaderData, Link, Navigate } from "react-router-dom";
 
 import DialectCompliance from "./DialectCompliance";
 import EmbedBadges from "./EmbedBadges";
 import LoadingAnimation from "../LoadingAnimation";
-import { ImplementationDialectCompliance } from "../../data/parseReportData";
+import { ImplementationReport } from "../../data/parseReportData";
 import { mapLanguage } from "../../data/mapLanguage";
 import { versionsBadgeFor } from "../../data/Badge";
 
 export const ImplementationReportView = () => {
-  // Fetch all supported implementation's metadata.
-  const allImplementationsDialectCompliance = useLoaderData() as Record<
-    string,
-    ImplementationDialectCompliance
-  >;
+  const implementationReport = useLoaderData() as ImplementationReport | null;
 
-  // Get the selected implementation's name from the URL parameters.
-  const { langImplementation } = useParams();
-  // FIXME: This magic prefix is duplicated from the backend side,
-  //        and probably needs some tweaking for when using a local image.
-  const image = langImplementation
-    ? `ghcr.io/bowtie-json-schema/${langImplementation}`
-    : "";
-  const currImplementationDialectCompliance =
-    allImplementationsDialectCompliance[image];
-
-  // FIXME: Probably redirect to /implementations if/when that's a thing.
-  return allImplementationsDialectCompliance ? (
-    currImplementationDialectCompliance ? (
-      <ReportComponent
-        implementationDialectCompliance={currImplementationDialectCompliance}
-      />
-    ) : (
-      <Navigate to="/" />
-    )
-  ) : (
+  return implementationReport === null ? (
+    // FIXME: Probably redirect to /implementations if/when that's a thing.
+    <Navigate to="/" />
+  ) : !implementationReport ? (
     <LoadingAnimation />
+  ) : (
+    <ReportComponent implementationReport={implementationReport} />
   );
 };
 
 const ReportComponent: React.FC<{
-  implementationDialectCompliance: ImplementationDialectCompliance;
-}> = ({ implementationDialectCompliance }) => {
-  const { implementation } = implementationDialectCompliance;
+  implementationReport: ImplementationReport;
+}> = ({ implementationReport }) => {
+  const { implementation } = implementationReport;
 
   return (
     <Container className="p-4">
@@ -154,9 +136,7 @@ const ReportComponent: React.FC<{
           </Table>
         </Card.Body>
       </Card>
-      <DialectCompliance
-        implementationDialectCompliance={implementationDialectCompliance}
-      />
+      <DialectCompliance implementationReport={implementationReport} />
     </Container>
   );
 };

--- a/frontend/src/components/Modals/DetailsButtonModal.tsx
+++ b/frontend/src/components/Modals/DetailsButtonModal.tsx
@@ -22,7 +22,7 @@ export const DetailsButtonModal = ({
   implementation: Implementation;
 }) => {
   const failedResults: JSX.Element[] = [];
-  Array.from(implementationResults.cases.entries()).forEach(
+  Array.from(implementationResults.caseResults.entries()).forEach(
     ([seq, results]) => {
       const caseData = cases.get(seq)!;
       for (let i = 0; i < results.length; i++) {
@@ -33,7 +33,7 @@ export const DetailsButtonModal = ({
 
         let message;
         if (result.state === "skipped" || result.state === "errored") {
-          message = implementationResults.cases.get(seq)![i].message!;
+          message = implementationResults.caseResults.get(seq)![i].message!;
         } else if (result.valid) {
           message = "Unexpectedly valid";
         } else {

--- a/frontend/src/components/Summary/ImplementationRow.tsx
+++ b/frontend/src/components/Summary/ImplementationRow.tsx
@@ -12,19 +12,21 @@ import { ThemeContext } from "../../context/ThemeContext";
 
 const ImplementationRow = ({
   cases,
-  implementationResults,
+  id,
   implementation,
+  implementationResults,
 }: {
   cases: Map<number, Case>;
-  implementationResults: ImplementationResults;
+  id: string;
   implementation: Implementation;
+  implementationResults: ImplementationResults;
   key: number;
   index: number;
 }) => {
   const { isDarkMode } = useContext(ThemeContext);
   const [showDetails, setShowDetails] = useState(false);
   const navigate = useNavigate();
-  const implementationPath = getImplementationPath(implementationResults);
+  const implementationPath = getImplementationPath(id);
 
   return (
     <tr>
@@ -51,27 +53,28 @@ const ImplementationRow = ({
       </td>
 
       <td className="text-center align-middle">
-        {implementationResults.erroredCases}
+        {implementationResults.totals.erroredCases}
       </td>
       <td className="text-center align-middle">
-        {implementationResults.skippedTests}
+        {implementationResults.totals.skippedTests}
       </td>
       <td className="text-center align-middle details-required">
-        {implementationResults.failedTests + implementationResults.erroredTests}
+        {implementationResults.totals.failedTests! +
+          implementationResults.totals.erroredTests!}
         <div className="hover-details text-center">
           <p>
-            <b>failed</b>: &nbsp;{implementationResults.failedTests}
+            <b>failed</b>: &nbsp;{implementationResults.totals.failedTests}
           </p>
           <p>
-            <b>errored</b>: &nbsp;{implementationResults.erroredTests}
+            <b>errored</b>: &nbsp;{implementationResults.totals.erroredTests}
           </p>
         </div>
       </td>
 
       <td className="align-middle p-0">
-        {implementationResults.failedTests +
-          implementationResults.erroredTests +
-          implementationResults.skippedTests >
+        {implementationResults.totals.failedTests! +
+          implementationResults.totals.erroredTests! +
+          implementationResults.totals.skippedTests! >
           0 && (
           <button
             type="button"
@@ -93,8 +96,8 @@ const ImplementationRow = ({
   );
 };
 
-const getImplementationPath = (implResult: ImplementationResults) => {
-  const pathSegment = implResult.id.split("/");
+const getImplementationPath = (id: string) => {
+  const pathSegment = id.split("/");
   return pathSegment[pathSegment.length - 1];
 };
 

--- a/frontend/src/components/Summary/SummaryTable.tsx
+++ b/frontend/src/components/Summary/SummaryTable.tsx
@@ -59,23 +59,22 @@ const SummaryTable = ({ reportData }: { reportData: ReportData }) => {
         </tr>
       </thead>
       <tbody className="table-group-divider">
-        {Array.from(reportData.implementationsResults.values())
+        {Array.from(reportData.implementationsResults.entries())
           .sort(
-            (a, b) =>
-              a.failedTests +
-              a.erroredTests +
-              a.skippedTests -
-              b.failedTests -
-              b.erroredTests -
-              b.skippedTests,
+            ([, a], [, b]) =>
+              a.totals.failedTests! +
+              a.totals.erroredTests! +
+              a.totals.skippedTests! -
+              b.totals.failedTests! -
+              b.totals.erroredTests! -
+              b.totals.skippedTests!,
           )
-          .map((implResults, index) => (
+          .map(([id, implResults], index) => (
             <ImplementationRow
               cases={reportData.cases}
+              id={id}
+              implementation={reportData.runMetadata.implementations.get(id)!}
               implementationResults={implResults}
-              implementation={
-                reportData.runMetadata.implementations.get(implResults.id)!
-              }
               key={index}
               index={index}
             />

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -131,7 +131,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
     const testCase = report.cases.get(1);
 
@@ -154,7 +154,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [
@@ -195,13 +195,13 @@ describe("parseReportData", () => {
 
     const lines = bowtie(
       ["run", "-i", tag("envsonschema"), "-D", "7"],
-      cases.join("\n") + "\n"
+      cases.join("\n") + "\n",
     );
 
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
 
     expect(report).toStrictEqual({
@@ -223,7 +223,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [
@@ -299,7 +299,7 @@ describe("parseReportData", () => {
     for (const dialect of Dialect.known()) {
       const lines = bowtie(
         ["run", "-i", tag("envsonschema"), "-D", dialect.shortName],
-        cases.join("\n") + "\n"
+        cases.join("\n") + "\n",
       );
       const report = fromSerialized(lines);
       combinedData[dialect.shortName] = report;

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -6,7 +6,12 @@ import { tmpdir } from "node:os";
 import { describe, expect, test } from "vitest";
 
 import Dialect from "./Dialect";
-import { RunMetadata, fromSerialized } from "./parseReportData";
+import {
+  ReportData,
+  RunMetadata,
+  fromSerialized,
+  parseImplementationData,
+} from "./parseReportData";
 
 function tag(image: string) {
   // Should match what's used in our `noxfile`, certainly until we handle image
@@ -39,6 +44,72 @@ function bowtie(args: string[] = [], input?: string, status = 0) {
   return result.stdout.toString();
 }
 
+const testCases = {
+  case1: {
+    description: "case1",
+    schema: {
+      additionalProperties: { type: "boolean" },
+      properties: { bar: {}, foo: {} },
+    },
+    tests: [
+      {
+        description: "one",
+        instance: { foo: 1 },
+        valid: true,
+      },
+      {
+        description: "two",
+        instance: { foo: 1, bar: 2, quux: true },
+        valid: true,
+      },
+      {
+        description: "three",
+        instance: { foo: 1, bar: 2, quux: 12 },
+        valid: false,
+      },
+    ],
+  },
+  case2: {
+    description: "case2",
+    schema: {
+      additionalProperties: { type: "boolean" },
+    },
+    tests: [
+      {
+        description: "one",
+        instance: { foo: true },
+        valid: true,
+      },
+      {
+        description: "two",
+        instance: { foo: 1 },
+        valid: false,
+      },
+    ],
+  },
+  case3: {
+    description: "case3",
+    schema: {
+      allOf: [
+        { $ref: "https://example.com/schema-with-anchor#foo" },
+        { then: { $id: "http://example.com/ref/then", type: "integer" } },
+      ],
+    },
+    tests: [
+      {
+        description: "one",
+        instance: "foo",
+        valid: false,
+      },
+      {
+        description: "two",
+        instance: 12,
+        valid: true,
+      },
+    ],
+  },
+};
+
 describe("parseReportData", () => {
   test("parses reports", async () => {
     let lines: string;
@@ -60,7 +131,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema"),
+      tag("envsonschema")
     )!;
     const testCase = report.cases.get(1);
 
@@ -78,12 +149,13 @@ describe("parseReportData", () => {
               issues: metadata.issues,
               source: metadata.source,
               links: metadata.links,
+              results: metadata.results,
             },
           ],
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {},
+        {}
       ),
       implementationsResults: new Map([
         [
@@ -120,80 +192,17 @@ describe("parseReportData", () => {
   });
 
   test("parses reports with multiple test cases", () => {
-    const case1 = {
-      description: "case1",
-      schema: {
-        additionalProperties: { type: "boolean" },
-        properties: { bar: {}, foo: {} },
-      },
-      tests: [
-        {
-          description: "one",
-          instance: { foo: 1 },
-          valid: true,
-        },
-        {
-          description: "two",
-          instance: { foo: 1, bar: 2, quux: true },
-          valid: true,
-        },
-        {
-          description: "three",
-          instance: { foo: 1, bar: 2, quux: 12 },
-          valid: false,
-        },
-      ],
-    };
-    const case2 = {
-      description: "case2",
-      schema: {
-        additionalProperties: { type: "boolean" },
-      },
-      tests: [
-        {
-          description: "one",
-          instance: { foo: true },
-          valid: true,
-        },
-        {
-          description: "two",
-          instance: { foo: 1 },
-          valid: false,
-        },
-      ],
-    };
-    const case3 = {
-      description: "case3",
-      schema: {
-        allOf: [
-          { $ref: "https://example.com/schema-with-anchor#foo" },
-          { then: { $id: "http://example.com/ref/then", type: "integer" } },
-        ],
-      },
-      tests: [
-        {
-          description: "one",
-          instance: "foo",
-          valid: false,
-        },
-        {
-          description: "two",
-          instance: 12,
-          valid: true,
-        },
-      ],
-    };
-    const cases = [case1, case2, case3].map((each) => JSON.stringify(each));
+    const cases = Object.values(testCases).map((each) => JSON.stringify(each));
 
     const lines = bowtie(
       ["run", "-i", tag("envsonschema"), "-D", "7"],
-      cases.join("\n") + "\n",
+      cases.join("\n") + "\n"
     );
 
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema"),
+      tag("envsonschema")
     )!;
 
     expect(report).toStrictEqual({
@@ -210,12 +219,13 @@ describe("parseReportData", () => {
               issues: metadata.issues,
               source: metadata.source,
               links: metadata.links,
+              results: metadata.results,
             },
           ],
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {},
+        {}
       ),
       implementationsResults: new Map([
         [
@@ -258,29 +268,93 @@ describe("parseReportData", () => {
         [
           1,
           {
-            description: case1.description,
-            schema: case1.schema,
-            tests: case1.tests,
+            description: testCases.case1.description,
+            schema: testCases.case1.schema,
+            tests: testCases.case1.tests,
           },
         ],
         [
           2,
           {
-            description: case2.description,
-            schema: case2.schema,
-            tests: case2.tests,
+            description: testCases.case2.description,
+            schema: testCases.case2.schema,
+            tests: testCases.case2.tests,
           },
         ],
         [
           3,
           {
-            description: case3.description,
-            schema: case3.schema,
-            tests: case3.tests,
+            description: testCases.case3.description,
+            schema: testCases.case3.schema,
+            tests: testCases.case3.tests,
           },
         ],
       ]),
       didFailFast: false,
+    });
+  });
+
+  test("parses report with dialect compliances", () => {
+    const cases = Object.values(testCases).map((each) => JSON.stringify(each));
+    const combinedData: Record<string, ReportData> = {};
+
+    for (const dialect of Dialect.known()) {
+      const lines = bowtie(
+        ["run", "-i", tag("envsonschema"), "-D", dialect.shortName],
+        cases.join("\n") + "\n"
+      );
+      const report = fromSerialized(lines);
+      combinedData[dialect.shortName] = report;
+    }
+
+    const parsedImplementationData = parseImplementationData(combinedData);
+    const metadata =
+      parsedImplementationData[tag("envsonschema")].implementation;
+
+    expect(parsedImplementationData).toStrictEqual({
+      [tag("envsonschema")]: {
+        implementation: {
+          name: "envsonschema",
+          language: "python",
+          homepage: metadata.homepage,
+          issues: metadata.issues,
+          source: metadata.source,
+          dialects: metadata.dialects,
+          links: metadata.links,
+        },
+        dialectCompliance: {
+          [Dialect.withName("draft2020-12").shortName]: {
+            erroredTests: 0,
+            skippedTests: 0,
+            failedTests: 4,
+          },
+          [Dialect.withName("draft2019-09").shortName]: {
+            erroredTests: 0,
+            skippedTests: 0,
+            failedTests: 4,
+          },
+          [Dialect.withName("draft7").shortName]: {
+            erroredTests: 0,
+            skippedTests: 0,
+            failedTests: 4,
+          },
+          [Dialect.withName("draft6").shortName]: {
+            erroredTests: 0,
+            skippedTests: 0,
+            failedTests: 4,
+          },
+          [Dialect.withName("draft4").shortName]: {
+            erroredTests: 0,
+            skippedTests: 0,
+            failedTests: 4,
+          },
+          [Dialect.withName("draft3").shortName]: {
+            erroredTests: 0,
+            skippedTests: 0,
+            failedTests: 4,
+          },
+        },
+      },
     });
   });
 });

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -89,13 +89,13 @@ describe("parseReportData", () => {
         [
           tag("envsonschema"),
           {
-            erroredCases: 0,
-            erroredTests: 0,
-            skippedTests: 0,
-            failedTests: 1,
-
-            id: tag("envsonschema"),
-            cases: new Map([[1, [{ state: "failed", valid: false }]]]),
+            totals: {
+              erroredCases: 0,
+              erroredTests: 0,
+              skippedTests: 0,
+              failedTests: 1,
+            },
+            caseResults: new Map([[1, [{ state: "failed", valid: false }]]]),
           },
         ],
       ]),
@@ -221,13 +221,13 @@ describe("parseReportData", () => {
         [
           tag("envsonschema"),
           {
-            erroredCases: 0,
-            erroredTests: 0,
-            skippedTests: 0,
-            failedTests: 4,
-
-            id: tag("envsonschema"),
-            cases: new Map([
+            totals: {
+              erroredCases: 0,
+              erroredTests: 0,
+              skippedTests: 0,
+              failedTests: 4,
+            },
+            caseResults: new Map([
               [
                 1,
                 [

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -131,7 +131,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
     const testCase = report.cases.get(1);
 
@@ -154,7 +154,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [
@@ -195,13 +195,13 @@ describe("parseReportData", () => {
 
     const lines = bowtie(
       ["run", "-i", tag("envsonschema"), "-D", "7"],
-      cases.join("\n") + "\n"
+      cases.join("\n") + "\n",
     );
 
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
 
     expect(report).toStrictEqual({
@@ -223,7 +223,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [
@@ -299,7 +299,7 @@ describe("parseReportData", () => {
     for (const dialect of Dialect.known()) {
       const lines = bowtie(
         ["run", "-i", tag("envsonschema"), "-D", dialect.shortName],
-        cases.join("\n") + "\n"
+        cases.join("\n") + "\n",
       );
       const report = fromSerialized(lines);
       combinedData.set(dialect, report);
@@ -307,7 +307,7 @@ describe("parseReportData", () => {
 
     const implementationReport = prepareImplementationReport(
       combinedData,
-      tag("envsonschema")
+      tag("envsonschema"),
     );
     const metadata = implementationReport!.implementation;
 

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -131,7 +131,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
     const testCase = report.cases.get(1);
 
@@ -155,7 +155,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [
@@ -196,13 +196,13 @@ describe("parseReportData", () => {
 
     const lines = bowtie(
       ["run", "-i", tag("envsonschema"), "-D", "7"],
-      cases.join("\n") + "\n"
+      cases.join("\n") + "\n",
     );
 
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
 
     expect(report).toStrictEqual({
@@ -225,7 +225,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [
@@ -301,7 +301,7 @@ describe("parseReportData", () => {
     for (const dialect of Dialect.known()) {
       const lines = bowtie(
         ["run", "-i", tag("envsonschema"), "-D", dialect.shortName],
-        cases.join("\n") + "\n"
+        cases.join("\n") + "\n",
       );
       const report = fromSerialized(lines);
       combinedData[dialect.shortName] = report;

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -7,8 +7,8 @@ import { describe, expect, test } from "vitest";
 
 import Dialect from "./Dialect";
 import {
-  ReportData,
   RunMetadata,
+  ReportData,
   fromSerialized,
   parseImplementationData,
 } from "./parseReportData";

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -131,7 +131,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema"),
+      tag("envsonschema")
     )!;
     const testCase = report.cases.get(1);
 
@@ -149,13 +149,12 @@ describe("parseReportData", () => {
               issues: metadata.issues,
               source: metadata.source,
               links: metadata.links,
-              results: metadata.results,
             },
           ],
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {},
+        {}
       ),
       implementationsResults: new Map([
         [
@@ -196,13 +195,13 @@ describe("parseReportData", () => {
 
     const lines = bowtie(
       ["run", "-i", tag("envsonschema"), "-D", "7"],
-      cases.join("\n") + "\n",
+      cases.join("\n") + "\n"
     );
 
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema"),
+      tag("envsonschema")
     )!;
 
     expect(report).toStrictEqual({
@@ -219,13 +218,12 @@ describe("parseReportData", () => {
               issues: metadata.issues,
               source: metadata.source,
               links: metadata.links,
-              results: metadata.results,
             },
           ],
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {},
+        {}
       ),
       implementationsResults: new Map([
         [
@@ -301,7 +299,7 @@ describe("parseReportData", () => {
     for (const dialect of Dialect.known()) {
       const lines = bowtie(
         ["run", "-i", tag("envsonschema"), "-D", dialect.shortName],
-        cases.join("\n") + "\n",
+        cases.join("\n") + "\n"
       );
       const report = fromSerialized(lines);
       combinedData[dialect.shortName] = report;

--- a/frontend/src/data/parseReportData.ts
+++ b/frontend/src/data/parseReportData.ts
@@ -71,12 +71,13 @@ export const parseReportData = (
   const implementationsResultsMap = new Map<string, ImplementationResults>();
   for (const id of runMetadata.implementations.keys()) {
     implementationsResultsMap.set(id, {
-      id,
-      cases: new Map(),
-      erroredCases: 0,
-      skippedTests: 0,
-      failedTests: 0,
-      erroredTests: 0,
+      caseResults: new Map(),
+      totals: {
+        erroredCases: 0,
+        skippedTests: 0,
+        failedTests: 0,
+        erroredTests: 0,
+      },
     });
   }
 
@@ -94,9 +95,9 @@ export const parseReportData = (
         const context = line.context as Record<string, unknown>;
         const errorMessage: string = (context?.message ??
           context?.stderr) as string;
-        implementationResults.erroredCases++;
-        implementationResults.erroredTests += caseData.tests.length;
-        implementationResults.cases.set(
+        implementationResults.totals.erroredCases!++;
+        implementationResults.totals.erroredTests! += caseData.tests.length;
+        implementationResults.caseResults.set(
           line.seq as number,
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "errored",
@@ -104,8 +105,8 @@ export const parseReportData = (
           }),
         );
       } else if (line.skipped) {
-        implementationResults.skippedTests += caseData.tests.length;
-        implementationResults.cases.set(
+        implementationResults.totals.skippedTests! += caseData.tests.length;
+        implementationResults.caseResults.set(
           line.seq as number,
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "skipped",
@@ -119,13 +120,13 @@ export const parseReportData = (
           if (res.errored) {
             const context = res.context as Record<string, unknown>;
             const errorMessage = context?.message ?? context?.stderr;
-            implementationResults.erroredTests++;
+            implementationResults.totals.erroredTests!++;
             return {
               state: "errored",
               message: errorMessage as string | undefined,
             };
           } else if (res.skipped) {
-            implementationResults.skippedTests++;
+            implementationResults.totals.skippedTests!++;
             return {
               state: "skipped",
               message: res.message as string | undefined,
@@ -138,7 +139,7 @@ export const parseReportData = (
                 valid: res.valid as boolean | undefined,
               };
             } else {
-              implementationResults.failedTests++;
+              implementationResults.totals.failedTests!++;
               return {
                 state: "failed",
                 valid: res.valid as boolean | undefined,
@@ -146,7 +147,7 @@ export const parseReportData = (
             }
           }
         });
-        implementationResults.cases.set(line.seq as number, caseResults);
+        implementationResults.caseResults.set(line.seq as number, caseResults);
       } else if (line.did_fail_fast !== undefined) {
         didFailFast = line.did_fail_fast as boolean;
       }
@@ -213,9 +214,9 @@ const calculateImplementationTotal = (
 
   Array.from(implementationsResults.entries()).forEach(([key, value]) => {
     implementationResult[key] = {
-      erroredTests: value.erroredTests,
-      skippedTests: value.skippedTests,
-      failedTests: value.failedTests,
+      erroredTests: value.totals.erroredTests,
+      skippedTests: value.totals.skippedTests,
+      failedTests: value.totals.failedTests,
     };
   });
 
@@ -230,10 +231,10 @@ export const calculateTotals = (data: ReportData): Totals => {
   return Array.from(data.implementationsResults.values()).reduce(
     (prev, curr) => ({
       totalTests,
-      erroredCases: prev.erroredCases + curr.erroredCases,
-      skippedTests: prev.skippedTests + curr.skippedTests,
-      failedTests: prev.failedTests + curr.failedTests,
-      erroredTests: prev.erroredTests + curr.erroredTests,
+      erroredCases: prev.erroredCases + curr.totals.erroredCases!,
+      skippedTests: prev.skippedTests + curr.totals.skippedTests!,
+      failedTests: prev.failedTests + curr.totals.failedTests!,
+      erroredTests: prev.erroredTests + curr.totals.erroredTests!,
     }),
     {
       totalTests: totalTests,
@@ -273,12 +274,8 @@ export interface ReportData {
 }
 
 export interface ImplementationResults {
-  id: string;
-  cases: Map<number, CaseResult[]>;
-  erroredCases: number;
-  skippedTests: number;
-  failedTests: number;
-  erroredTests: number;
+  caseResults: Map<number, CaseResult[]>;
+  totals: Partial<Totals>;
 }
 
 export interface CaseResult {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -15,7 +15,7 @@ import {
   ImplementationData,
   ReportData,
   implementationFromData,
-  parseImplementationData,
+  prepareImplementationReport,
 } from "./data/parseReportData";
 
 const fetchReportData = async (dialect: Dialect) => {
@@ -23,19 +23,17 @@ const fetchReportData = async (dialect: Dialect) => {
   return dialect.fetchReport();
 };
 
-const fetchAllReportData = async (langImplementation: string) => {
+const fetchAllReportsData = async (langImplementation: string) => {
   document.title = `Bowtie - ${langImplementation}`;
-  const loaderData: Record<string, ReportData> = {};
+  const allReportsData = new Map<Dialect, ReportData>();
   const promises = [];
   for (const dialect of Dialect.known()) {
     promises.push(
-      dialect
-        .fetchReport()
-        .then((data) => (loaderData[dialect.shortName] = data)),
+      dialect.fetchReport().then((data) => allReportsData.set(dialect, data)),
     );
   }
   await Promise.all(promises);
-  return parseImplementationData(loaderData);
+  return prepareImplementationReport(allReportsData, langImplementation);
 };
 
 const fetchImplementationMetadata = async () => {
@@ -85,7 +83,7 @@ const router = createHashRouter([
         path: "/implementations/:langImplementation",
         Component: ImplementationReportView,
         loader: async ({ params }) =>
-          fetchAllReportData(params.langImplementation!),
+          fetchAllReportsData(params.langImplementation!),
       },
     ],
   },

--- a/implementations/dotnet-jsonschema-net/bowtie_json_everything.csproj
+++ b/implementations/dotnet-jsonschema-net/bowtie_json_everything.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="6.0.6" />
+    <PackageReference Include="JsonSchema.Net" Version="6.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/implementations/java-json-schema-validator/Dockerfile
+++ b/implementations/java-json-schema-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.6.0-jdk17 AS builder
+FROM gradle:8.7.0-jdk17 AS builder
 COPY BowtieJsonSchemaValidator.java /opt/app/BowtieJsonSchemaValidator.java
 COPY build.gradle /opt/app/build.gradle
 WORKDIR /opt/app

--- a/implementations/java-json-schema/Dockerfile
+++ b/implementations/java-json-schema/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.6.0-jdk17 AS builder
+FROM gradle:8.7.0-jdk17 AS builder
 COPY BowtieJsonSchema.java /opt/app/BowtieJsonSchema.java
 COPY build.gradle /opt/app/build.gradle
 WORKDIR /opt/app

--- a/implementations/java-jsonschemafriend/Dockerfile
+++ b/implementations/java-jsonschemafriend/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.6.0-jdk17 AS builder
+FROM gradle:8.7.0-jdk17 AS builder
 WORKDIR /opt/app
 COPY BowtieJsonSchemaFriend.java .
 COPY build.gradle .

--- a/implementations/java-openapiprocessor/Dockerfile
+++ b/implementations/java-openapiprocessor/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.6.0-jdk17 AS builder
+FROM gradle:8.7.0-jdk17 AS builder
 WORKDIR /opt/app
 COPY . .
 RUN gradle installDist --no-daemon

--- a/implementations/kotlin-kmp-json-schema-validator/Dockerfile
+++ b/implementations/kotlin-kmp-json-schema-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:8.6.0-jdk17 AS builder
+FROM gradle:8.7.0-jdk17 AS builder
 WORKDIR /opt/app
 COPY gradle/libs.versions.toml gradle/
 COPY settings.gradle.kts .

--- a/implementations/rust-boon/Cargo.lock
+++ b/implementations/rust-boon/Cargo.lock
@@ -66,6 +66,8 @@ version = "0.1.0"
 dependencies = [
  "boon",
  "cargo-lock",
+ "os_info",
+ "rustc_version_runtime",
  "serde_json",
 ]
 
@@ -165,6 +167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +183,17 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "os_info"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -230,6 +249,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -387,6 +425,72 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"

--- a/implementations/rust-jsonschema/Cargo.lock
+++ b/implementations/rust-jsonschema/Cargo.lock
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,3 +6,4 @@ markdown-it-py==3.0.0
 pytest
 pytest-asyncio==0.21.1
 pytest-icdiff
+pexpect

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -63,7 +63,7 @@ github3-py==4.0.1
     # via
     #   -r requirements.txt
     #   bowtie-json-schema
-hypothesis==6.99.8
+hypothesis==6.99.13
     # via -r test-requirements.in
 icdiff==2.0.7
     # via pytest-icdiff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -42,6 +42,10 @@ click==8.1.7
     # via
     #   -r requirements.txt
     #   bowtie-json-schema
+colorama==0.4.6
+    # via
+    #   click
+    #   pytest
 cryptography==42.0.5
     # via
     #   -r requirements.txt
@@ -104,10 +108,14 @@ multidict==6.0.5
     #   yarl
 packaging==24.0
     # via pytest
+pexpect==4.9.0
+    # via -r test-requirements.in
 pluggy==1.4.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+ptyprocess==0.7.0
+    # via pexpect
 pycparser==2.21
     # via
     #   -r requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -42,10 +42,6 @@ click==8.1.7
     # via
     #   -r requirements.txt
     #   bowtie-json-schema
-colorama==0.4.6
-    # via
-    #   click
-    #   pytest
 cryptography==42.0.5
     # via
     #   -r requirements.txt

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,11 +13,12 @@ import tarfile
 from aiodocker.exceptions import DockerError
 from markdown_it import MarkdownIt
 from markdown_it.tree import SyntaxTreeNode
+import pexpect
 import pytest
 import pytest_asyncio
 
 from bowtie._commands import ErroredTest, TestResult
-from bowtie._core import Dialect, Test, TestCase
+from bowtie._core import Dialect, Implementation, Test, TestCase
 from bowtie._report import EmptyReport, InvalidReport, Report
 
 Test.__test__ = TestCase.__test__ = TestResult.__test__ = (
@@ -1360,6 +1361,21 @@ async def test_info_unsuccessful_start(succeed_immediately):
 
     assert stdout.strip() in {"", "{}"}  # empty, but ignore if JSON or not
     assert "failed to start" in stderr.lower(), stderr
+
+
+@pytest.mark.asyncio
+async def test_filter_implementations_no_arguments():
+    stdout, stderr = [], ""
+
+    try:
+        child = pexpect.spawn("bowtie filter-implementations")
+        child.expect(pexpect.EOF)
+        stdout = child.before.decode().splitlines()
+    except pexpect.exceptions.ExceptionPexpect as err:
+        stderr = str(err)
+
+    expected = sorted(Implementation.known())
+    assert (sorted(stdout), stderr) == (expected, "")
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -865,6 +865,25 @@ async def test_fail_fast(envsonschema):
 
 
 @pytest.mark.asyncio
+async def test_fail_fast_many_tests_at_once(envsonschema):
+    async with run("-i", envsonschema, "-x") as send:
+        results, stderr = await send(
+            """
+            {"description": "1", "schema": {}, "tests": [{"description": "valid:1", "instance": {}, "valid": false}, {"description": "valid:1", "instance": {}, "valid": false}, {"description": "valid:1", "instance": {}, "valid": false}] }
+            {"description": "2", "schema": {}, "tests": [{"description": "valid:0", "instance": 7, "valid": false}] }
+            {"description": "3", "schema": {}, "tests": [{"description": "valid:1", "instance": {}, "valid": true}] }
+            """,  # noqa: E501
+        )
+
+    assert results == [
+        {tag("envsonschema"): TestResult.VALID},
+        {tag("envsonschema"): TestResult.VALID},
+        {tag("envsonschema"): TestResult.VALID},
+    ], stderr
+    assert stderr != ""
+
+
+@pytest.mark.asyncio
 async def test_max_fail(envsonschema):
     async with run("-i", envsonschema, "--max-fail", "2") as send:
         results, stderr = await send(


### PR DESCRIPTION
This test specifically tests [this function](https://github.com/bowtie-json-schema/bowtie/blob/0e642d67dc7c0344bab52ea4e34bd25419815f1c/frontend/src/data/parseReportData.ts#L177) which is called [here](https://github.com/bowtie-json-schema/bowtie/blob/0e642d67dc7c0344bab52ea4e34bd25419815f1c/frontend/src/index.tsx#L38) when we are on the `ImplementationReportView` page to collect dialect compliance data for all the dialects.