### PR TITLE
Generating report for implementation versions workflow

### DIFF
--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           printf 'dialects=%s\n' "$(jq -c '[.[].shortName]' data/dialects.json)" >> $GITHUB_OUTPUT
 
-  regenerate-reports:
+  regenerate-versioned-reports:
     needs: dialects
     runs-on: ubuntu-latest
     strategy:
@@ -31,26 +31,17 @@ jobs:
       - name: Install Bowtie
         uses: ./
 
-      - name: Generate a New Report
+      - name: Generate a New Versioned Report
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
-              # Construct the bowtie command
-              cmd="bowtie suite"
-              for version in $(jq -r '.[]' "$matrix_versions_file"); do
-                cmd+=" -i image:$impl:$version"
-              done
-              cmd+=" https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > versioned-$impl-${{ matrix.version }}.json"
+              # Run Bowtie suite
+              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json
               
-              # Run the command
-              eval $cmd
-              
-              # Delete the Docker images for this implementation
-              for version in $(jq -r '.[]' "$matrix_versions_file"); do
-                docker rmi "ghcr.io/bowtie-json-schema/$impl:$version" || true
-              done
+              # Delete the multiple fetched Docker images for the current implementation
+              docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i ghcr.io/bowtie-json-schema/$impl:/") || true
             fi
           done
 
@@ -66,7 +57,7 @@ jobs:
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
-            report_file="versioned-$impl-${{ matrix.version }}.json"
+            report_file="$impl.json"
             if [ -f "$report_file" ]; then
               echo "Checking report for $impl (${{ matrix.version }}):"
               if bowtie summary --show failures "$report_file" --format markdown >> $GITHUB_STEP_SUMMARY; then
@@ -83,4 +74,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: versioned-reports-${{ matrix.version }}
-          path: versioned-*-${{ matrix.version }}.json
+          path: "*.json"
+          if-no-files-found: error

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -40,7 +40,7 @@ jobs:
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
               # Run bowtie suite
-              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > versioned-$impl.json    
+              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json    
 
               # Delete the multiple fetched docker images for the current implementation
               # just so that we avoid running out of memory.
@@ -71,4 +71,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: versioned-report-${{ matrix.version }}
-          path: versioned-*.json
+          path: |
+            *.json
+            !.prettierrc.json

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -40,7 +40,7 @@ jobs:
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
               # Run bowtie suite
-              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json    
+              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json
 
               # Delete the multiple fetched docker images for the current implementation
               # just so that we avoid running out of memory.
@@ -60,11 +60,10 @@ jobs:
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
-            report_file="$impl.json"
-            if [ -f "$report_file" ]; then
-              bowtie summary --show failures "$report_file" --format markdown >> $GITHUB_STEP_SUMMARY
+            if [ -f "$impl.json" ]; then
+              bowtie summary --show failures "$impl.json" --format markdown >> $GITHUB_STEP_SUMMARY
             else
-              echo "Warning: Report file $report_file not found. Skipping."
+              echo 'Warning: Report file "$impl.json" not found. Skipping.'
             fi
           done
 

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -40,9 +40,10 @@ jobs:
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
               # Run bowtie suite
-              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json    
+              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > versioned-$impl.json    
 
               # Delete the multiple fetched docker images for the current implementation
+              # just so that we avoid running out of memory.
               docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i ghcr.io/bowtie-json-schema/$impl:/") || true
             fi
           done
@@ -61,13 +62,7 @@ jobs:
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
             report_file="$impl.json"
             if [ -f "$report_file" ]; then
-              echo "Checking report for $impl (${{ matrix.version }}):"
-              if bowtie summary --show failures "$report_file" --format markdown >> $GITHUB_STEP_SUMMARY; then
-                echo "Report for $impl (${{ matrix.version }}) is valid."
-              else
-                echo "Error: Report for $impl (${{ matrix.version }}) is invalid."
-                exit 1
-              fi
+              bowtie summary --show failures "$report_file" --format markdown >> $GITHUB_STEP_SUMMARY
             else
               echo "Warning: Report file $report_file not found. Skipping."
             fi
