### PR TITLE
Add concurrency group for ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
     - cron: "12 5 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   list:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unfortunately, creating a concurrency group that will work only for PR is impossible. It will also affect the pushes to branches and scheduled workflows. If only PRs should be affected, probably, the best option would be to create a reusable workflow from CI workflow and create two separate workflows that use it: one for PRs (with concurrency group) and one for pushes to branches/tags and scheduled runs.

Using `${{ github.event_name }}` should prevent collisions between scheduled executions and pushes to the main branch.

Resolves #1202

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1301.org.readthedocs.build/en/1301/

<!-- readthedocs-preview bowtie-json-schema end -->