### PR TITLE
reusable unsuccessfulTests schema in summary.json

### DIFF
--- a/bowtie/schemas/cli/summary.json
+++ b/bowtie/schemas/cli/summary.json
@@ -92,15 +92,13 @@
       "additionalProperties": false,
       "required": ["failed", "errored", "skipped"],
       "properties": {
-        "failed": { "$ref": "#count" },
-        "errored": { "$ref": "#count" },
-        "skipped": { "$ref": "#count" }
+        "failed": { "$ref": "#/$defs/count" },
+        "errored": { "$ref": "#/$defs/count" },
+        "skipped": { "$ref": "#/$defs/count" }
       }
     },
     "count": {
       "description": "The total number of tests with a specific outcome.",
-
-      "$anchor": "count",
 
       "type": "integer",
       "minimum": 0

--- a/bowtie/schemas/cli/summary.json
+++ b/bowtie/schemas/cli/summary.json
@@ -77,32 +77,33 @@
         "unevaluatedItems": false,
         "prefixItems": [
           { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
-          {
-            "description": "Unsuccessful tests for a specific implementation.",
-
-            "type": "object",
-
-            "additionalProperties": false,
-            "required": ["failed", "errored", "skipped"],
-            "properties": {
-              "failed": { "$ref": "#count" },
-              "errored": { "$ref": "#count" },
-              "skipped": { "$ref": "#count" }
-            },
-
-            "$defs": {
-              "count": {
-                "description": "The total number of tests with a specific outcome.",
-
-                "$anchor": "count",
-
-                "type": "integer",
-                "minimum": 0
-              }
-            }
-          }
+          { "$ref": "#/$defs/unsuccessfulTests" }
         ]
       }
     }
-  ]
+  ],
+  "$defs": {
+    "unsuccessfulTests": {
+      "description": "Unsuccessful tests for a specific implementation.",
+
+      "$id": "tag:bowtie.report,2024:cli:summary:unsuccessfulTests",
+
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failed", "errored", "skipped"],
+      "properties": {
+        "failed": { "$ref": "#count" },
+        "errored": { "$ref": "#count" },
+        "skipped": { "$ref": "#count" }
+      }
+    },
+    "count": {
+      "description": "The total number of tests with a specific outcome.",
+
+      "$anchor": "count",
+
+      "type": "integer",
+      "minimum": 0
+    }
+  }
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -77,32 +77,33 @@
         "unevaluatedItems": false,
         "prefixItems": [
           { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
-          {
-            "description": "Unsuccessful tests for a specific implementation.",
-
-            "type": "object",
-
-            "additionalProperties": false,
-            "required": ["failed", "errored", "skipped"],
-            "properties": {
-              "failed": { "$ref": "#count" },
-              "errored": { "$ref": "#count" },
-              "skipped": { "$ref": "#count" }
-            },
-
-            "$defs": {
-              "count": {
-                "description": "The total number of tests with a specific outcome.",
-
-                "$anchor": "count",
-
-                "type": "integer",
-                "minimum": 0
-              }
-            }
-          }
+          { "$ref": "#/$defs/unsuccessfulTests" }
         ]
       }
     }
-  ]
+  ],
+  "$defs": {
+    "unsuccessfulTests": {
+      "description": "Unsuccessful tests for a specific implementation.",
+
+      "$id": "tag:bowtie.report,2024:cli:summary:unsuccessfulTests",
+
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failed", "errored", "skipped"],
+      "properties": {
+        "failed": { "$ref": "#count" },
+        "errored": { "$ref": "#count" },
+        "skipped": { "$ref": "#count" }
+      }
+    },
+    "count": {
+      "description": "The total number of tests with a specific outcome.",
+
+      "$anchor": "count",
+
+      "type": "integer",
+      "minimum": 0
+    }
+  }
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -92,19 +92,16 @@
       "additionalProperties": false,
       "required": ["failed", "errored", "skipped"],
       "properties": {
-        "failed": { "$ref": "#count" },
-        "errored": { "$ref": "#count" },
-        "skipped": { "$ref": "#count" }
-      },
-
-      "$defs": {
-        "count": {
-          "description": "The total number of tests with a specific outcome.",
-
-          "type": "integer",
-          "minimum": 0
-        }
+        "failed": { "$ref": "#/$defs/count" },
+        "errored": { "$ref": "#/$defs/count" },
+        "skipped": { "$ref": "#/$defs/count" }
       }