@@ -76,5 +71,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: versioned-report-${{ matrix.version }}
-          path: "*.json"
-          if-no-files-found: error
+          path: versioned-*.json

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -32,18 +32,37 @@ jobs:
         uses: ./
 
       - name: Generate a New Versioned Report
+        id: generate-new-versioned-report
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
+          no_impl_started=false
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
-              # Run bowtie suite
-              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json
+              # Run bowtie suite and capture output
+              output=$(bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} 2>&1)
+              exit_code=$?
+              if echo "$output" | grep -q "No implementations started successfully!"; then
+                echo "No implementations started for $impl (${{ matrix.version }})"
+                no_impl_started=true
+              elif [ $exit_code -ne 0 ]; then
+                echo "Error running bowtie suite for $impl (${{ matrix.version }})"
+                echo "$output"
+                exit $exit_code
+              else
+                echo "$output" > $impl.json
+                echo "Report generated for $impl (${{ matrix.version }})"
+              fi     
 
-              # Delete the multiple fetched docker images for the current implementation
+              # Delete the multiple fetched Docker images for the current implementation
               docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i ghcr.io/bowtie-json-schema/$impl:/") || true
             fi
           done
+          if $no_impl_started; then
+            echo "no_impl_started=true" >> $GITHUB_OUTPUT
+          else
+            echo "no_impl_started=false" >> $GITHUB_OUTPUT
+          fi
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
       # number of container images.
@@ -54,6 +73,7 @@ jobs:
       # This unfortunately can go wrong if e.g. we ever run out of memory above.
       # Probably we should also atomically move files into place.
       - name: Check Reports are Valid
+        if: steps.generate-new-versioned-report.outputs.no_impl_started != 'true'
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
@@ -72,7 +92,8 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v4
+        if: steps.generate-new-versioned-report.outputs.no_impl_started != 'true'
         with:
           name: versioned-report-${{ matrix.version }}
           path: "*.json"
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -1,29 +1,40 @@
 # This workflow is a separate workflow from `report.yml` for regenerating the versioned report data needed for Bowtie's UI.
-# It retests all of Bowtie's supported implementations for all their multiple versions listed in `matrix-versions.json` file.
+# It retests all of Bowtie's supported implementations for all their multiple versions listed in `matrix-versions.json` file if one exists for them.
 name: Collect New Versioned Test Results
 
 on:
   workflow_dispatch:
 
 jobs:
-  dialects:
+  list-implementations:
     runs-on: ubuntu-latest
     outputs:
-      dialects: ${{ steps.dialects-matrix.outputs.dialects }}
+      implementations: ${{ steps.implementations-matrix.outputs.implementations }}
     steps:
       - uses: actions/checkout@v4
-      - name: Collect supported dialects
-        id: dialects-matrix
+
+      - name: Install Bowtie
+        uses: ./
+
+      - name: List all Bowtie supported implementations having a "matrix-versions.json" file
+        id: implementations-matrix
         run: |
-          printf 'dialects=%s\n' "$(jq -c '[.[].shortName]' data/dialects.json)" >> $GITHUB_OUTPUT
+          IMPLEMENTATIONS=$(bowtie filter-implementations --format json | jq -r '.[]')
+          MATRIX="[]"
+          for impl in $(echo "$IMPLEMENTATIONS"); do
+            if [ -f "implementations/$impl/matrix-versions.json" ]; then
+              MATRIX=$(echo $MATRIX | jq --arg impl "$impl" '. + [$impl]')
+            fi
+          done
+          echo "implementations=$(echo $MATRIX | jq -c .)" >> $GITHUB_OUTPUT
 
   regenerate-versioned-reports:
