### PR TITLE
A public directory structure for serving `implementations.json` to `json-schema-org`

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -86,10 +86,25 @@ jobs:
         run: |
           bowtie info $(bowtie filter-implementations | sed 's/^/-i /') --format json > implementations.json
 
+      - name: Generate public-implementations.json file
+        run: |
+          jq 'to_entries | map({
+              (.value.source): (
+                .value + {name: .key}
+                | del(.os, .os_version, .language_version, .source)
+              )
+            })
+            | add' implementations.json > public-implementations.json
+
       - uses: actions/upload-artifact@v4
         with:
           name: implementations
           path: implementations.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: public-implementations
+          path: public-implementations.json
 
   site:
     needs:
@@ -119,6 +134,18 @@ jobs:
         with:
           name: implementations
           path: site/
+
+      - name: Create a Public Directory Structure for JSON Schema Org
+        run: mkdir -p site/v1/json-schema-org
+
+      - name: Include Public Implementation Metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: public-implementations
+          path: site/v1/json-schema-org/
+
+      - name: Rename public-implementations.json to implementations.json
+        run: mv site/v1/json-schema-org/public-implementations.json site/v1/json-schema-org/implementations.json
 
       - name: Generate Badges
         run: bowtie badges

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -104,8 +104,15 @@ jobs:
             done | \
           jq -s 'add' > public-implementations
 
-      - name: Validate public-implementations against a JSON Schema
-        run: bowtie validate -i python-jsonschema bowtie/schemas/public-implementations.json public-implementations
+      - name: Validate public-implementations against its corresponding JSON Schema
+        run: |
+          VALIDATION=$(bowtie validate --expect valid -i python-jsonschema bowtie/schemas/public-implementations.json public-implementations)
+          SUMMARY=$(echo "$VALIDATION" | bowtie summary --show failures --format json)
+          if [ $(echo "$SUMMARY" | \
+                 jq 'all(.[]; .[1].failed == 0 and .[1].errored == 0 and .[1].skipped == 0)') == false ]; then
+              echo "public-implementations file is invalid under its JSON Schema"
+              exit 1
+          fi
 
       - uses: actions/upload-artifact@v4
         with:
@@ -140,7 +147,7 @@ jobs:
           path: site/
           merge-multiple: true
 
-      - name: Include Implementation Metadata
+      - name: Include Implementations Metadata (Private API)
         uses: actions/download-artifact@v4
         with:
           name: implementations
@@ -149,7 +156,7 @@ jobs:
       - name: Create a Public Directory Structure for JSON Schema Org
         run: mkdir -p site/v1/json-schema-org
 
-      - name: Include Public Implementation Metadata
+      - name: Include Public Implementations Metadata (Public API)
         uses: actions/download-artifact@v4
         with:
           name: public-implementations

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -82,19 +82,30 @@ jobs:
         with:
           version: ${{ inputs.bowtie-version }}
 
-      - name: Generate implementations.json file
+      - name: Generate implementations.json (Private API) file
         run: |
           bowtie info $(bowtie filter-implementations | sed 's/^/-i /') --format json > implementations.json
 
-      - name: Generate public-implementations.json file
+      - name: Generate public-implementations (Public API) file
         run: |
-          jq 'to_entries | map({
-              (.value.source): (
-                .value + {name: .key}
-                | del(.os, .os_version, .language_version, .source)
-              )
-            })
-            | add' implementations.json > public-implementations.json
+          bowtie filter-implementations | \
+            while read -r impl; do
+              bowtie info -i $impl --format json | \
+              jq --arg impl "$impl" '
+                {(.source): (
+                  . + {name: $impl}
+                  | del(
+                      .os,
+                      .os_version,
+                      .source
+                    )
+                )}
+              '
+            done | \
+          jq -s 'add' > public-implementations
+
+      - name: Validate public-implementations against a JSON Schema
+        run: bowtie validate -i python-jsonschema bowtie/schemas/public-implementations.json public-implementations
 
       - uses: actions/upload-artifact@v4
         with:
@@ -104,7 +115,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: public-implementations
-          path: public-implementations.json
+          path: public-implementations
 
   site:
     needs:
@@ -144,8 +155,8 @@ jobs:
           name: public-implementations
           path: site/v1/json-schema-org/
 
-      - name: Rename public-implementations.json to implementations.json
-        run: mv site/v1/json-schema-org/public-implementations.json site/v1/json-schema-org/implementations.json
+      - name: Rename "public-implementations" file to just "implementations"
+        run: mv site/v1/json-schema-org/public-implementations site/v1/json-schema-org/implementations
 
       - name: Generate Badges
         run: bowtie badges

--- a/bowtie/schemas/public-implementations.json
+++ b/bowtie/schemas/public-implementations.json
@@ -1,6 +1,6 @@
 {
   "title": "Public Implementations",
-  "description": "A Public API providing information on Bowtie Supported Implementations",
+  "description": "A Public API providing metadata about implementations of JSON Schema supported by Bowtie",
 
   "$schema": "https://json-schema.org/draft/2020-12/schema",
 
@@ -30,17 +30,6 @@
         "type": "array",
         "items": { "type": "string", "format": "uri" }
       },
