### PR TITLE
Add JSON Schemas for all JSON CLI output other than our report

### DIFF
--- a/bowtie/schemas/cli/info.json
+++ b/bowtie/schemas/cli/info.json
@@ -1,0 +1,27 @@
+{
+  "title": "bowtie info",
+  "description": "Information about supported implementations, emitted by `bowtie info --format json`.",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:cli:info",
+
+  "type": "object",
+
+  "oneOf": [
+    {
+      "description": "A single implementation",
+      "$ref": "tag:bowtie.report,2024:models:implementation"
+    },
+    {
+      "description": "Multiple implementations, nested by their ID.",
+      "minProperties": 2,
+      "propertyNames": {
+        "$ref": "tag:bowtie.report,2024:models:implementation:id"
+      },
+      "additionalProperties": {
+        "$ref": "tag:bowtie.report,2024:models:implementation"
+      }
+    }
+  ]
+}

--- a/bowtie/schemas/cli/smoke.json
+++ b/bowtie/schemas/cli/smoke.json
@@ -1,0 +1,8 @@
+{
+  "title": "bowtie smoke",
+  "description": "Smoke test results for supported implementation(s)",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:cli:smoke"
+}

--- a/bowtie/schemas/cli/summary.json
+++ b/bowtie/schemas/cli/summary.json
@@ -1,0 +1,108 @@
+{
+  "title": "bowtie summary",
+  "description": "Summarized output from a Bowtie test run.",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:cli:summary",
+
+  "$todo": [
+    "Add surrounding metadata for the run, which probably turns this into an object.",
+    "Can we make `bowtie summary --show foo --schema` show only the relevant subschema?"
+  ],
+
+  "type": "array",
+
+  "unevaluatedItems": false,
+  "oneOf": [
+    {
+      "title": "Validation Results",
+      "description": "A summary of the validation results collected for each test.",
+
+      "items": {
+        "type": "array",
+
+        "unevaluatedItems": false,
+        "prefixItems": [
+          {
+            "title": "JSON Schema",
+            "description": "The schema which validated this test case."
+          },
+          {
+            "description": "Results across all instances which were tested.",
+
+            "type": "array",
+
+            "unevaluatedItems": false,
+            "items": {
+              "title": "Instance Result",
+              "description": "The result of validation for a specific instance across implementations.",
+
+              "type": "array",
+
+              "unevaluatedItems": false,
+              "prefixItems": [
+                {
+                  "title": "Instance",
+                  "description": "The instance which was validated in this test."
+                },
+                {
+                  "title": "Per-implementation Validation Results",
+                  "description": "The results of validation for each implementation which was run.",
+
+                  "type": "object",
+                  "minProperties": 1,
+
+                  "propertyNames": {
+                    "$ref": "tag:bowtie.report,2024:models:implementation:id"
+                  },
+                  "additionalProperties": {
+                    "$todo": "Include more of the actual result details.",
+                    "enum": ["valid", "invalid", "skipped", "error"]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "title": "Test Failures",
+      "description": "A summary of which validation results did not succeed against what was expected by the test case.",
+
+      "items": {
+        "type": "array",
+
+        "unevaluatedItems": false,
+        "prefixItems": [
+          { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
+          {
+            "description": "Unsuccessful tests for a specific implementation.",
+
+            "type": "object",
+
+            "additionalProperties": false,
+            "required": ["failed", "errored", "skipped"],
+            "properties": {
+              "failed": { "$ref": "#count" },
+              "errored": { "$ref": "#count" },
+              "skipped": { "$ref": "#count" }
+            },
+
+            "$defs": {
+              "count": {
+                "description": "The total number of tests with a specific outcome.",
+
+                "$anchor": "count",
+
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/bowtie/schemas/models/group.json
+++ b/bowtie/schemas/models/group.json
@@ -2,7 +2,7 @@
   "description": "A collection of related, runnable tests, either individually or themselves in subgroups. Groups are used only for organizing test input and reporting -- they are not sent to harnesses when actually running tests, as there's no need for the harness to have to deal with any grouping structure.",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
-  "$id": "tag:bowtie.report,2023:ihop:group",
+  "$id": "tag:bowtie.report,2023:models:group",
 
   "type": "object",
   "required": ["description", "children"],
@@ -22,7 +22,7 @@
     },
     "registry": {
       "description": "A schema registry to be made available for all tests in this group.",
-      "$ref": "tag:bowtie.report,2023:ihop:registry"
+      "$ref": "tag:bowtie.report,2023:models:registry"
     },
     "children": {
       "description": "A set of related children of this test group",
@@ -34,7 +34,9 @@
     {
       "description": "a leaf test group (whose children are tests, and which therefore declares a schema for its children)",
       "properties": {
-        "children": { "items": { "$ref": "tag:bowtie.report,2023:ihop:test" } }
+        "children": {
+          "items": { "$ref": "tag:bowtie.report,2023:models:test" }
+        }
       },
       "required": ["schema"]
     },

--- a/bowtie/schemas/models/implementation-id.json
+++ b/bowtie/schemas/models/implementation-id.json
@@ -1,0 +1,9 @@
+{
+  "title": "Implementation ID",
+  "description": "A string identifier used to globally refer to a specific supported implementation.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:models:implementation:id",
+
+  "type": "string"
+}

--- a/bowtie/schemas/models/registry.json
+++ b/bowtie/schemas/models/registry.json
@@ -3,7 +3,7 @@
   "description": "A collection of schemas, identified by URIs, which tests may reference (via $ref) and expect to be retrievable. They should be registered in whatever mechanism is expected by the implementation.",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
-  "$id": "tag:bowtie.report,2023:ihop:registry",
+  "$id": "tag:bowtie.report,2023:models:registry",
 
   "type": "object",
   "propertyNames": { "format": "uri" }

--- a/bowtie/schemas/models/test.json
+++ b/bowtie/schemas/models/test.json
@@ -2,7 +2,7 @@
   "description": "A single test case",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
-  "$id": "tag:bowtie.report,2023:ihop:test",
+  "$id": "tag:bowtie.report,2023:models:test",
 
   "type": "object",
   "required": ["description", "instance"],

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -33,7 +33,7 @@ cryptography==42.0.5
     # via pyjwt
 diagnostic==2.1.0
     # via bowtie-json-schema
-docutils==0.21.1
+docutils==0.21.2
     # via
     #   diagnostic
     #   sphinx
@@ -96,7 +96,7 @@ pyjwt==2.8.0
     # via github3-py
 python-dateutil==2.9.0.post0
     # via github3-py
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   bowtie-json-schema
     #   jsonschema
@@ -113,7 +113,7 @@ rich==13.7.1
     #   bowtie-json-schema
     #   diagnostic
     #   rich-click
-rich-click==1.8.0.dev6
+rich-click==1.8.0.dev7
     # via bowtie-json-schema
 rpds-py==0.18.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,13 @@ ignore = [
     "D001",  # one sentence per line, so max length doesn't make sense
 ]
 
+[tool.pytest.ini_options]
+addopts = ["--strict-markers"]
+xfail_strict = true
+markers = [
+    "json: Tests of Bowtie's JSON output",
+]
+
 [tool.pyright]
 reportUnnecessaryTypeIgnoreComment = true
 strict = ["**/*.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ click==8.1.7
 cryptography==42.0.5
     # via pyjwt
 diagnostic==2.1.0
-docutils==0.21.1
+docutils==0.21.2
     # via diagnostic
 frozenlist==1.4.1
     # via
@@ -56,7 +56,7 @@ pyjwt==2.8.0
     # via github3-py
 python-dateutil==2.9.0.post0
     # via github3-py
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -68,7 +68,7 @@ rich==13.7.1
     # via
     #   diagnostic
     #   rich-click
-rich-click==1.8.0.dev6
+rich-click==1.8.0.dev7
 rpds-py==0.18.0
     # via
     #   jsonschema

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -26,7 +26,7 @@ cryptography==42.0.5
     # via pyjwt
 diagnostic==2.1.0
     # via bowtie-json-schema
-docutils==0.21.1
+docutils==0.21.2
     # via diagnostic
 frozenlist==1.4.1
     # via
@@ -84,7 +84,7 @@ pytest-asyncio==0.21.1
 pytest-icdiff==0.9
 python-dateutil==2.9.0.post0
     # via github3-py
-referencing==0.34.0
+referencing==0.35.0
     # via
     #   bowtie-json-schema
     #   jsonschema
@@ -99,7 +99,7 @@ rich==13.7.1
     #   bowtie-json-schema
     #   diagnostic
     #   rich-click
-rich-click==1.8.0.dev6
+rich-click==1.8.0.dev7
     # via bowtie-json-schema
 rpds-py==0.18.0
     # via

--- a/tests/fauxmplementations/lintsonschema/schemas/cli/info.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/cli/info.json
@@ -1,0 +1,27 @@
+{
+  "title": "bowtie info",
+  "description": "Information about supported implementations, emitted by `bowtie info --format json`.",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:cli:info",
+
+  "type": "object",
+
+  "oneOf": [
+    {
+      "description": "A single implementation",
+      "$ref": "tag:bowtie.report,2024:models:implementation"
+    },
+    {
+      "description": "Multiple implementations, nested by their ID.",
+      "minProperties": 2,
+      "propertyNames": {
+        "$ref": "tag:bowtie.report,2024:models:implementation:id"
+      },
+      "additionalProperties": {
+        "$ref": "tag:bowtie.report,2024:models:implementation"
+      }
+    }
+  ]
+}

--- a/tests/fauxmplementations/lintsonschema/schemas/cli/smoke.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/cli/smoke.json
@@ -1,0 +1,8 @@
+{
+  "title": "bowtie smoke",
+  "description": "Smoke test results for supported implementation(s)",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:cli:smoke"
+}

--- a/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -1,0 +1,108 @@
+{
+  "title": "bowtie summary",
+  "description": "Summarized output from a Bowtie test run.",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:cli:summary",
+
+  "$todo": [
+    "Add surrounding metadata for the run, which probably turns this into an object.",
+    "Can we make `bowtie summary --show foo --schema` show only the relevant subschema?"
+  ],
+
+  "type": "array",
+
+  "unevaluatedItems": false,
+  "oneOf": [
+    {
+      "title": "Validation Results",
+      "description": "A summary of the validation results collected for each test.",
+
+      "items": {
+        "type": "array",
+
+        "unevaluatedItems": false,
+        "prefixItems": [
+          {
+            "title": "JSON Schema",
+            "description": "The schema which validated this test case."
+          },
+          {
+            "description": "Results across all instances which were tested.",
+
+            "type": "array",
+
+            "unevaluatedItems": false,
+            "items": {
+              "title": "Instance Result",
+              "description": "The result of validation for a specific instance across implementations.",
+
+              "type": "array",
+
+              "unevaluatedItems": false,
+              "prefixItems": [
+                {
+                  "title": "Instance",
+                  "description": "The instance which was validated in this test."
+                },
+                {
+                  "title": "Per-implementation Validation Results",
+                  "description": "The results of validation for each implementation which was run.",
+
+                  "type": "object",
+                  "minProperties": 1,
+
+                  "propertyNames": {
+                    "$ref": "tag:bowtie.report,2024:models:implementation:id"
+                  },
+                  "additionalProperties": {
+                    "$todo": "Include more of the actual result details.",
+                    "enum": ["valid", "invalid", "skipped", "error"]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "title": "Test Failures",
+      "description": "A summary of which validation results did not succeed against what was expected by the test case.",
+
+      "items": {
+        "type": "array",
+
+        "unevaluatedItems": false,
+        "prefixItems": [
+          { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
+          {
+            "description": "Unsuccessful tests for a specific implementation.",
+
+            "type": "object",
+
+            "additionalProperties": false,
+            "required": ["failed", "errored", "skipped"],
+            "properties": {
+              "failed": { "$ref": "#count" },
+              "errored": { "$ref": "#count" },
+              "skipped": { "$ref": "#count" }
+            },
+
+            "$defs": {
+              "count": {
+                "description": "The total number of tests with a specific outcome.",
+
+                "$anchor": "count",
+
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fauxmplementations/lintsonschema/schemas/models/group.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/models/group.json
@@ -2,7 +2,7 @@
   "description": "A collection of related, runnable tests, either individually or themselves in subgroups. Groups are used only for organizing test input and reporting -- they are not sent to harnesses when actually running tests, as there's no need for the harness to have to deal with any grouping structure.",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
-  "$id": "tag:bowtie.report,2023:ihop:group",
+  "$id": "tag:bowtie.report,2023:models:group",
 
   "type": "object",
   "required": ["description", "children"],
@@ -22,7 +22,7 @@
     },
     "registry": {
       "description": "A schema registry to be made available for all tests in this group.",
-      "$ref": "tag:bowtie.report,2023:ihop:registry"
+      "$ref": "tag:bowtie.report,2023:models:registry"
     },
     "children": {
       "description": "A set of related children of this test group",
@@ -34,7 +34,9 @@
     {
       "description": "a leaf test group (whose children are tests, and which therefore declares a schema for its children)",
       "properties": {
-        "children": { "items": { "$ref": "tag:bowtie.report,2023:ihop:test" } }
+        "children": {
+          "items": { "$ref": "tag:bowtie.report,2023:models:test" }
+        }
       },
       "required": ["schema"]
     },

--- a/tests/fauxmplementations/lintsonschema/schemas/models/implementation-id.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/models/implementation-id.json
@@ -1,0 +1,9 @@
+{
+  "title": "Implementation ID",
+  "description": "A string identifier used to globally refer to a specific supported implementation.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:models:implementation:id",
+
+  "type": "string"
+}

--- a/tests/fauxmplementations/lintsonschema/schemas/models/registry.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/models/registry.json
@@ -3,7 +3,7 @@
   "description": "A collection of schemas, identified by URIs, which tests may reference (via $ref) and expect to be retrievable. They should be registered in whatever mechanism is expected by the implementation.",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
-  "$id": "tag:bowtie.report,2023:ihop:registry",
+  "$id": "tag:bowtie.report,2023:models:registry",
 
   "type": "object",
   "propertyNames": { "format": "uri" }

--- a/tests/fauxmplementations/lintsonschema/schemas/models/test.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/models/test.json
@@ -2,7 +2,7 @@
   "description": "A single test case",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
-  "$id": "tag:bowtie.report,2023:ihop:test",
+  "$id": "tag:bowtie.report,2023:models:test",
 
   "type": "object",
   "required": ["description", "instance"],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1037,6 +1037,10 @@ async def test_smoke_json(envsonschema):
         json=True,
         exit_code=-1,  # because indeed envsonschema gets answers wrong.
     )
+
+    schema, _ = await bowtie("smoke", "--schema")
+    validate(instance=jsonout, schema=_json.loads(schema), registry=REGISTRY)
+
     assert jsonout == [
         {
             "case": {
@@ -1612,13 +1616,17 @@ async def test_summary_show_failures_json(envsonschema, tmp_path):
         stdin=validate_stdout,
         json=True,
     )
-    assert stderr == ""
+
+    schema, _ = await bowtie("summary", "--schema")
+    validate(instance=jsonout, schema=_json.loads(schema), registry=REGISTRY)
+
     assert jsonout == [
         [
             tag("envsonschema"),
             dict(failed=2, skipped=0, errored=0),
         ],
     ]
+    assert stderr == ""
 
 
 @pytest.mark.asyncio
@@ -1757,7 +1765,7 @@ async def test_validate_no_tests(envsonschema, tmp_path):
 
 @pytest.mark.asyncio
 @pytest.mark.json
-async def test_summary_show_validation(envsonschema, always_valid):
+async def test_summary_show_validation_json(envsonschema, always_valid):
     raw = """
         {"description":"one","schema":{"type": "integer"},"tests":[{"description":"valid:1","instance":12},{"description":"valid:0","instance":12.5}]}
         {"description":"two","schema":{"type": "string"},"tests":[{"description":"crash:1","instance":"{}"}]}
@@ -1786,7 +1794,10 @@ async def test_summary_show_validation(envsonschema, always_valid):
         stdin=run_stdout,
         json=True,
     )
-    assert stderr == ""
+
+    schema, _ = await bowtie("summary", "--schema")
+    validate(instance=jsonout, schema=_json.loads(schema), registry=REGISTRY)
+
     assert jsonout == [
         [
             {"type": "integer"},
@@ -1894,6 +1905,7 @@ async def test_summary_show_validation(envsonschema, always_valid):
             ],
         ],
     ], run_stderr
+    assert stderr == ""
 
 
 @pytest.mark.asyncio
@@ -1977,7 +1989,10 @@ async def test_run_with_registry(always_valid):
         stdin=run_stdout,
         json=True,
     )
-    assert stderr == ""
+
+    schema, _ = await bowtie("summary", "--schema")
+    validate(instance=jsonout, schema=_json.loads(schema), registry=REGISTRY)
+
     assert jsonout == [
         [
             {"type": "integer"},
@@ -1987,6 +2002,7 @@ async def test_run_with_registry(always_valid):
             ],
         ],
     ], run_stderr
+    assert stderr == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1022,6 +1022,7 @@ async def test_smoke_valid_markdown(envsonschema):
 
 
 @pytest.mark.asyncio
+@pytest.mark.json
 async def test_smoke_json(envsonschema):
     jsonout, stderr = await bowtie(
         "smoke",
@@ -1269,6 +1270,7 @@ async def test_info_valid_markdown(envsonschema):
 
 
 @pytest.mark.asyncio
+@pytest.mark.json
 async def test_info_json(envsonschema):
     stdout, stderr = await bowtie(
         "info",
@@ -1296,6 +1298,7 @@ async def test_info_json(envsonschema):
 
 
 @pytest.mark.asyncio
+@pytest.mark.json
 async def test_info_json_multiple_implementations(envsonschema, links):
     stdout, stderr = await bowtie(
         "info",
@@ -1569,7 +1572,8 @@ async def test_validate(envsonschema, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_summary_show_failures(envsonschema, tmp_path):
+@pytest.mark.json
+async def test_summary_show_failures_json(envsonschema, tmp_path):
     tmp_path.joinpath("schema.json").write_text("{}")
     tmp_path.joinpath("one.json").write_text("12")
     tmp_path.joinpath("two.json").write_text("37")
@@ -1738,6 +1742,7 @@ async def test_validate_no_tests(envsonschema, tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.json
 async def test_summary_show_validation(envsonschema, always_valid):
     raw = """
         {"description":"one","schema":{"type": "integer"},"tests":[{"description":"valid:1","instance":12},{"description":"valid:0","instance":12.5}]}
@@ -1935,6 +1940,7 @@ async def test_badges_nothing_ran(envsonschema, tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.json
 async def test_run_with_registry(always_valid):
     raw = """
         {"description":"one","schema":{"type": "integer"}, "registry":{"urn:example:foo": "http://example.com"},"tests":[{"description":"valid:1","instance":12},{"description":"valid:0","instance":12.5}]}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -152,7 +152,7 @@ def errors(uri, instance):
     ],
 )
 def test_group(valid, instance):
-    got = errors("tag:bowtie.report,2023:ihop:group", instance)
+    got = errors("tag:bowtie.report,2023:models:group", instance)
     assert valid == (not got), got
 
 


### PR DESCRIPTION
They're each available at `bowtie foo --schema` so that folks can know what output to expect.

Some improvement both to the schemas as well as output itself is certainly still possible.

We should at some point also render these in the docs.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1124.org.readthedocs.build/en/1124/

<!-- readthedocs-preview bowtie-json-schema end -->