-    needs: dialects
+    needs: list-implementations
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.dialects.outputs.dialects) }}
+        implementation: ${{ fromJson(needs.list-implementations.outputs.implementations) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -34,17 +45,12 @@ jobs:
       - name: Generate a New Versioned Report
         id: generate-new-versioned-report
         run: |
-          IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
-          for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
-            matrix_versions_file="implementations/$impl/matrix-versions.json"
-            if [ -f $matrix_versions_file ]; then
-              # Run bowtie suite
-              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json
-
-              # Delete the multiple fetched docker images for the current implementation
-              # just so that we avoid running out of memory.
-              docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/ghcr.io\/bowtie-json-schema\/$impl:/") || true
-            fi
+          impl=${{ matrix.implementation }}
+          SUPPORTED_DIALECT_URIS=$(bowtie info -i $impl --format json | jq -r '.dialects[]')
+          MATRIX_VERSIONS_FILE="implementations/$impl/matrix-versions.json"
+          for dialect_uri in $(echo $SUPPORTED_DIALECT_URIS); do
+            dialect_shortname=$(jq -r --arg uri "$dialect_uri" '.[] | select(.uri == $uri) | .shortName' data/dialects.json)
+            bowtie suite $(jq -r '.[]' "$MATRIX_VERSIONS_FILE" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/$dialect_shortname > $dialect_shortname.json
           done
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
@@ -57,18 +63,17 @@ jobs:
       # Probably we should also atomically move files into place.
       - name: Check Reports are Valid
         run: |
-          IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
-          for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
-            if [ -f "$impl.json" ]; then
-              bowtie summary --show failures "$impl.json" --format markdown >> $GITHUB_STEP_SUMMARY
-            else
-              echo "Warning: Report file '$impl.json' not found. Skipping."
+          DIALECT_URIS=$(bowtie filter-dialects)
+          for dialect_uri in $(echo $DIALECT_URIS); do
+            dialect_shortname=$(jq -r --arg uri "$dialect_uri" '.[] | select(.uri == $uri) | .shortName' data/dialects.json)
+            if [ -f "$dialect_shortname.json" ]; then
+              bowtie summary --show failures "$dialect_shortname.json" --format markdown >> $GITHUB_STEP_SUMMARY
             fi
           done
 
       - uses: actions/upload-artifact@v4
         with:
-          name: versioned-report-${{ matrix.version }}
+          name: ${{ matrix.implementation }}
           path: |
             *.json
             !.prettierrc.json

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -62,7 +62,7 @@ jobs:
             if [ -f "$impl.json" ]; then
               bowtie summary --show failures "$impl.json" --format markdown >> $GITHUB_STEP_SUMMARY
             else
-              echo 'Warning: Report file "$impl.json" not found. Skipping.'
+              echo "Warning: Report file '$impl.json' not found. Skipping."
             fi
           done
 

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -46,7 +46,7 @@ jobs:
         id: generate-new-versioned-report
         run: |
           impl=${{ matrix.implementation }}
-          SUPPORTED_DIALECT_URIS=$(bowtie info -i $impl --format json | jq -r '.dialects[]')
+          SUPPORTED_DIALECT_URIS=$(bowtie filter-dialects -i $impl)
           MATRIX_VERSIONS_FILE="implementations/$impl/matrix-versions.json"
           for dialect_uri in $(echo $SUPPORTED_DIALECT_URIS); do
             dialect_shortname=$(jq -r --arg uri "$dialect_uri" '.[] | select(.uri == $uri) | .shortName' data/dialects.json)
@@ -63,9 +63,8 @@ jobs:
       # Probably we should also atomically move files into place.
       - name: Check all Generated Reports for ${{ matrix.implementation }} are Valid
         run: |
-          DIALECT_URIS=$(bowtie filter-dialects)
-          for dialect_uri in $(echo $DIALECT_URIS); do
-            dialect_shortname=$(jq -r --arg uri "$dialect_uri" '.[] | select(.uri == $uri) | .shortName' data/dialects.json)
+          DIALECT_SHORTNAMES=$(jq -r '.[].shortName' data/dialects.json)
+          for dialect_shortname in $(echo $DIALECT_SHORTNAMES); do
             if [ -f "$dialect_shortname.json" ]; then
               bowtie summary --show failures "$dialect_shortname.json" --format markdown >> $GITHUB_STEP_SUMMARY
             fi

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -39,30 +39,13 @@ jobs:
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
-              # Run bowtie suite and capture output
-              output=$(bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} 2>&1)
-              exit_code=$?
-              if echo "$output" | grep -q "No implementations started successfully!"; then
-                echo "No implementations started for $impl (${{ matrix.version }})"
-                no_impl_started=true
-              elif [ $exit_code -ne 0 ]; then
-                echo "Error running bowtie suite for $impl (${{ matrix.version }})"
-                echo "$output"
-                exit $exit_code
-              else
-                echo "$output" > $impl.json
-                echo "Report generated for $impl (${{ matrix.version }})"
-              fi     
+              # Run bowtie suite
+              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json    
 
-              # Delete the multiple fetched Docker images for the current implementation
+              # Delete the multiple fetched docker images for the current implementation
               docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i ghcr.io/bowtie-json-schema/$impl:/") || true
             fi
           done
-          if $no_impl_started; then
-            echo "no_impl_started=true" >> $GITHUB_OUTPUT
-          else
-            echo "no_impl_started=false" >> $GITHUB_OUTPUT
-          fi
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
       # number of container images.
@@ -73,7 +56,6 @@ jobs:
       # This unfortunately can go wrong if e.g. we ever run out of memory above.
       # Probably we should also atomically move files into place.
       - name: Check Reports are Valid
-        if: steps.generate-new-versioned-report.outputs.no_impl_started != 'true'
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
@@ -92,7 +74,6 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v4
-        if: steps.generate-new-versioned-report.outputs.no_impl_started != 'true'
         with:
           name: versioned-report-${{ matrix.version }}
           path: "*.json"

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -1,0 +1,86 @@
+# This workflow is a separate workflow from `report.yml` for regenerating the versioned report data needed for Bowtie's UI.
+# It retests all of Bowtie's supported implementations for all their multiple versions listed in `matrix-versions.json` file.
+name: Collect New Versioned Test Results
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dialects:
+    runs-on: ubuntu-latest
+    outputs:
+      dialects: ${{ steps.dialects-matrix.outputs.dialects }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Collect supported dialects
+        id: dialects-matrix
+        run: |
+          printf 'dialects=%s\n' "$(jq -c '[.[].shortName]' data/dialects.json)" >> $GITHUB_OUTPUT
+
+  regenerate-reports:
+    needs: dialects
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.dialects.outputs.dialects) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bowtie
+        uses: ./
+
+      - name: Generate a New Report
+        run: |
+          IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
+          for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
+            matrix_versions_file="implementations/$impl/matrix-versions.json"
+            if [ -f $matrix_versions_file ]; then
+              # Construct the bowtie command
+              cmd="bowtie suite"
+              for version in $(jq -r '.[]' "$matrix_versions_file"); do
+                cmd+=" -i image:$impl:$version"
+              done
+              cmd+=" https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > versioned-$impl-${{ matrix.version }}.json"
+              
+              # Run the command
+              eval $cmd
+              
+              # Delete the Docker images for this implementation
+              for version in $(jq -r '.[]' "$matrix_versions_file"); do
+                docker rmi "$impl:$version" || true
+              done
+            fi
+          done
+
+      # This is useful to debug whether Bowtie accidentally fetched some huge
+      # number of container images.
+      - name: Show what images we fetched
+        run: docker images
+        if: always()
+
+      # This unfortunately can go wrong if e.g. we ever run out of memory above.
+      # Probably we should also atomically move files into place.
+      - name: Check Reports are Valid
+        run: |
+          IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
+          for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
+            report_file="versioned-$impl-${{ matrix.version }}.json"
+            if [ -f "$report_file" ]; then
+              echo "Checking report for $impl (${{ matrix.version }}):"
+              if bowtie summary --show failures "$report_file" --format markdown >> $GITHUB_STEP_SUMMARY; then
+                echo "Report for $impl (${{ matrix.version }}) is valid."
+              else
+                echo "Error: Report for $impl (${{ matrix.version }}) is invalid."
+                exit 1
+              fi
+            else
+              echo "Warning: Report file $report_file not found. Skipping."
+            fi
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: reports-${{ matrix.version }}
+          path: versioned-*-${{ matrix.version }}.json

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -32,18 +32,37 @@ jobs:
         uses: ./
 
       - name: Generate a New Versioned Report
+        id: generate-new-versioned-report
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
+          no_impl_started=false
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
-              # Run Bowtie suite
-              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json
-              
+              # Run bowtie suite and capture output
+              output=$(bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} 2>&1)
+              exit_code=$?
+              if echo "$output" | grep -q "No implementations started successfully!"; then
+                echo "No implementations started for $impl (${{ matrix.version }})"
+                no_impl_started=true
+              elif [ $exit_code -ne 0 ]; then
+                echo "Error running bowtie suite for $impl (${{ matrix.version }})"
+                echo "$output"
+                exit $exit_code
+              else
+                echo "$output" > $impl.json
+                echo "Report generated for $impl (${{ matrix.version }})"
+              fi     
+
               # Delete the multiple fetched Docker images for the current implementation
               docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i ghcr.io/bowtie-json-schema/$impl:/") || true
             fi
           done
+          if $no_impl_started; then
+            echo "no_impl_started=true" >> $GITHUB_OUTPUT
+          else
+            echo "no_impl_started=false" >> $GITHUB_OUTPUT
+          fi
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
       # number of container images.
@@ -72,7 +91,8 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v4
+        if: steps.generate-new-versioned-report.outputs.no_impl_started != 'true'
         with:
-          name: versioned-reports-${{ matrix.version }}
+          name: versioned-report-${{ matrix.version }}
           path: "*.json"
           if-no-files-found: error

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -44,7 +44,7 @@ jobs:
 
               # Delete the multiple fetched docker images for the current implementation
               # just so that we avoid running out of memory.
-              docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i ghcr.io/bowtie-json-schema/$impl:/") || true
+              docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/ghcr.io\/bowtie-json-schema\/$impl:/") || true
             fi
           done
 

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Bowtie
         uses: ./
 
-      - name: List all Bowtie supported implementations having a "matrix-versions.json" file
+      - name: List all Bowtie Supported Implementations having a "matrix-versions.json" File
         id: implementations-matrix
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json | jq -r '.[]')
@@ -42,7 +42,7 @@ jobs:
       - name: Install Bowtie
         uses: ./
 
