### PR TITLE
Correctly set the language for JSON Toolkit

### DIFF
--- a/implementations/cpp-jsontoolkit/bowtie_jsontoolkit.cpp
+++ b/implementations/cpp-jsontoolkit/bowtie_jsontoolkit.cpp
@@ -30,7 +30,7 @@ int main() {
       auto response{JSON::make_object()};
       response.assign("version", JSON{1});
       auto implementation{JSON::make_object()};
-      implementation.assign("language", JSON{"cpp"});
+      implementation.assign("language", JSON{"c++"});
       implementation.assign("name", JSON{"jsontoolkit"});
       implementation.assign("homepage",
                             JSON{"https://github.com/sourcemeta/jsontoolkit"});


### PR DESCRIPTION
Other C++ implementations use "C++" while I set "Cpp"

<img width="927" alt="Screenshot 2024-06-13 at 2 37 47 PM" src="https://github.com/bowtie-json-schema/bowtie/assets/2192773/8dae29dd-aae4-42da-9ec2-45a04fd1e9bc">


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1297.org.readthedocs.build/en/1297/

<!-- readthedocs-preview bowtie-json-schema end -->