### PR TITLE
no need to explicitly manage "braces" package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,6 @@
     "eslint-plugin-react-hooks": "4.6.2",
     "jsdom": "^24.1.0",
     "react-test-renderer": "^18.3.1",
-    "braces": "^3.0.3",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.1(vite@5.2.13(@types/node@20.11.5)(terser@5.31.1))
-      braces:
-        specifier: ^3.0.3
-        version: 3.0.3
       eslint:
         specifier: 8.57.0
         version: 8.57.0


### PR DESCRIPTION
@Julian your commit in here https://github.com/bowtie-json-schema/bowtie/commit/2a9152cf964e4663a7ec6109e7ebccb2d2b7c4fb fixed the vulnerable transitive dependency so need to explicitly manage it anymore.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1289.org.readthedocs.build/en/1289/

<!-- readthedocs-preview bowtie-json-schema end -->