-      - name: Generate a New Versioned Report
+      - name: Generate a New Versioned Report for ${{ matrix.implementation }}
         id: generate-new-versioned-report
         run: |
           impl=${{ matrix.implementation }}
@@ -61,7 +61,7 @@ jobs:
 
       # This unfortunately can go wrong if e.g. we ever run out of memory above.
       # Probably we should also atomically move files into place.
-      - name: Check Reports are Valid
+      - name: Check all Generated Reports for ${{ matrix.implementation }} are Valid
         run: |
           DIALECT_URIS=$(bowtie filter-dialects)
           for dialect_uri in $(echo $DIALECT_URIS); do

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -49,7 +49,7 @@ jobs:
               
               # Delete the Docker images for this implementation
               for version in $(jq -r '.[]' "$matrix_versions_file"); do
-                docker rmi "$impl:$version" || true
+                docker rmi "ghcr.io/bowtie-json-schema/$impl:$version" || true
               done
             fi
           done
@@ -82,5 +82,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: reports-${{ matrix.version }}
+          name: versioned-reports-${{ matrix.version }}
           path: versioned-*-${{ matrix.version }}.json

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -35,7 +35,6 @@ jobs:
         id: generate-new-versioned-report
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
-          no_impl_started=false
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -32,37 +32,18 @@ jobs:
         uses: ./
 
       - name: Generate a New Versioned Report