-      "version": {
-        "description": "The implementation version",
-
-        "type": "string"
-      },
-      "documentation": {
-        "description": "A URL for the implementation's documentation",
-
-        "type": "string",
-        "format": "uri"
-      },
       "homepage": {
         "description": "A URL for the implementation's homepage",
 
@@ -49,6 +38,21 @@
       },
       "issues": {
         "description": "A URL for the implementation's bug tracker",
+
+        "type": "string",
+        "format": "uri"
+      },
+      "version": {
+        "description": "The implementation version",
+
+        "type": "string"
+      },
+      "language_version": {
+        "description": "Version of language used to run the implementation",
+        "type": "string"
+      },
+      "documentation": {
+        "description": "A URL for the implementation's documentation",
 
         "type": "string",
         "format": "uri"
@@ -66,12 +70,8 @@
           },
           "additionalProperties": false
         }
-      },
-      "language_version": {
-        "description": "Version of language used to run the implementation",
-        "type": "string"
-      },
-      "additionalProperties": false
-    }
+      }
+    },
+    "additionalProperties": false
   }
 }

--- a/bowtie/schemas/public-implementations.json
+++ b/bowtie/schemas/public-implementations.json
@@ -1,0 +1,77 @@
+{
+  "title": "Public Implementations",
+  "description": "A Public API providing information on Bowtie Supported Implementations",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:models:public-implementations",
+
+  "type": "object",
+  "propertyNames": {
+    "description": "A URL where the implementation's source code is hosted",
+
+    "type": "string",
+    "format": "uri"
+  },
+  "additionalProperties": {
+    "type": "object",
+    "required": ["name", "language", "dialects", "homepage", "issues"],
+    "properties": {
+      "name": { "type": "string" },
+      "language": {
+        "description": "The implementation language (e.g. C++, Python, etc.)",
+
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-+_]*$"
+      },
+      "dialects": {
+        "description": "A list of JSON Schema dialects (URIs) which the implementation understands. When running test cases, this list will be consulted before sending them to the implementation (and any unsupported dialects will be skipped).",
+
+        "type": "array",
+        "items": { "type": "string", "format": "uri" }
+      },
+      "version": {
+        "description": "The implementation version",
+
+        "type": "string"
+      },
+      "documentation": {
+        "description": "A URL for the implementation's documentation",
+
+        "type": "string",
+        "format": "uri"
+      },
+      "homepage": {
+        "description": "A URL for the implementation's homepage",
+
+        "type": "string",
+        "format": "uri"
+      },
+      "issues": {
+        "description": "A URL for the implementation's bug tracker",
+
+        "type": "string",
+        "format": "uri"
+      },
+      "links": {
+        "description": "Additional web page links relevant to the implementation",
+
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["description", "url"],
+          "properties": {
+            "description": { "type": "string" },
+            "url": { "type": "string", "format": "uri" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "language_version": {
+        "description": "Version of language used to run the implementation",
+        "type": "string"
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/fauxmplementations/lintsonschema/schemas/public-implementations.json
+++ b/tests/fauxmplementations/lintsonschema/schemas/public-implementations.json
@@ -1,0 +1,77 @@
+{
+  "title": "Public Implementations",
+  "description": "A Public API providing metadata about implementations of JSON Schema supported by Bowtie",
+
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:models:public-implementations",
+
+  "type": "object",
+  "propertyNames": {
+    "description": "A URL where the implementation's source code is hosted",
+
+    "type": "string",
+    "format": "uri"
+  },
+  "additionalProperties": {
+    "type": "object",
+    "required": ["name", "language", "dialects", "homepage", "issues"],
+    "properties": {
+      "name": { "type": "string" },
+      "language": {
+        "description": "The implementation language (e.g. C++, Python, etc.)",
+
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-+_]*$"
+      },
+      "dialects": {
+        "description": "A list of JSON Schema dialects (URIs) which the implementation understands. When running test cases, this list will be consulted before sending them to the implementation (and any unsupported dialects will be skipped).",
+
+        "type": "array",
+        "items": { "type": "string", "format": "uri" }
+      },
+      "homepage": {
+        "description": "A URL for the implementation's homepage",
+
+        "type": "string",
+        "format": "uri"
+      },
+      "issues": {
+        "description": "A URL for the implementation's bug tracker",
+
+        "type": "string",
+        "format": "uri"
+      },
+      "version": {
+        "description": "The implementation version",
+
+        "type": "string"
+      },
+      "language_version": {
+        "description": "Version of language used to run the implementation",
+        "type": "string"
+      },
+      "documentation": {
+        "description": "A URL for the implementation's documentation",
+
+        "type": "string",
+        "format": "uri"
+      },
+      "links": {
+        "description": "Additional web page links relevant to the implementation",
+
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["description", "url"],
+          "properties": {
+            "description": { "type": "string" },
+            "url": { "type": "string", "format": "uri" }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
resolves #1312 

@Julian I am not sure if this was the best way of doing this but this is where my initial thoughts inclined towards. Here's how this file would look like once deployed.

https://adwait-godbole.github.io/bowtie/v1/json-schema-org/implementations.json

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1331.org.readthedocs.build/en/1331/

<!-- readthedocs-preview bowtie-json-schema end -->