### PR TITLE
Removing redundant `id` field from `ImplementationResults` interface and some deduplication and renaming (independent of PR #1058)

### DIFF
--- a/frontend/src/components/Cases/CaseItem.tsx
+++ b/frontend/src/components/Cases/CaseItem.tsx
@@ -34,7 +34,7 @@ const CaseContent = ({
   implementationsResults,
 }: CaseProps) => {
   const [instance, setInstance] = useState<SetStateAction<unknown>>(
-    caseData.tests[0].instance,
+    caseData.tests[0].instance
   );
   const [activeRow, setActiveRow] = useState<SetStateAction<unknown>>(0);
 
@@ -84,7 +84,7 @@ const CaseContent = ({
                   <p className="m-0">{test.description}</p>
                 </td>
                 {implementationsResults.map((implResult, i) => {
-                  const caseResults = implResult.cases.get(seq);
+                  const caseResults = implResult.caseResults.get(seq);
                   const result: CaseResult =
                     caseResults !== undefined
                       ? caseResults[index]
@@ -119,8 +119,8 @@ const CaseItem = ({
           implementations={implementations}
           implementationsResults={implementationsResults}
           schemaDisplayRef={schemaDisplayRef}
-        />,
-      ),
+        />
+      )
     );
   }, [seq, caseData, implementations, implementationsResults]);
   return (

--- a/frontend/src/components/Cases/CaseItem.tsx
+++ b/frontend/src/components/Cases/CaseItem.tsx
@@ -34,7 +34,7 @@ const CaseContent = ({
   implementationsResults,
 }: CaseProps) => {
   const [instance, setInstance] = useState<SetStateAction<unknown>>(
-    caseData.tests[0].instance
+    caseData.tests[0].instance,
   );
   const [activeRow, setActiveRow] = useState<SetStateAction<unknown>>(0);
 
@@ -119,8 +119,8 @@ const CaseItem = ({
           implementations={implementations}
           implementationsResults={implementationsResults}
           schemaDisplayRef={schemaDisplayRef}
-        />
-      )
+        />,
+      ),
     );
   }, [seq, caseData, implementations, implementationsResults]);
   return (

--- a/frontend/src/components/Cases/CasesSection.tsx
+++ b/frontend/src/components/Cases/CasesSection.tsx
@@ -5,11 +5,11 @@ import CaseItem from "./CaseItem";
 
 const CasesSection = ({ reportData }: { reportData: ReportData }) => {
   const implementationsResults = Array.from(
-    reportData.implementationsResults.values(),
+    reportData.implementationsResults.values()
   );
-  const implementations = implementationsResults.map(
-    (implResult) => reportData.runMetadata.implementations.get(implResult.id)!,
-  );
+  const implementations = Array.from(
+    reportData.implementationsResults.keys()
+  ).map((id) => reportData.runMetadata.implementations.get(id)!);
 
   return (
     <Accordion id="cases">

--- a/frontend/src/components/Cases/CasesSection.tsx
+++ b/frontend/src/components/Cases/CasesSection.tsx
@@ -5,10 +5,10 @@ import CaseItem from "./CaseItem";
 
 const CasesSection = ({ reportData }: { reportData: ReportData }) => {
   const implementationsResults = Array.from(
-    reportData.implementationsResults.values()
+    reportData.implementationsResults.values(),
   );
   const implementations = Array.from(
-    reportData.implementationsResults.keys()
+    reportData.implementationsResults.keys(),
   ).map((id) => reportData.runMetadata.implementations.get(id)!);
 
   return (

--- a/frontend/src/components/Modals/DetailsButtonModal.tsx
+++ b/frontend/src/components/Modals/DetailsButtonModal.tsx
@@ -22,7 +22,7 @@ export const DetailsButtonModal = ({
   implementation: Implementation;
 }) => {
   const failedResults: JSX.Element[] = [];
-  Array.from(implementationResults.cases.entries()).forEach(
+  Array.from(implementationResults.caseResults.entries()).forEach(
     ([seq, results]) => {
       const caseData = cases.get(seq)!;
       for (let i = 0; i < results.length; i++) {
@@ -33,7 +33,7 @@ export const DetailsButtonModal = ({
 
         let message;
         if (result.state === "skipped" || result.state === "errored") {
-          message = implementationResults.cases.get(seq)![i].message!;
+          message = implementationResults.caseResults.get(seq)![i].message!;
         } else if (result.valid) {
           message = "Unexpectedly valid";
         } else {
@@ -50,10 +50,10 @@ export const DetailsButtonModal = ({
             instance={caseData.tests[i].instance}
             message={message}
             borderClass={borderClass}
-          />,
+          />
         );
       }
-    },
+    }
   );
   return (
     <Modal show={show} onHide={handleClose} fullscreen={true}>

--- a/frontend/src/components/Modals/DetailsButtonModal.tsx
+++ b/frontend/src/components/Modals/DetailsButtonModal.tsx
@@ -50,10 +50,10 @@ export const DetailsButtonModal = ({
             instance={caseData.tests[i].instance}
             message={message}
             borderClass={borderClass}
-          />
+          />,
         );
       }
-    }
+    },
   );
   return (
     <Modal show={show} onHide={handleClose} fullscreen={true}>

--- a/frontend/src/components/Summary/ImplementationRow.tsx
+++ b/frontend/src/components/Summary/ImplementationRow.tsx
@@ -12,19 +12,21 @@ import { ThemeContext } from "../../context/ThemeContext";
 
 const ImplementationRow = ({
   cases,
-  implementationResults,
+  id,
   implementation,
+  implementationResults,
 }: {
   cases: Map<number, Case>;
-  implementationResults: ImplementationResults;
+  id: string;
   implementation: Implementation;
+  implementationResults: ImplementationResults;
   key: number;
   index: number;
 }) => {
   const { isDarkMode } = useContext(ThemeContext);
   const [showDetails, setShowDetails] = useState(false);
   const navigate = useNavigate();
-  const implementationPath = getImplementationPath(implementationResults);
+  const implementationPath = getImplementationPath(id);
 
   return (
     <tr>
@@ -51,27 +53,28 @@ const ImplementationRow = ({
       </td>
 
       <td className="text-center align-middle">
-        {implementationResults.erroredCases}
+        {implementationResults.totals.erroredCases}
       </td>
       <td className="text-center align-middle">
-        {implementationResults.skippedTests}
+        {implementationResults.totals.skippedTests}
       </td>
       <td className="text-center align-middle details-required">
-        {implementationResults.failedTests + implementationResults.erroredTests}
+        {implementationResults.totals.failedTests! +
+          implementationResults.totals.erroredTests!}
         <div className="hover-details text-center">
           <p>
-            <b>failed</b>: &nbsp;{implementationResults.failedTests}
+            <b>failed</b>: &nbsp;{implementationResults.totals.failedTests}
           </p>
           <p>
-            <b>errored</b>: &nbsp;{implementationResults.erroredTests}
+            <b>errored</b>: &nbsp;{implementationResults.totals.erroredTests}
           </p>
         </div>
       </td>
 
       <td className="align-middle p-0">
-        {implementationResults.failedTests +
-          implementationResults.erroredTests +
-          implementationResults.skippedTests >
+        {implementationResults.totals.failedTests! +
+          implementationResults.totals.erroredTests! +
+          implementationResults.totals.skippedTests! >
           0 && (
           <button
             type="button"
@@ -93,8 +96,8 @@ const ImplementationRow = ({
   );
 };
 
-const getImplementationPath = (implResult: ImplementationResults) => {
-  const pathSegment = implResult.id.split("/");
+const getImplementationPath = (id: string) => {
+  const pathSegment = id.split("/");
   return pathSegment[pathSegment.length - 1];
 };
 

--- a/frontend/src/components/Summary/SummaryTable.tsx
+++ b/frontend/src/components/Summary/SummaryTable.tsx
@@ -59,23 +59,22 @@ const SummaryTable = ({ reportData }: { reportData: ReportData }) => {
         </tr>
       </thead>
       <tbody className="table-group-divider">
-        {Array.from(reportData.implementationsResults.values())
+        {Array.from(reportData.implementationsResults.entries())
           .sort(
-            (a, b) =>
-              a.failedTests +
-              a.erroredTests +
-              a.skippedTests -
-              b.failedTests -
-              b.erroredTests -
-              b.skippedTests,
+            ([, a], [, b]) =>
+              a.totals.failedTests! +
+              a.totals.erroredTests! +
+              a.totals.skippedTests! -
+              b.totals.failedTests! -
+              b.totals.erroredTests! -
+              b.totals.skippedTests!
           )
-          .map((implResults, index) => (
+          .map(([id, implResults], index) => (
             <ImplementationRow
               cases={reportData.cases}
+              id={id}
+              implementation={reportData.runMetadata.implementations.get(id)!}
               implementationResults={implResults}
-              implementation={
-                reportData.runMetadata.implementations.get(implResults.id)!
-              }
               key={index}
               index={index}
             />

--- a/frontend/src/components/Summary/SummaryTable.tsx
+++ b/frontend/src/components/Summary/SummaryTable.tsx
@@ -67,7 +67,7 @@ const SummaryTable = ({ reportData }: { reportData: ReportData }) => {
               a.totals.skippedTests! -
               b.totals.failedTests! -
               b.totals.erroredTests! -
-              b.totals.skippedTests!
+              b.totals.skippedTests!,
           )
           .map(([id, implResults], index) => (
             <ImplementationRow

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -60,7 +60,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
     const testCase = report.cases.get(1);
 
@@ -83,7 +83,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [
@@ -187,13 +187,13 @@ describe("parseReportData", () => {
 
     const lines = bowtie(
       ["run", "-i", tag("envsonschema"), "-D", "7"],
-      cases.join("\n") + "\n"
+      cases.join("\n") + "\n",
     );
 
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema")
+      tag("envsonschema"),
     )!;
 
     expect(report).toStrictEqual({
@@ -215,7 +215,7 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {}
+        {},
       ),
       implementationsResults: new Map([
         [

--- a/frontend/src/data/parseReportData.test.ts
+++ b/frontend/src/data/parseReportData.test.ts
@@ -60,7 +60,7 @@ describe("parseReportData", () => {
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema"),
+      tag("envsonschema")
     )!;
     const testCase = report.cases.get(1);
 
@@ -83,19 +83,19 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {},
+        {}
       ),
       implementationsResults: new Map([
         [
           tag("envsonschema"),
           {
-            erroredCases: 0,
-            erroredTests: 0,
-            skippedTests: 0,
-            failedTests: 1,
-
-            id: tag("envsonschema"),
-            cases: new Map([[1, [{ state: "failed", valid: false }]]]),
+            totals: {
+              erroredCases: 0,
+              erroredTests: 0,
+              skippedTests: 0,
+              failedTests: 1,
+            },
+            caseResults: new Map([[1, [{ state: "failed", valid: false }]]]),
           },
         ],
       ]),
@@ -187,13 +187,13 @@ describe("parseReportData", () => {
 
     const lines = bowtie(
       ["run", "-i", tag("envsonschema"), "-D", "7"],
-      cases.join("\n") + "\n",
+      cases.join("\n") + "\n"
     );
 
     const report = fromSerialized(lines);
 
     const metadata = report.runMetadata.implementations.get(
-      tag("envsonschema"),
+      tag("envsonschema")
     )!;
 
     expect(report).toStrictEqual({
@@ -215,19 +215,19 @@ describe("parseReportData", () => {
         ]),
         report.runMetadata.bowtieVersion,
         report.runMetadata.started,
-        {},
+        {}
       ),
       implementationsResults: new Map([
         [
           tag("envsonschema"),
           {
-            erroredCases: 0,
-            erroredTests: 0,
-            skippedTests: 0,
-            failedTests: 4,
-
-            id: tag("envsonschema"),
-            cases: new Map([
+            totals: {
+              erroredCases: 0,
+              erroredTests: 0,
+              skippedTests: 0,
+              failedTests: 4,
+            },
+            caseResults: new Map([
               [
                 1,
                 [

--- a/frontend/src/data/parseReportData.ts
+++ b/frontend/src/data/parseReportData.ts
@@ -11,7 +11,7 @@ dayjs.extend(relativeTime);
 export const fromSerialized = (jsonl: string): ReportData => {
   const lines = jsonl.trim().split(/\r?\n/);
   return parseReportData(
-    lines.map((line) => JSON.parse(line) as Record<string, unknown>)
+    lines.map((line) => JSON.parse(line) as Record<string, unknown>),
   );
 };
 
@@ -30,7 +30,7 @@ export class RunMetadata {
     implementations: Map<string, Implementation>,
     bowtieVersion: string,
     started: Date,
-    metadata: Record<string, unknown>
+    metadata: Record<string, unknown>,
   ) {
     this.dialect = dialect;
     this.implementations = implementations;
@@ -48,14 +48,14 @@ export class RunMetadata {
       Object.entries(record.implementations).map(([id, info]) => [
         id,
         implementationFromData(info),
-      ])
+      ]),
     );
     return new RunMetadata(
       Dialect.forURI(record.dialect),
       implementations,
       record.bowtie_version,
       new Date(record.started),
-      record.metadata
+      record.metadata,
     );
   }
 }
@@ -64,7 +64,7 @@ export class RunMetadata {
  * Parse a report from some deserialized JSON objects.
  */
 export const parseReportData = (
-  lines: Record<string, unknown>[]
+  lines: Record<string, unknown>[],
 ): ReportData => {
   const runMetadata = RunMetadata.fromRecord(lines[0] as unknown as Header);
 
@@ -89,7 +89,7 @@ export const parseReportData = (
     } else if (line.implementation) {
       const caseData = caseMap.get(line.seq as number)!;
       const implementationResults = implementationsResultsMap.get(
-        line.implementation as string
+        line.implementation as string,
       )!;
       if (line.caught !== undefined) {
         const context = line.context as Record<string, unknown>;
@@ -102,7 +102,7 @@ export const parseReportData = (
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "errored",
             message: errorMessage,
-          })
+          }),
         );
       } else if (line.skipped) {
         implementationResults.totals.skippedTests! += caseData.tests.length;
@@ -111,7 +111,7 @@ export const parseReportData = (
           new Array<CaseResult>(caseData.tests.length).fill({
             state: "skipped",
             message: line.message as string,
-          })
+          }),
         );
       } else if (line.implementation) {
         const caseResults: CaseResult[] = (
@@ -168,15 +168,15 @@ export const parseReportData = (
  * If/when Implementation is a class, this will be its fromRecord.
  */
 export const implementationFromData = (
-  data: ImplementationData
+  data: ImplementationData,
 ): Implementation =>
   ({
     ...data,
     dialects: data.dialects.map((uri) => Dialect.forURI(uri)),
-  } as Implementation);
+  }) as Implementation;
 
 export const parseImplementationData = (
-  loaderData: Record<string, ReportData>
+  loaderData: Record<string, ReportData>,
 ) => {
   const allImplementations: Record<string, ImplementationDialectCompliance> =
     {};
@@ -187,7 +187,7 @@ export const parseImplementationData = (
     { implementationsResults, runMetadata },
   ] of Object.entries(loaderData)) {
     dialectCompliance[dialect] = calculateImplementationTotal(
-      implementationsResults
+      implementationsResults,
     );
 
     for (const [id, implementation] of runMetadata.implementations.entries()) {
@@ -208,7 +208,7 @@ export const parseImplementationData = (
 };
 
 const calculateImplementationTotal = (
-  implementationsResults: Map<string, ImplementationResults>
+  implementationsResults: Map<string, ImplementationResults>,
 ) => {
   const implementationResult: Record<string, Partial<Totals>> = {};
 
@@ -226,7 +226,7 @@ const calculateImplementationTotal = (
 export const calculateTotals = (data: ReportData): Totals => {
   const totalTests = Array.from(data.cases.values()).reduce(
     (prev, curr) => prev + curr.tests.length,
-    0
+    0,
   );
   return Array.from(data.implementationsResults.values()).reduce(
     (prev, curr) => ({
@@ -242,7 +242,7 @@ export const calculateTotals = (data: ReportData): Totals => {
       skippedTests: 0,
       failedTests: 0,
       erroredTests: 0,
-    }
+    },
   );
 };
 


### PR DESCRIPTION
This PR does the following changes

**BEFORE**
```typescript 
export interface ImplementationResults {
  id: string;
  cases: Map<number, CaseResult[]>;
  erroredCases: number;
  skippedTests: number;
  failedTests: number;
  erroredTests: number;
}
```
**AFTER**

```typescript
export interface ImplementationResults {
  caseResults: Map<number, CaseResult[]>;
  totals: Partial<Totals>;
}
```

@Julian instead of doing the above I can also do

```typescript
export interface ImplementationResults extends Partial<Totals>{
  caseResults: Map<number, CaseResult[]>;
}
```

both of them would work the same way only difference being the second way wouldn’t require a `totals` key explicitly.