-        id: generate-new-versioned-report
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
-          no_impl_started=false
           for impl in $(echo $IMPLEMENTATIONS | jq -r '.[]'); do
             matrix_versions_file="implementations/$impl/matrix-versions.json"
             if [ -f $matrix_versions_file ]; then
-              # Run bowtie suite and capture output
-              output=$(bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} 2>&1)
-              exit_code=$?
-              if echo "$output" | grep -q "No implementations started successfully!"; then
-                echo "No implementations started for $impl (${{ matrix.version }})"
-                no_impl_started=true
-              elif [ $exit_code -ne 0 ]; then
-                echo "Error running bowtie suite for $impl (${{ matrix.version }})"
-                echo "$output"
-                exit $exit_code
-              else
-                echo "$output" > $impl.json
-                echo "Report generated for $impl (${{ matrix.version }})"
-              fi     
+              # Run bowtie suite
+              bowtie suite $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} > $impl.json
 
-              # Delete the multiple fetched Docker images for the current implementation
+              # Delete the multiple fetched docker images for the current implementation
               docker rmi $(jq -r '.[]' "$matrix_versions_file" | sed "s/^/-i ghcr.io/bowtie-json-schema/$impl:/") || true
             fi
           done
-          if $no_impl_started; then
-            echo "no_impl_started=true" >> $GITHUB_OUTPUT
-          else
-            echo "no_impl_started=false" >> $GITHUB_OUTPUT
-          fi
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
       # number of container images.
