### PR TITLE
A new `versioned-report.yml` workflow for generating reports for different versions of an implementation

### DIFF
--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -1,4 +1,4 @@
-# This workflow is a separate workflow from `report.yml` for regenerating the versioned report data needed for Bowtie's UI.
+# This workflow is a separate workflow from `report.yml` for regenerating the versioned report data needed for Bowtie's UI and `bowtie trend`.
 # It retests all of Bowtie's supported implementations for all their multiple versions listed in `matrix-versions.json` file if one exists for them.
 name: Collect New Versioned Test Results
 

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -1,0 +1,77 @@
+# This workflow is a separate workflow from `report.yml` for regenerating the versioned report data needed for Bowtie's UI.
+# It retests all of Bowtie's supported implementations for all their multiple versions listed in `matrix-versions.json` file if one exists for them.
+name: Collect New Versioned Test Results
+
+on:
+  workflow_dispatch:
+
+jobs:
+  list-implementations:
+    runs-on: ubuntu-latest
+    outputs:
+      implementations: ${{ steps.implementations-matrix.outputs.implementations }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bowtie
+        uses: ./
+
+      - name: List all Bowtie Supported Implementations having a "matrix-versions.json" file
+        id: implementations-matrix
+        run: |
+          IMPLEMENTATIONS=$(bowtie filter-implementations --format json | jq -r '.[]')
+          MATRIX="[]"
+          for impl in $(echo "$IMPLEMENTATIONS"); do
+            if [ -f "implementations/$impl/matrix-versions.json" ]; then
+              MATRIX=$(echo $MATRIX | jq --arg impl "$impl" '. + [$impl]')
+            fi
+          done
+          echo "implementations=$(echo $MATRIX | jq -c .)" >> $GITHUB_OUTPUT
+
+  regenerate-versioned-reports:
+    needs: list-implementations
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        implementation: ${{ fromJson(needs.list-implementations.outputs.implementations) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bowtie
+        uses: ./
+
+      - name: Generate New Versioned Reports for all Supported Dialects of ${{ matrix.implementation }}
+        id: generate-new-versioned-report
+        run: |
+          impl=${{ matrix.implementation }}
+          SUPPORTED_DIALECTS=$(bowtie filter-dialects -i $impl | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
+          MATRIX_VERSIONS_FILE="implementations/$impl/matrix-versions.json"
+          for dialect in $(echo $SUPPORTED_DIALECTS); do
+            bowtie suite $(jq -r '.[]' "$MATRIX_VERSIONS_FILE" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/$dialect > $dialect.json
+          done
+
+      # This is useful to debug whether Bowtie accidentally fetched some huge
+      # number of container images.
+      - name: Show what images we fetched
+        run: docker images
+        if: always()
+
+      # This unfortunately can go wrong if e.g. we ever run out of memory above.
+      # Probably we should also atomically move files into place.
+      - name: Check that all Generated Reports for ${{ matrix.implementation }} are Valid
+        run: |
+          DIALECTS=$(bowtie filter-dialects | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
+          for dialect in $(echo $DIALECTS); do
+            if [ -f "$dialect.json" ]; then
+              bowtie summary --show failures "$dialect.json" --format markdown >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.implementation }}
+          path: |
+            *.json
+            !.prettierrc.json

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json | jq -r '.[]')
           MATRIX="[]"
-          for impl in $(echo "$IMPLEMENTATIONS"); do
+          for impl in $IMPLEMENTATIONS; do
             if [ -f "implementations/$impl/matrix-versions.json" ]; then
               MATRIX=$(echo $MATRIX | jq --arg impl "$impl" '. + [$impl]')
             fi
@@ -42,14 +42,29 @@ jobs:
       - name: Install Bowtie
         uses: ./
 
+        # just so that we don't get rate limited (429)
+      - name: Checkout JSON Schema Test Suite
+        uses: actions/checkout@v4
+        with:
+          repository: json-schema-org/JSON-Schema-Test-Suite
+          path: json-schema-test-suite
+
+      - name: Make a ${{ matrix.implementation }} directory to keep all its version reports
+        run: mkdir ${{ matrix.implementation }}
+
       - name: Generate New Versioned Reports for all Supported Dialects of ${{ matrix.implementation }}
         id: generate-new-versioned-report
         run: |
           impl=${{ matrix.implementation }}
-          SUPPORTED_DIALECTS=$(bowtie filter-dialects -i $impl | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
-          MATRIX_VERSIONS_FILE="implementations/$impl/matrix-versions.json"
-          for dialect in $(echo $SUPPORTED_DIALECTS); do
-            bowtie suite $(jq -r '.[]' "$MATRIX_VERSIONS_FILE" | sed "s/^/-i image:$impl:/") https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/$dialect > $dialect.json
+          MATRIX_VERSIONS=$(jq -r '.[]' "implementations/$impl/matrix-versions.json")
+          for version in $MATRIX_VERSIONS; do
+            SUPPORTED_DIALECTS=$(bowtie filter-dialects -i image:$impl:$version | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
+            if [ -n "$SUPPORTED_DIALECTS" ]; then
+              mkdir "$impl/$version"
+              for dialect in $SUPPORTED_DIALECTS; do
+                bowtie suite -i image:$impl:$version ./json-schema-test-suite/tests/$dialect > "$impl/v$version/$dialect.json"
+              done
+            fi
           done
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
@@ -62,10 +77,14 @@ jobs:
       # Probably we should also atomically move files into place.
       - name: Check that all Generated Reports for ${{ matrix.implementation }} are Valid
         run: |
-          DIALECTS=$(bowtie filter-dialects | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
-          for dialect in $(echo $DIALECTS); do
-            if [ -f "$dialect.json" ]; then
-              bowtie summary --show failures "$dialect.json" --format markdown >> $GITHUB_STEP_SUMMARY
+          impl=${{ matrix.implementation }}
+          MATRIX_VERSIONS=$(jq -r '.[]' "implementations/$impl/matrix-versions.json")
+          for version in $MATRIX_VERSIONS; do
+            SUPPORTED_DIALECTS=$(bowtie filter-dialects -i image:$impl:$version | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
+            if [ -n "$SUPPORTED_DIALECTS" ]; then
+              for dialect in $SUPPORTED_DIALECTS; do
+                bowtie summary --show failures "$impl/v$version/$dialect.json" --format markdown >> $GITHUB_STEP_SUMMARY
+              done
             fi
           done
 
@@ -73,5 +92,18 @@ jobs:
         with:
           name: ${{ matrix.implementation }}
           path: |
-            *.json
-            !.prettierrc.json
+            ${{ matrix.implementation }}
+
+  combine-all-versioned-reports:
+    runs-on: ubuntu-latest
+    needs: regenerate-versioned-reports
+    steps:
+      - name: Download all uploaded artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: implementations
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: implementations
+          path: implementations


### PR DESCRIPTION
@Julian sorry for closing the other PR since it had a lot of unnecessary commits but this one's clean now. [Here's](https://github.com/adwait-godbole/bowtie/actions/runs/9674687356) the workflow run on my fork. Let me know what you think about this now and also the below thought.

What I am planning to do now is to modify our current `report.yml` workflow to download the artifacts that were published by this `versioned-report.yml` workflow's last run and every time upload it alongside other implementation reports which are generated by `report.yml` itself. This way we will have the traditionally generated reports for the latest versions of all implementations by `report.yml` and also alongside them we will have these versioned reports which were generated by `versioned-report.yml`. With this, `report.yml` would not have to do any heavy lifting of generating these versioned reports since we anyways will be generating them by manually triggering `versioned-report.yml` workflow once/whenever we need and storing the artifacts (ig atleast for a maximum of 90 days), so `report.yml` will just have to download them and use them as they are.



<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1337.org.readthedocs.build/en/1337/

<!-- readthedocs-preview bowtie-json-schema end -->