### PR TITLE
Update dotnet-jsoneverything-net registry lookup for lib v7

### DIFF
--- a/implementations/dotnet-jsonschema-net/Program.cs
+++ b/implementations/dotnet-jsonschema-net/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Reflection;
@@ -89,10 +90,9 @@ while (cmdSource.GetNextCommand() is {} line && line != "")
             var testCaseDescription = testCase["description"].GetValue<string>();
             string? testDescription = null;
             var schemaText = testCase["schema"];
-            var registry = testCase["registry"];
+            var registry = testCase["registry"].AsObject().ToDictionary(x => new Uri(x.Key), x => x.Value);
 
-            options.SchemaRegistry.Fetch = uri =>
-            { return registry[uri.ToString()].Deserialize<JsonSchema>(); };
+            options.SchemaRegistry.Fetch = uri => registry[uri].Deserialize<JsonSchema>();
 
             var schema = schemaText.Deserialize<JsonSchema>();
             var tests = testCase["tests"].AsArray();


### PR DESCRIPTION
Fixed an issue with registry lookups.

.Net `Uri` comparisons don't consider the fragment, and v7 now passes the complete URI into the `Fetch` function.  When Bowtie `.ToString()`s the URI to perform a string lookup, it includes the fragment and (rightly) can't find it.

This change updates the registry lookup so that it's a `Uri` key and the fragment will be ignored.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1186.org.readthedocs.build/en/1186/

<!-- readthedocs-preview bowtie-json-schema end -->