@@ -91,8 +72,7 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v4
-        if: steps.generate-new-versioned-report.outputs.no_impl_started != 'true'
         with:
           name: versioned-report-${{ matrix.version }}
           path: "*.json"
-          if-no-files-found: error
+          if-no-files-found: warn

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -61,7 +61,7 @@ jobs:
 
       # This unfortunately can go wrong if e.g. we ever run out of memory above.
       # Probably we should also atomically move files into place.
-      - name: Check all Generated Reports for ${{ matrix.implementation }} are Valid
+      - name: Check that All Generated Reports for ${{ matrix.implementation }} are Valid
         run: |
           DIALECT_SHORTNAMES=$(jq -r '.[].shortName' data/dialects.json)
           for dialect_shortname in $(echo $DIALECT_SHORTNAMES); do


### PR DESCRIPTION
Hi @Julian I have written this workflow and you can see a run of it over [here on my fork](https://github.com/adwait-godbole/bowtie/actions/runs/9652139138) (though there it shows workflow failed because of `draft3` job failure which is  happening because of no implementation (ruby and hyperjump in this case) supporting draft3 and hence none started successfully so it is exiting with some exit code and failing the entire job. I am not sure how to fix it yet. Can you help regarding this please.) and also possibly have a look at the uploaded artifacts.
 
Currently I have made it so that this `versioned-report.yml` workflow runs for all versions of all implementations which have "matrix-versions.json" file for them. However while implementing this I've made sure that once we run the suite against all versions for one implementation, then we delete whatever images we fetched for it so that helps us not running out of memory at any point of time.

What I am planning to do now is to modify our current `report.yml` workflow to download the artifacts that were published by this `versioned-report.yml` workflow's last run and every time upload it alongside other implementation reports which will be generated by `report.yml` itself. This way we have the traditionally generated reports for the latest versions of all implementations by `report.yml` and also alongside them we will have these versioned reports which were generated by `versioned-report.yml` workflow. This way `report.yml` does not have to do any heavy lifting of generating these versioned reports since we anyways will be manually triggering them once/whenever we need and storing them forever so `report.yml` just needs to download them and use them.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1330.org.readthedocs.build/en/1330/

<!-- readthedocs-preview bowtie-json-schema end -->