### PR TITLE
Remove custom python code for listing implementations and instead use `bowtie filter-implementations` 

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -35,7 +35,7 @@ jobs:
 
       - id: images-matrix
         run: |
-          echo "images=$(bowtie filter-implementations | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "images=$(bowtie filter-implementations --format json" >> $GITHUB_OUTPUT
 
   build:
     needs: list

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -35,7 +35,7 @@ jobs:
 
       - id: images-matrix
         run: |
-          echo "images=$(bowtie filter-implementations --format json" >> $GITHUB_OUTPUT
+          echo "images=$(bowtie filter-implementations --format json)" >> $GITHUB_OUTPUT
 
   build:
     needs: list

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -35,7 +35,7 @@ jobs:
 
       - id: images-matrix
         run: |
-          echo "images=$(bowtie filter-implementations --format json)" >> $GITHUB_OUTPUT
+          echo "images=$(bowtie filter-implementations --format json | jq -c)" >> $GITHUB_OUTPUT
 
   build:
     needs: list

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -35,7 +35,7 @@ jobs:
 
       - id: images-matrix
         run: |
-          echo "images=$(bowtie filter-implementations | sed -e 's/^/"/; s/$/"/; $!s/$/,/' | sed -e '1i[' -e '$a]')" >> $GITHUB_OUTPUT
+          echo "images=$(bowtie filter-implementations | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   build:
     needs: list

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,18 +26,16 @@ jobs:
       images: ${{ steps.images-matrix.outputs.images }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Bowtie
+        uses: ./
+        with:
+          installation-attempts: "5"
+          installation-wait-seconds: "10"
+
       - id: images-matrix
         run: |
-          python3 -c '
-          from pathlib import Path
-          import json
-          paths = [
-              str(path.name)
-              for path in Path("implementations").iterdir()
-              if path.is_dir()
-          ]
-          print(f"images={json.dumps(paths)}")
-          ' >> $GITHUB_OUTPUT
+          echo "images=$(bowtie filter-implementations | sed -e 's/^/"/; s/$/"/; $!s/$/,/' | sed -e '1i[' -e '$a]')" >> $GITHUB_OUTPUT
 
   build:
     needs: list


### PR DESCRIPTION
@Julian just this minor fix I noticed while skimming through this file to get an idea of how to write a similar one for building multiple images.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1306.org.readthedocs.build/en/1306/

<!-- readthedocs-preview bowtie-json-schema end -->