### PR TITLE
`bowtie summary --show failures` should return nonzero status on failures

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -616,7 +616,8 @@ def summary(report: _report.Report, format: _F, show: str):
             if any(
                 unsuccessful.failed or unsuccessful.errored
                 for _, __, unsuccessful in results
-            ) else 0
+            )
+            else 0
         )
         to_table = _failure_table
         to_markdown_table = _failure_table_in_markdown
@@ -667,6 +668,7 @@ def summary(report: _report.Report, format: _F, show: str):
             console.Console().print(table)
 
     return exit_code
+
 
 def _failure_table(
     report: _report.Report,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -611,6 +611,13 @@ def summary(report: _report.Report, format: _F, show: str):
     """
     if show == "failures":
         results = report.worst_to_best()
+        exit_code = (
+            EX.DATAERR
+            if any(
+                unsuccessful.failed or unsuccessful.errored
+                for _, __, unsuccessful in results
+            ) else 0
+        )
         to_table = _failure_table
         to_markdown_table = _failure_table_in_markdown
 
@@ -623,6 +630,7 @@ def summary(report: _report.Report, format: _F, show: str):
 
     else:
         results = report.cases_with_results()
+        exit_code = 0
         to_table = _validation_results_table
         to_markdown_table = _validation_results_table_in_markdown
 
@@ -658,6 +666,7 @@ def summary(report: _report.Report, format: _F, show: str):
             table = to_markdown_table(report, results)  # type: ignore[reportGeneralTypeIssues]
             console.Console().print(table)
 
+    return exit_code
 
 def _failure_table(
     report: _report.Report,

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -2523,6 +2523,7 @@ async def test_summary_show_failures_json(tmp_path):
         "failures",
         stdin=validate_stdout,
         json=True,
+        exit_code=EX.DATAERR,
     )
 
     assert (await command_validator("summary")).validated(jsonout) == [
@@ -2564,6 +2565,7 @@ async def test_summary_show_failures_markdown(tmp_path):
         "--show",
         "failures",
         stdin=validate_stdout,
+        exit_code=EX.DATAERR,
     )
     assert stderr == ""
     assert stdout == dedent(
@@ -2664,6 +2666,7 @@ async def test_summary_failures_valid_markdown(tmp_path):
         "--show",
         "failures",
         stdin=validate_stdout,
+        exit_code=EX.DATAERR,
     )
     parsed_markdown = MarkdownIt("gfm-like", {"linkify": False}).parse(stdout)
     tokens = SyntaxTreeNode(parsed_markdown).pretty(indent=2)


### PR DESCRIPTION
Fixes #1414 

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1431.org.readthedocs.build/en/1431/

<!-- readthedocs-preview bowtie-json-schema end -->