### PR TITLE
Tab completion for Bowtie commands and implementations

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -674,7 +674,6 @@ class _Image(click.ParamType):
             if name.startswith(incomplete.lower())
         ]
 
-
 class _Dialect(click.ParamType):
     """
     Select a JSON Schema dialect.

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -671,7 +671,7 @@ class _Image(click.ParamType):
         return [
             CompletionItem(name)
             for name in Implementation.known()
-            if name.startswith(incomplete)
+            if name.startswith(incomplete.lower())
         ]
 
 
@@ -996,7 +996,7 @@ class _LanguageChoice(click.ParamType):
         return [
             CompletionItem(name)
             for name in self.choices
-            if name.startswith(incomplete)
+            if name.startswith(incomplete.lower())
         ]
 
 @implementation_subcommand()  # type: ignore[reportArgumentType]

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -674,6 +674,7 @@ class _Image(click.ParamType):
             if name.startswith(incomplete.lower())
         ]
 
+
 class _Dialect(click.ParamType):
     """
     Select a JSON Schema dialect.
@@ -957,6 +958,7 @@ KNOWN_LANGUAGES = {
     *LANGUAGE_ALIASES.values(),
     *(i.partition("-")[0] for i in Implementation.known()),
 }
+
 
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @click.option(

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -667,7 +667,7 @@ class _Image(click.ParamType):
         ctx: click.Context,
         param: click.Parameter,
         incomplete: str,
-    ) -> box.List[CompletionItem]:
+    ) -> list[CompletionItem]:
         return [
             CompletionItem(name)
             for name in Implementation.known() if name.startswith(incomplete)

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -674,6 +674,7 @@ class _Image(click.ParamType):
             if name.startswith(incomplete.lower())
         ]
 
+
 class _Dialect(click.ParamType):
     """
     Select a JSON Schema dialect.

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -674,7 +674,6 @@ class _Image(click.ParamType):
             if name.startswith(incomplete)
         ]
 
-
 class _Dialect(click.ParamType):
     """
     Select a JSON Schema dialect.
@@ -959,6 +958,44 @@ KNOWN_LANGUAGES = {
     *(i.partition("-")[0] for i in Implementation.known()),
 }
 
