### PR TITLE
Choose default dialect form $schema in bowtie validate command

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -722,7 +722,9 @@ def _set_dialect(ctx: click.Context, _, value: _Dialect):
     if value:
         return value
     schema = ctx.params.get("schema")
-    dialect_from_schema = schema.get("$schema") if schema else None
+    dialect_from_schema = (
+        schema.get("$schema") if isinstance(schema, dict) else None
+    )
     return (
         Dialect.from_str(dialect_from_schema)
         if dialect_from_schema

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -921,7 +921,7 @@ def run(
 @click.argument(
     "schema",
     type=click.File(mode="rb"),
-    callback=lambda _, __, value: json.load(value), # type: ignore[reportUnknownLambdaType]
+    callback=lambda _, __, value: json.load(value),  # type: ignore[reportUnknownLambdaType]
 )
 @click.argument("instances", nargs=-1, type=click.File(mode="rb"))
 def validate(

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -722,11 +722,13 @@ def _set_dialect(ctx: click.Context, _, value: _Dialect):
     if value:
         return value
     schema = ctx.params.get("schema")
-    dialect_from_schema = (
-        schema.get("$schema") if isinstance(schema, dict) else None
+    dialect_from_schema: str | None = ( # type: ignore[reportUnknownVariableType]
+        schema.get("$schema")  # type: ignore[reportUnknownMemberType]
+        if isinstance(schema, dict)
+        else None
     )
     return (
-        Dialect.from_str(dialect_from_schema)
+        Dialect.from_str(dialect_from_schema) # type: ignore[reportUnknownArgumentType]
         if dialect_from_schema
         else max(Dialect.known())
     )

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -721,7 +721,8 @@ def _set_dialect(ctx: click.Context, _, value: _Dialect):
     """
     if value:
         return value
-    dialect_from_schema = ctx.params.get("schema", {}).get("$schema")
+    schema = ctx.params.get("schema")
+    dialect_from_schema = schema.get("$schema") if schema else None
     return (
         Dialect.from_str(dialect_from_schema)
         if dialect_from_schema
@@ -925,7 +926,7 @@ def run(
 )
 @click.argument("instances", nargs=-1, type=click.File(mode="rb"))
 def validate(
-    schema: dict[str, Any],
+    schema: Any,
     instances: Iterable[TextIO],
     expect: str,
     description: str,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -722,13 +722,13 @@ def _set_dialect(ctx: click.Context, _, value: _Dialect):
     if value:
         return value
     schema = ctx.params.get("schema")
-    dialect_from_schema: str | None = ( # type: ignore[reportUnknownVariableType]
+    dialect_from_schema: str | None = (  # type: ignore[reportUnknownVariableType]
         schema.get("$schema")  # type: ignore[reportUnknownMemberType]
         if isinstance(schema, dict)
         else None
     )
     return (
-        Dialect.from_str(dialect_from_schema) # type: ignore[reportUnknownArgumentType]
+        Dialect.from_str(dialect_from_schema)  # type: ignore[reportUnknownArgumentType]
         if dialect_from_schema
         else max(Dialect.known())
     )

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -717,10 +717,7 @@ class _Filter(click.ParamType):
 
 def _set_dialect(ctx: click.Context, _, value: _Dialect):
     """
-    Sets the dialect as follows:
-        1. if -D is not passed then use $schema
-        2. if both -D, $schema not present use latest dialect
-        2. else use passed value
+    Sets the dialect according to $schema if specified.
     """
     if value:
         return value
@@ -924,7 +921,7 @@ def run(
 @click.argument(
     "schema",
     type=click.File(mode="rb"),
-    callback=lambda _, __, value: json.load(value),
+    callback=lambda _, __, value: json.load(value), # type: ignore[reportUnknownLambdaType]
 )
 @click.argument("instances", nargs=-1, type=click.File(mode="rb"))
 def validate(

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -724,8 +724,13 @@ def _set_dialect(ctx: click.Context, _, value: _Dialect):
     """
     if value:
         return value
-    dialect_from_schema = ctx.params.get('schema', {}).get('$schema')
-    return Dialect.from_str(dialect_from_schema) if dialect_from_schema else max(Dialect.known())
+    dialect_from_schema = ctx.params.get("schema", {}).get("$schema")
+    return (
+        Dialect.from_str(dialect_from_schema)
+        if dialect_from_schema
+        else max(Dialect.known())
+    )
+
 
 def _set_schema(dialect: Dialect) -> CaseTransform:
     """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2014,9 +2014,9 @@ async def test_validate_mismatched_dialect(envsonschema, tmp_path):
         tmp_path / "schema.json",
         tmp_path / "instance.json",
     )
-    dialect = _json.loads(stdout.split('\n')[0])['dialect']
+    dialect = _json.loads(stdout.split("\n")[0])["dialect"]
 
-    assert dialect=="http://json-schema.org/draft-07/schema#"
+    assert dialect == "http://json-schema.org/draft-07/schema#"
     assert "$schema keyword does not" in stderr, stderr
 
 
@@ -2076,14 +2076,14 @@ async def test_validate_set_dialect_from_schema(envsonschema, tmp_path):
         tmp_path / "schema.json",
         tmp_path / "instance.json",
     )
-    dialect = _json.loads(stdout.split('\n')[0])['dialect']
-    assert dialect=="https://json-schema.org/draft/2019-09/schema", stderr
+    dialect = _json.loads(stdout.split("\n")[0])["dialect"]
+    assert dialect == "https://json-schema.org/draft/2019-09/schema", stderr
 
 
 @pytest.mark.asyncio
 async def test_validate_specify_dialect(envsonschema, tmp_path):
     tmp_path.joinpath("schema.json").write_text(
-        '{}',
+        "{}",
     )
     tmp_path.joinpath("instance.json").write_text("12")
 
@@ -2096,5 +2096,5 @@ async def test_validate_specify_dialect(envsonschema, tmp_path):
         tmp_path / "schema.json",
         tmp_path / "instance.json",
     )
-    dialect = _json.loads(stdout.split('\n')[0])['dialect']
-    assert dialect=="https://json-schema.org/draft/2019-09/schema"
+    dialect = _json.loads(stdout.split("\n")[0])["dialect"]
+    assert dialect == "https://json-schema.org/draft/2019-09/schema"


### PR DESCRIPTION
Closes #995.

Configured `bowtie validate` to pick dialect from schema if not specified instead of the latest one. If dialect not specified in schema as well then it would default to the latest one.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1057.org.readthedocs.build/en/1057/

<!-- readthedocs-preview bowtie-json-schema end -->