+    },
+    "count": {
+      "description": "The total number of tests with a specific outcome.",
+
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -92,16 +92,21 @@
       "additionalProperties": false,
       "required": ["failed", "errored", "skipped"],
       "properties": {
-        "failed": { "$ref": "#/$defs/count" },
-        "errored": { "$ref": "#/$defs/count" },
-        "skipped": { "$ref": "#/$defs/count" }
-      }
-    },
-    "count": {
-      "description": "The total number of tests with a specific outcome.",
+        "failed": { "$ref": "#count" },
+        "errored": { "$ref": "#count" },
+        "skipped": { "$ref": "#count" }
+      },
 
-      "type": "integer",
-      "minimum": 0
+      "$defs": {
+        "count": {
+          "description": "The total number of tests with a specific outcome.",
+
+          "$anchor": "count",
+
+          "type": "integer",
+          "minimum": 0
+        }
+      }
     }
   }
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -92,21 +92,16 @@
       "additionalProperties": false,
       "required": ["failed", "errored", "skipped"],
       "properties": {
-        "failed": { "$ref": "#count" },
-        "errored": { "$ref": "#count" },
-        "skipped": { "$ref": "#count" }
-      },
-
-      "$defs": {
-        "count": {
-          "description": "The total number of tests with a specific outcome.",
-
-          "$anchor": "count",
-
-          "type": "integer",
-          "minimum": 0
-        }
+        "failed": { "$ref": "#/$defs/count" },
+        "errored": { "$ref": "#/$defs/count" },
+        "skipped": { "$ref": "#/$defs/count" }
       }
+    },
+    "count": {
+      "description": "The total number of tests with a specific outcome.",
+
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -92,9 +92,9 @@
       "additionalProperties": false,
       "required": ["failed", "errored", "skipped"],
       "properties": {
-        "failed": { "$ref": "#/$defs/count" },
-        "errored": { "$ref": "#/$defs/count" },
-        "skipped": { "$ref": "#/$defs/count" }
+        "failed": { "$ref": "#count" },
+        "errored": { "$ref": "#count" },
+        "skipped": { "$ref": "#count" }
       }
     },
     "count": {

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -92,16 +92,19 @@
       "additionalProperties": false,
       "required": ["failed", "errored", "skipped"],
       "properties": {
-        "failed": { "$ref": "#/$defs/count" },
-        "errored": { "$ref": "#/$defs/count" },
-        "skipped": { "$ref": "#/$defs/count" }
-      }
-    },
-    "count": {
-      "description": "The total number of tests with a specific outcome.",
+        "failed": { "$ref": "#count" },
+        "errored": { "$ref": "#count" },
+        "skipped": { "$ref": "#count" }
+      },
 
-      "type": "integer",
-      "minimum": 0
+      "$defs": {
+        "count": {
+          "description": "The total number of tests with a specific outcome.",
+
+          "type": "integer",
+          "minimum": 0
+        }
+      }
     }
   }
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -92,9 +92,9 @@
       "additionalProperties": false,
       "required": ["failed", "errored", "skipped"],
       "properties": {
-        "failed": { "$ref": "#count" },
-        "errored": { "$ref": "#count" },
-        "skipped": { "$ref": "#count" }
+        "failed": { "$ref": "#/$defs/count" },
+        "errored": { "$ref": "#/$defs/count" },
+        "skipped": { "$ref": "#/$defs/count" }
       }
     },
     "count": {

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -95,15 +95,18 @@
         "failed": { "$ref": "#count" },
         "errored": { "$ref": "#count" },
         "skipped": { "$ref": "#count" }
+      },
+
+      "$defs": {
+        "count": {
+          "description": "The total number of tests with a specific outcome.",
+
+          "$anchor": "count",
+
+          "type": "integer",
+          "minimum": 0
+        }
       }
-    },
-    "count": {
-      "description": "The total number of tests with a specific outcome.",
-
-      "$anchor": "count",
-
-      "type": "integer",
-      "minimum": 0
     }
   }
 }


### PR DESCRIPTION
@Julian this was [one of your suggestions](https://github.com/bowtie-json-schema/bowtie/pull/1384#discussion_r1713954715) in the `bowtie trend` PR. 

So now I can use ` "$ref": "tag:bowtie.report,2024:cli:summary:unsuccessfulTests"` in `trend.json` schema. 

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1435.org.readthedocs.build/en/1435/

<!-- readthedocs-preview bowtie-json-schema end -->