### PR TITLE
Include latest versioned reports in UI deployment artifact

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -77,6 +77,14 @@ jobs:
           name: site
           path: _site
 
+      - name: Download latest versioned test reports
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: versioned-report.yml
+          branch: main
+          name: implementations
+          path: _site/implementations
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
@Julian this would include the versioned reports in the frontend / github-pages site artifact.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1377.org.readthedocs.build/en/1377/

<!-- readthedocs-preview bowtie-json-schema end -->