### PR TITLE
Fixed bowtie test errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ cython_debug/
 # Editor vomit
 .idea/
 .vscode/
+.vs/

--- a/implementations/dotnet-corvus-jsonschema/Program.cs
+++ b/implementations/dotnet-corvus-jsonschema/Program.cs
@@ -99,6 +99,8 @@ static JsonSchemaTypeBuilder CreateTypeBuilder()
                         JsonDocument.Parse(File.ReadAllText("./metaschema/draft2020-12/meta/hyper-schema.json")));
     builder.AddDocument("https://json-schema.org/draft/2020-12/meta/meta-data",
                         JsonDocument.Parse(File.ReadAllText("./metaschema/draft2020-12/meta/meta-data.json")));
+    builder.AddDocument("https://json-schema.org/draft/2020-12/meta/unevaluated",
+                        JsonDocument.Parse(File.ReadAllText("./metaschema/draft2020-12/meta/unevaluated.json")));
     builder.AddDocument("https://json-schema.org/draft/2020-12/meta/validation",
                         JsonDocument.Parse(File.ReadAllText("./metaschema/draft2020-12/meta/validation.json")));
 

--- a/implementations/dotnet-corvus-jsonschema/bowtie_corvus_jsonschema.csproj
+++ b/implementations/dotnet-corvus-jsonschema/bowtie_corvus_jsonschema.csproj
@@ -18,12 +18,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Json.CodeGeneration.201909" Version="3.0.23" />
-    <PackageReference Include="Corvus.Json.CodeGeneration.202012" Version="3.0.23" />
-    <PackageReference Include="Corvus.Json.CodeGeneration.4" Version="3.0.24" />
-    <PackageReference Include="Corvus.Json.CodeGeneration.6" Version="3.0.23" />
-    <PackageReference Include="Corvus.Json.CodeGeneration.7" Version="3.0.23" />
-    <PackageReference Include="Corvus.Json.ExtendedTypes" Version="3.0.24" />
+    <PackageReference Include="Corvus.Json.CodeGeneration.201909" Version="3.0.25" />
+    <PackageReference Include="Corvus.Json.CodeGeneration.202012" Version="3.0.25" />
+    <PackageReference Include="Corvus.Json.CodeGeneration.4" Version="3.0.25" />
+    <PackageReference Include="Corvus.Json.CodeGeneration.6" Version="3.0.25" />
+    <PackageReference Include="Corvus.Json.CodeGeneration.7" Version="3.0.25" />
+    <PackageReference Include="Corvus.Json.ExtendedTypes" Version="3.0.25" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />


### PR DESCRIPTION
1. Support generating code with "do not assert format" for 2020-12
2. Add missing `unevaluated` metaschema for 2020-12
3. Added .vs folder to the .gitignore section for "editor cruft"

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1205.org.readthedocs.build/en/1205/

<!-- readthedocs-preview bowtie-json-schema end -->