### PR TITLE
Default `report_artifact_in_scope` to false to be sure build frontend runs if workflow triggered by release published

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -23,7 +23,7 @@ jobs:
         run: mkdir _site
 
       # if called from report workflow
-      - name: Download the previous frontend-build
+      - name: Download latest frontend-build
         uses: dawidd6/action-download-artifact@v3
         if: inputs.report_artifact_in_scope == true
         with:
@@ -41,14 +41,14 @@ jobs:
           path: _site
 
       # if called as a separate workflow
-      - name: Download the frontend-build from local artifact
+      - name: Download frontend-build from local artifact
         uses: actions/download-artifact@v4
         if: inputs.report_artifact_in_scope == false
         with:
           name: frontend-build
           path: _site
 
-      - name: Generate and Download latest test report
+      - name: Download latest test report
         if: inputs.report_artifact_in_scope == false
         uses: dawidd6/action-download-artifact@v3
         with:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -18,7 +18,6 @@ jobs:
 
   collect:
     runs-on: ubuntu-latest
-    needs: build-frontend
     steps:
       # if called from report workflow
       - name: Download existing _site artifact having "frontend-build"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -19,13 +19,19 @@ jobs:
   collect:
     runs-on: ubuntu-latest
     steps:
+      - name: Create _site directory
+        run: mkdir _site
+
       # if called from report workflow
-      - name: Download existing _site artifact having "frontend-build"
-        uses: actions/download-artifact@v4
+      - name: Download the previous frontend-build
+        uses: dawidd6/action-download-artifact@v3
         if: inputs.report_artifact_in_scope == true
         with:
-          name: _site
+          workflow: build-frontend.yml
+          branch: main
+          name: frontend-build
           path: _site
+          if_no_artifact_found: warn
 
       - name: Download test report from local artifact
         uses: actions/download-artifact@v4
@@ -35,18 +41,14 @@ jobs:
           path: _site
 
       # if called as a separate workflow
-      - name: Create _site directory
-        run: mkdir _site
-        if: inputs.report_artifact_in_scope == false
-
-      - name: Download frontend build
+      - name: Download the frontend-build from local artifact
         uses: actions/download-artifact@v4
         if: inputs.report_artifact_in_scope == false
         with:
           name: frontend-build
           path: _site
 
-      - name: Download latest test report
+      - name: Generate and Download latest test report
         if: inputs.report_artifact_in_scope == false
         uses: dawidd6/action-download-artifact@v3
         with:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
     inputs:
       report_artifact_in_scope:
-        required: false
         type: boolean
         default: false
   workflow_dispatch:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -6,6 +6,7 @@ on:
       report_artifact_in_scope:
         required: false
         type: boolean
+        default: false
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
```yml
  build-frontend:
    uses: ./.github/workflows/build-frontend.yml
    if: inputs.report_artifact_in_scope == false

```
As mentioned in this [comment](https://github.com/bowtie-json-schema/bowtie/pull/1154#issuecomment-2098707093) in PR #1154 I am not sure if the above job would run if the workflow was triggered by a release publish but ig it would definitely run if the default for `report_artifact_in_scope` was set to false perhaps ? So ig let's just default it to false.

@Julian so let's remove `required` as well or set it to `true` explicitly ? since we are already defaulting `report_artifact_in_scope` to false.