### PR TITLE
Propagate !failure() checks till last job

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -70,6 +70,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: ${{ !failure() }}
     needs: collect
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
[Last workflow run](https://github.com/bowtie-json-schema/bowtie/actions/runs/9006736249/job/24745041155)

@Julian Unless we don't do this here as well then even if the `collect` job was successful having `build-frontend` as skipped still the skipped chain propagates down to `deploy` job because of its indirect dependency on `build-frontend` through `collect` ([reference](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds)). Doing this check here as well ensures that this job definitely runs only if not failure in any of it's parent jobs.

Tested this and works on my workflow fork 👍. Below SS for reference.

`if: inputs.report_artifact_in_scope == true`

![Screenshot (146)](https://github.com/bowtie-json-schema/bowtie/assets/68469605/6b629a1f-8593-413d-a05c-7d6827247294)

`if: inputs.report_artifact_in_scope == false`

![Screenshot (147)](https://github.com/bowtie-json-schema/bowtie/assets/68469605/ea111f98-cbda-41e3-a282-0c9e39bc51ff)

Ignore my `deploy` job failure as I haven't configured my github pages environment, it will work in this repo but atleast after adding `${{ !failure() }}` it wasn't skipped 👍