### PR TITLE
By default, filter-benchmarks should return all benchmarks instead of just default ones

### DIFF
--- a/bowtie/_benchmarks.py
+++ b/bowtie/_benchmarks.py
@@ -65,7 +65,7 @@ benchmark_validated, benchmark_invalidated = (
 
 
 def get_benchmark_files(
-    benchmark_type: str,
+    benchmark_type: str | None,
     dialect: Dialect,
     benchmarks: Iterable[str] = [],
 ) -> list[Path]:
@@ -82,7 +82,7 @@ def get_benchmark_files(
         )
         if (
             benchmark_group is not None
-            and benchmark_group.benchmark_type == benchmark_type
+            and (benchmark_group.benchmark_type == benchmark_type or benchmark_type is None)
             and dialect in benchmark_group.dialects_supported
         ):
             files.append(file)

--- a/bowtie/_benchmarks.py
+++ b/bowtie/_benchmarks.py
@@ -82,7 +82,10 @@ def get_benchmark_files(
         )
         if (
             benchmark_group is not None
-            and (benchmark_group.benchmark_type == benchmark_type or benchmark_type is None)
+            and (
+                benchmark_group.benchmark_type == benchmark_type
+                or benchmark_type is None
+            )
             and dialect in benchmark_group.dialects_supported
         ):
             files.append(file)

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1419,7 +1419,7 @@ def perf(
     "-t",
     "--benchmark-type",
     type=click.Choice(["default", "keyword"]),
-    default="default",
+    default=None,
     show_default=True,
     help=("Specify the type of benchmark to filter."),
 )
@@ -1436,7 +1436,7 @@ def perf(
 )
 def filter_benchmarks(
     dialect: Dialect,
-    benchmark_type: str,
+    benchmark_type: str | None,
     benchmark_names: Iterable[str],
 ):
     """


### PR DESCRIPTION


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1444.org.readthedocs.build/en/1444/

<!-- readthedocs-preview bowtie-json-schema end -->