### PR TITLE
Bug Fix: Somehow the former gives error in terms of some url library missing during the workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install Bowtie
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,8 +106,14 @@ jobs:
           path: benchmarks-${{ matrix.dialect }}/
           merge-multiple: true
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
       - name: Install Bowtie
-        uses: ./
+        run: |
+          pip install -e .
 
       - name: Merge Benchmark Reports for a dialect
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -107,13 +107,16 @@ jobs:
           merge-multiple: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
+      - name: Set up uv
+        uses: hynek/setup-cached-uv@v2
+
       - name: Install Bowtie
         run: |
-          pip install -e .
+          uv pip install --system .
 
       - name: Merge Benchmark Reports for a dialect
         run: |


### PR DESCRIPTION
I had tested the workflow using, since the latest benchmark changes were not there in the latest release:

This works fine
```
     - name: Set up Python
        uses: actions/setup-python@v4
        with:
          python-version: '3.12'

      - name: Install Bowtie
         run: |
          pip install -e .
```

However now using, 

This doesnt work
```
- name: Install Bowtie
        uses: ./
```

Since the latest release has been done, the workflow is failing on the python script step saying `url` library not found. I dont understand why though @Julian . Both code should work the same functionality wise right ?


ERROR:

```
Run python - <<EOF
  python - <<EOF
  from pathlib import Path
  from bowtie._benchmarks import combine_benchmark_reports_to_serialized as combine
  
  Path("draft[2](https://github.com/sudo-jarvis/bowtie/actions/runs/10547927252/job/29221319098#step:5:2)020-12.json").write_text(
      combine(
          Path("benchmarks-draft2020-12").iterdir()
      )
  )
  
  EOF
  shell: /usr/bin/bash -e {0}
  
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/home/runner/work/bowtie/bowtie/bowtie/__init__.py", line [5](https://github.com/sudo-jarvis/bowtie/actions/runs/10547927252/job/29221319098#step:5:5), in <module>
    from url import URL
ModuleNotFoundError: No module named 'url'
Error: Process completed with exit code 1.
```

Failed job link: https://github.com/sudo-jarvis/bowtie/actions/runs/10547927252/job/29221319098#step:5:19


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1476.org.readthedocs.build/en/1476/

<!-- readthedocs-preview bowtie-json-schema end -->