### PR TITLE
Remove colorama from test requirements

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -994,7 +994,7 @@ async def filter_implementations(
     """
     if not dialects and languages == KNOWN_LANGUAGES:
         for implementation in ctx.params["image_names"]:
-            click.echo(implementation.split("/")[-1])
+            click.echo(implementation.removeprefix(f"{IMAGE_REPOSITORY}/"))
         return
 
     async for each in start():

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -42,10 +42,6 @@ click==8.1.7
     # via
     #   -r requirements.txt
     #   bowtie-json-schema
-colorama==0.4.6
-    # via
-    #   click
-    #   pytest
 cryptography==42.0.5
     # via
     #   -r requirements.txt


### PR DESCRIPTION
For some reason when I ran `pip-compile --strip-extras test-requirements.in` for adding `pexpect` it added `colorama` as a test dependency [here](https://github.com/bowtie-json-schema/bowtie/pull/1020/files#diff-fac4c6890301d4de5c3f4266837803d5240c84a3d8b6c735bbc6a64c39d2f94e) (via `click` and `pytest`) which wasn't already present in our `test-requirements.txt`, so no need!. 

Also removed the `.split` logic and used `.removeprefix` just like how we do in the other case.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1049.org.readthedocs.build/en/1049/

<!-- readthedocs-preview bowtie-json-schema end -->