+class _LanguageChoice(click.ParamType):
+    """
+    Programming language choice for implementation.
+    """
+
+    name = "language"
+
+    def __init__(self, choices: list[str]):
+        self.choices = choices
+
+    def convert(
+        self,
+        value: str | None,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ):
+        if value is None:
+            return None
+        elif value.lower() in self.choices:
+            return value.lower()
+        else:
+            raise click.UsageError(
+                "Invalid value for '--language' / '-l': "
+                f"'{value}' is not one of "
+                f"{', '.join(map(repr, self.choices))}."
+            )
+    
+    def shell_complete(
+        self,
+        ctx: click.Context,
+        param: click.Parameter,
+        incomplete: str,
+    ) -> list[CompletionItem]:
+        return [
+            CompletionItem(name)
+            for name in self.choices
+            if name.startswith(incomplete)
+        ]
 
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @click.option(
@@ -978,7 +1015,7 @@ KNOWN_LANGUAGES = {
     "--language",
     "-l",
     "languages",
-    type=click.Choice(sorted(KNOWN_LANGUAGES), case_sensitive=False),
+    type=_LanguageChoice(choices=sorted(KNOWN_LANGUAGES)),
     callback=lambda _, __, value: (  # type: ignore[reportUnknownLambdaType]
         KNOWN_LANGUAGES
         if not value

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -674,7 +674,6 @@ class _Image(click.ParamType):
             if name.startswith(incomplete.lower())
         ]
 
-
 class _Dialect(click.ParamType):
     """
     Select a JSON Schema dialect.
@@ -959,47 +958,6 @@ KNOWN_LANGUAGES = {
     *(i.partition("-")[0] for i in Implementation.known()),
 }
 
-
-class _LanguageChoice(click.ParamType):
-    """
-    Programming language choice for implementation.
-    """
-
-    name = "language"
-
-    def __init__(self, choices: list[str]):
-        self.choices = choices
-
-    def convert(
-        self,
-        value: str | None,
-        param: click.Parameter | None,
-        ctx: click.Context | None,
-    ):
-        if value is None:
-            return None
-        elif value.lower() in self.choices:
-            return value.lower()
-        else:
-            raise click.UsageError(
-                "Invalid value for '--language' / '-l': "
-                f"'{value}' is not one of "
-                f"{', '.join(map(repr, self.choices))}.",
-            )
-
-    def shell_complete(
-        self,
-        ctx: click.Context,
-        param: click.Parameter,
-        incomplete: str,
-    ) -> list[CompletionItem]:
-        return [
-            CompletionItem(name)
-            for name in self.choices
-            if name.startswith(incomplete.lower())
-        ]
-
-
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @click.option(
     "--supports-dialect",
@@ -1018,7 +976,7 @@ class _LanguageChoice(click.ParamType):
     "--language",
     "-l",
     "languages",
-    type=_LanguageChoice(choices=sorted(KNOWN_LANGUAGES)),
+    type=click.Choice(sorted(KNOWN_LANGUAGES), case_sensitive=False),
     callback=lambda _, __, value: (  # type: ignore[reportUnknownLambdaType]
         KNOWN_LANGUAGES
         if not value

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -16,6 +16,7 @@ import sys
 
 from aiodocker import Docker
 from attrs import asdict
+from click.shell_completion import CompletionItem
 from diagnostic import DiagnosticError
 from jsonschema_lexer import JSONSchemaLexer
 from pygments.lexers.data import (  # type: ignore[reportMissingTypeStubs]
@@ -661,6 +662,17 @@ class _Image(click.ParamType):
             return value
         return f"{IMAGE_REPOSITORY}/{value}"
 
+    def shell_complete(
+        self,
+        ctx: click.Context,
+        param: click.Parameter,
+        incomplete: str,
+    ) -> box.List[CompletionItem]:
+        return [
+            CompletionItem(name)
+            for name in Implementation.known() if name.startswith(incomplete)
+        ]
+
 
 class _Dialect(click.ParamType):
     """
@@ -989,7 +1001,7 @@ async def filter_implementations(
     Output implementations matching a given criteria.
     """
     if not dialects and languages == KNOWN_LANGUAGES:
-        for implementation in ctx.params["image_names"]:
+        for implementation in ctx.params.get("image_names", ()):
             click.echo(implementation.removeprefix(f"{IMAGE_REPOSITORY}/"))
         return
 

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -999,7 +999,6 @@ class _LanguageChoice(click.ParamType):
             if name.startswith(incomplete.lower())
         ]
 
-
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @click.option(
     "--supports-dialect",

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -999,7 +999,6 @@ class _LanguageChoice(click.ParamType):
             if name.startswith(incomplete)
         ]
 
-
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @click.option(
     "--supports-dialect",

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -25,7 +25,7 @@ The Bowtie CLI supports tab completion using the `click module's built-in suppor
 Below are short instructions for your shell.
 
 .. tabs::
-    .. tab:: Bash
+    .. group-tab:: Bash
 
         Add this to ``~/.bashrc``:
 
@@ -33,7 +33,29 @@ Below are short instructions for your shell.
 
             $ eval "$(_BOWTIE_COMPLETE=bash_source bowtie)"
 
-        **OR**
+    .. group-tab:: Zsh
+
+        Add this to ``~/.zshrc``:
+
+        .. code:: sh
+
+            $ eval "$(_BOWTIE_COMPLETE=zsh_source bowtie)"
+
+    .. group-tab:: Fish
+
+        Add this to ``~/.config/fish/completions/bowtie.fish``:
+
+        .. code:: sh
+
+            $ _BOWTIE_COMPLETE=fish_source bowtie | source
+        
+        This is the same file used for the activation script method below. For Fish it's probably always easier to use that method.
+
+Using ``eval`` means that the command is invoked and evaluated every time a shell is started, which can delay shell responsiveness. 
+To speed it up, write the generated script to a file, then source that.
+
+.. tabs::
+    .. group-tab:: Bash
 
         Save the script somewhere.
 
@@ -47,15 +69,7 @@ Below are short instructions for your shell.
 
             $ . ~/.bowtie-complete.bash
 
-    .. tab:: Zsh
-
-        Add this to ``~/.zshrc``:
-
-        .. code:: sh
-
-            $ eval "$(_BOWTIE_COMPLETE=zsh_source bowtie)"
-
-        **OR**
+    .. group-tab:: Zsh
 
         Save the script somewhere.
 
@@ -69,15 +83,7 @@ Below are short instructions for your shell.
 
             $ . ~/.bowtie-complete.zsh
 
-    .. tab:: Fish
-
-        Add this to ``~/.config/fish/completions/bowtie.fish``:
-
-        .. code:: sh
-
-            $ _BOWTIE_COMPLETE=fish_source bowtie | source
-
-        **OR**
+    .. group-tab:: Fish
 
         Save the script to ~/.config/fish/completions/bowtie.fish:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -47,10 +47,10 @@ Add tab completion for implementations (and otherwise)
         .. code:: sh
 
             $ _BOWTIE_COMPLETE=fish_source bowtie | source
-        
+
         This is the same file used for the activation script method below. For Fish it's probably always easier to use that method.
 
-For Homebrew users, the shell completion is **automatically enabled** after running the Homebrew tap installation command.   
+For Homebrew users, the shell completion is **automatically enabled** after running the Homebrew tap installation command.
 
 Examples
 --------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -18,10 +18,11 @@ Below are a few sample command lines you might be interested in.
     If you have cloned Bowtie to :file:`/path/to/bowtie` you should be able to use ``$(ls /path/to/bowtie/implementations/ | sed 's/^| /-i /')`` in any command to expand out to all implementations.
     See `below <cli:running the official suite across all implementations>` for a full example.
 
-Add tab completion for implementations (and otherwise)
-------------------------------------------------------
+Enabling Shell Tab Completion
+-----------------------------
 
-`Click Shell Completion Reference`_
+The Bowtie CLI supports tab completion using the `click module's built-in support <click:shell-completion>`.
+Below are short instructions for your shell.
 
 .. tabs::
     .. tab:: Bash
@@ -32,6 +33,20 @@ Add tab completion for implementations (and otherwise)
 
             $ eval "$(_BOWTIE_COMPLETE=bash_source bowtie)"
 
+        **OR**
+
+        Save the script somewhere.
+
+        .. code:: sh
+
+            $ _BOWTIE_COMPLETE=bash_source bowtie > ~/.bowtie-complete.bash
+        
+        Source the file in ``~/.bashrc``.
+
+        .. code:: sh
+
+            $ . ~/.bowtie-complete.bash
+
     .. tab:: Zsh
 
         Add this to ``~/.zshrc``:
@@ -39,6 +54,20 @@ Add tab completion for implementations (and otherwise)
         .. code:: sh
 
             $ eval "$(_BOWTIE_COMPLETE=zsh_source bowtie)"
+        
+        **OR**
+
+        Save the script somewhere.
+
+        .. code:: sh
+
+            $ _BOWTIE_COMPLETE=zsh_source bowtie > ~/.bowtie-complete.zsh
+        
+        Source the file in ``~/.zshrc``.
+
+        .. code:: sh
+
+            $ . ~/.bowtie-complete.zsh
 
     .. tab:: Fish
 
@@ -47,8 +76,14 @@ Add tab completion for implementations (and otherwise)
         .. code:: sh
 
             $ _BOWTIE_COMPLETE=fish_source bowtie | source
+        
+        **OR**
 
-For Homebrew users, the shell completion is **automatically enabled** after running the Homebrew tap installation command.
+        Save the script to ~/.config/fish/completions/bowtie.fish:
+
+        .. code:: sh
+
+            $ _BOWTIE_COMPLETE=fish_source bowtie > ~/.config/fish/completions/bowtie.fish
 
 Examples
 --------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,7 +19,7 @@ Below are a few sample command lines you might be interested in.
     See `below <cli:running the official suite across all implementations>` for a full example.
 
 Add tab completion for implementations (and otherwise)
---------
+------------------------------------------------------
 
 `Click Shell Completion Reference`_
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -85,11 +85,13 @@ To speed it up, write the generated script to a file, then source that.
 
     .. group-tab:: Fish
 
-        Save the script to ~/.config/fish/completions/bowtie.fish:
+        Save the script to ``~/.config/fish/completions/bowtie.fish``:
 
         .. code:: sh
 
             $ _BOWTIE_COMPLETE=fish_source bowtie > ~/.config/fish/completions/bowtie.fish
+
+After modifying the shell config, you need to start a new shell in order for the changes to be loaded.
 
 Examples
 --------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -48,8 +48,6 @@ Add tab completion for implementations (and otherwise)
 
             $ _BOWTIE_COMPLETE=fish_source bowtie | source
 
-        This is the same file used for the activation script method below. For Fish it's probably always easier to use that method.
-
 For Homebrew users, the shell completion is **automatically enabled** after running the Homebrew tap installation command.
 
 Examples

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -18,6 +18,36 @@ Below are a few sample command lines you might be interested in.
     If you have cloned Bowtie to :file:`/path/to/bowtie` you should be able to use ``$(ls /path/to/bowtie/implementations/ | sed 's/^| /-i /')`` in any command to expand out to all implementations.
     See `below <cli:running the official suite across all implementations>` for a full example.
 
+Add tab completion for implementations (and otherwise)
+--------
+
+`Click Shell Completion Reference`_
+
+.. tabs::
+    .. tab:: Bash
+        Add this to ``~/.bashrc``:
+
+        .. code:: sh
+
+            $ eval "$(_BOWTIE_COMPLETE=bash_source bowtie)"
+
+    .. tab:: Zsh
+        Add this to ``~/.zshrc``:
+
+        .. code:: sh
+
+            $ eval "$(_BOWTIE_COMPLETE=zsh_source bowtie)"
+
+    .. tab:: Fish
+        Add this to ``~/.config/fish/completions/bowtie.fish``:
+
+        .. code:: sh
+            $ _BOWTIE_COMPLETE=fish_source bowtie | source
+        
+        This is the same file used for the activation script method below. For Fish it's probably always easier to use that method.
+
+For Homebrew users, the shell completion is **automatically enabled** after running the Homebrew tap installation command.   
+
 Examples
 --------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -25,6 +25,7 @@ Add tab completion for implementations (and otherwise)
 
 .. tabs::
     .. tab:: Bash
+
         Add this to ``~/.bashrc``:
 
         .. code:: sh
@@ -32,6 +33,7 @@ Add tab completion for implementations (and otherwise)
             $ eval "$(_BOWTIE_COMPLETE=bash_source bowtie)"
 
     .. tab:: Zsh
+
         Add this to ``~/.zshrc``:
 
         .. code:: sh
@@ -39,9 +41,11 @@ Add tab completion for implementations (and otherwise)
             $ eval "$(_BOWTIE_COMPLETE=zsh_source bowtie)"
 
     .. tab:: Fish
+
         Add this to ``~/.config/fish/completions/bowtie.fish``:
 
         .. code:: sh
+
             $ _BOWTIE_COMPLETE=fish_source bowtie | source
         
         This is the same file used for the activation script method below. For Fish it's probably always easier to use that method.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx_click",
     "sphinx_copybutton",
+    "sphinx_tabs.tabs",
     "sphinx_json_schema_spec",
     "sphinx_substitution_extensions",
     "sphinxcontrib.spelling",
@@ -76,6 +77,8 @@ rst_prolog = f"""
 
 
 .. _official test suite: https://github.com/json-schema-org/JSON-Schema-Test-Suite
+
+.. _Click Shell Completion Reference: https://click.palletsprojects.com/en/8.1.x/shell-completion/#shell-completion
 """  # noqa: E501, RUF100
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,8 +77,6 @@ rst_prolog = f"""
 
 
 .. _official test suite: https://github.com/json-schema-org/JSON-Schema-Test-Suite
-
-.. _Click Shell Completion Reference: https://click.palletsprojects.com/en/8.1.x/shell-completion/#shell-completion
 """  # noqa: E501, RUF100
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ intersphinx_mapping = {
     "pip": ("https://pip.pypa.io/en/stable/", None),
     "python": ("https://docs.python.org/", None),
     "sphinx": ("https://www.sphinx-doc.org", None),
-    "click": ("https://click.palletsprojects.com/en/8.1.x/#documentation", None)
+    "click": ("https://click.palletsprojects.com", None)
 }
 
 # -- extlinks --

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,7 @@ intersphinx_mapping = {
     "pip": ("https://pip.pypa.io/en/stable/", None),
     "python": ("https://docs.python.org/", None),
     "sphinx": ("https://www.sphinx-doc.org", None),
+    "click": ("https://click.palletsprojects.com/en/8.1.x/#documentation", None)
 }
 
 # -- extlinks --

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -5,6 +5,7 @@ sphinx-click
 sphinx-copybutton
 sphinx-json-schema-spec
 sphinx-substitution-extensions
+sphinx-tabs
 sphinx>5
 sphinxcontrib-spelling>5
 sphinxext-opengraph

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -45,6 +45,7 @@ docutils==0.20.1
     #   sphinx-click
     #   sphinx-prompt
     #   sphinx-substitution-extensions
+    #   sphinx-tabs
 frozenlist==1.4.1
     # via
     #   aiohttp
@@ -95,6 +96,7 @@ pygments==2.17.2
     #   rich
     #   sphinx
     #   sphinx-prompt
+    #   sphinx-tabs
 pygments-github-lexers==0.0.5
     # via -r docs/requirements.in
 pyjwt==2.8.0
@@ -138,6 +140,7 @@ sphinx==7.2.6
     #   sphinx-json-schema-spec
     #   sphinx-prompt
     #   sphinx-substitution-extensions
+    #   sphinx-tabs
     #   sphinxcontrib-spelling
     #   sphinxext-opengraph
 sphinx-basic-ng==1.0.0b2
@@ -151,6 +154,8 @@ sphinx-json-schema-spec==2024.1.1
 sphinx-prompt==1.8.0
     # via sphinx-substitution-extensions
 sphinx-substitution-extensions==2024.2.25
+    # via -r docs/requirements.in
+sphinx-tabs==3.4.5
     # via -r docs/requirements.in
 sphinxcontrib-applehelp==1.0.8
     # via sphinx

--- a/docs/spelling-wordlist.txt
+++ b/docs/spelling-wordlist.txt
@@ -23,6 +23,7 @@ shortnames
 subcommand
 subcommands
 validator
+config
 
 # Language names, which can disappear after we have a Language data file
 clojure


### PR DESCRIPTION
Fixes #802 

Hi @Julian 

The shell completion for implementations is working fine 👍 along with the completions for other bowtie commands and command options as well. Here's a demo :)

https://github.com/bowtie-json-schema/bowtie/assets/68469605/fb4d3fb7-e92e-41b9-aa37-3cfb5d14d181

I have some queries though:

1) We could add shell completions for languages as well ? and/or any other completions you've in mind ?

2) Regarding the automatically enabled shell completion for Homebrew installation that you asked for, pardon me but I am very much new to Homebrew formulae and Ruby 😅 (my local machine is Windows :( )  so I tried thinking of putting the below Ruby script in the [Homebrew install formula](https://github.com/bowtie-json-schema/homebrew-tap/blob/d106aa46ce80f643db9ccbd3f3cf9352205cc07b/bowtie.rb#L200) we currently have but this way didn't really work :(. The script doesn't enable the shell completion even if I just save it in a file and do `ruby test.rb`. Can you help me out here please ?

```ruby
require 'etc'

case ENV['SHELL']
when /bash/
  system("bash -c 'eval \"$(\_BOWTIE\_COMPLETE=bash\_source bowtie)\"'")
when /zsh/
  system("zsh -c 'eval \"$(\_BOWTIE\_COMPLETE=zsh\_source bowtie)\"'")
when /fish/
  system('_BOWTIE_COMPLETE=fish\_source bowtie | source')
else
  puts "Unsupported shell: #{shell}"
end
```

Thanks!

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1073.org.readthedocs.build/en/1073/

<!-- readthedocs-preview bowtie-json-schema end -->