### PR TITLE
reusable `unsuccessfulTests` schema from `summary.json`

### DIFF
--- a/bowtie/schemas/cli/summary.json
+++ b/bowtie/schemas/cli/summary.json
@@ -77,37 +77,9 @@
         "unevaluatedItems": false,
         "prefixItems": [
           { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
-          { "$ref": "#/$defs/unsuccessfulTests" }
+          { "$ref": "tag:bowtie.report,2024:models:unsuccessfulTests" }
         ]
       }
     }
-  ],
-  "$defs": {
-    "unsuccessfulTests": {
-      "description": "Unsuccessful tests for a specific implementation.",
-
-      "$id": "tag:bowtie.report,2024:cli:summary:unsuccessfulTests",
-
-      "type": "object",
-
-      "additionalProperties": false,
-      "required": ["failed", "errored", "skipped"],
-      "properties": {
-        "failed": { "$ref": "#count" },
-        "errored": { "$ref": "#count" },
-        "skipped": { "$ref": "#count" }
-      },
-
-      "$defs": {
-        "count": {
-          "description": "The total number of tests with a specific outcome.",
-
-          "$anchor": "count",
-
-          "type": "integer",
-          "minimum": 0
-        }
-      }
-    }
-  }
+  ]
 }

--- a/bowtie/schemas/cli/summary.json
+++ b/bowtie/schemas/cli/summary.json
@@ -77,32 +77,37 @@
         "unevaluatedItems": false,
         "prefixItems": [
           { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
-          {
-            "description": "Unsuccessful tests for a specific implementation.",
-
-            "type": "object",
-
-            "additionalProperties": false,
-            "required": ["failed", "errored", "skipped"],
-            "properties": {
-              "failed": { "$ref": "#count" },
-              "errored": { "$ref": "#count" },
-              "skipped": { "$ref": "#count" }
-            },
-
-            "$defs": {
-              "count": {
-                "description": "The total number of tests with a specific outcome.",
-
-                "$anchor": "count",
-
-                "type": "integer",
-                "minimum": 0
-              }
-            }
-          }
+          { "$ref": "#/$defs/unsuccessfulTests" }
         ]
       }
     }
-  ]
+  ],
+  "$defs": {
+    "unsuccessfulTests": {
+      "description": "Unsuccessful tests for a specific implementation.",
+
+      "$id": "tag:bowtie.report,2024:cli:summary:unsuccessfulTests",
+
+      "type": "object",
+
+      "additionalProperties": false,
+      "required": ["failed", "errored", "skipped"],
+      "properties": {
+        "failed": { "$ref": "#count" },
+        "errored": { "$ref": "#count" },
+        "skipped": { "$ref": "#count" }
+      },
+
+      "$defs": {
+        "count": {
+          "description": "The total number of tests with a specific outcome.",
+
+          "$anchor": "count",
+
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
 }

--- a/bowtie/schemas/models/unsuccessfulTests.json
+++ b/bowtie/schemas/models/unsuccessfulTests.json
@@ -1,0 +1,26 @@
+{
+  "description": "Unsuccessful tests for a specific implementation.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:models:unsuccessfulTests",
+
+  "type": "object",
+  "required": ["failed", "errored", "skipped"],
+  "properties": {
+    "failed": { "$ref": "#count" },
+    "errored": { "$ref": "#count" },
+    "skipped": { "$ref": "#count" }
+  },
+
+  "$defs": {
+    "count": {
+      "description": "The total number of tests with a specific outcome.",
+
+      "$anchor": "count",
+
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "additionalProperties": false
+}

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -77,7 +77,30 @@
         "unevaluatedItems": false,
         "prefixItems": [
           { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
-          { "$ref": "tag:bowtie.report,2024:models:unsuccessfulTests" }
+          {
+            "description": "Unsuccessful tests for a specific implementation.",
+
+            "type": "object",
+
+            "additionalProperties": false,
+            "required": ["failed", "errored", "skipped"],
+            "properties": {
+              "failed": { "$ref": "#count" },
+              "errored": { "$ref": "#count" },
+              "skipped": { "$ref": "#count" }
+            },
+
+            "$defs": {
+              "count": {
+                "description": "The total number of tests with a specific outcome.",
+
+                "$anchor": "count",
+
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
         ]
       }
     }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -77,37 +77,9 @@
         "unevaluatedItems": false,
         "prefixItems": [
           { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
-          { "$ref": "#/$defs/unsuccessfulTests" }
+          { "$ref": "tag:bowtie.report,2024:models:unsuccessfulTests" }
         ]
       }
     }
-  ],
-  "$defs": {
-    "unsuccessfulTests": {
-      "description": "Unsuccessful tests for a specific implementation.",
-
-      "$id": "tag:bowtie.report,2024:cli:summary:unsuccessfulTests",
-
-      "type": "object",
-
-      "additionalProperties": false,
-      "required": ["failed", "errored", "skipped"],
-      "properties": {
-        "failed": { "$ref": "#count" },
-        "errored": { "$ref": "#count" },
-        "skipped": { "$ref": "#count" }
-      },
-
-      "$defs": {
-        "count": {
-          "description": "The total number of tests with a specific outcome.",
-
-          "$anchor": "count",
-
-          "type": "integer",
-          "minimum": 0
-        }
-      }
-    }
-  }
+  ]
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/cli/summary.json
@@ -77,32 +77,37 @@
         "unevaluatedItems": false,
         "prefixItems": [
           { "$ref": "tag:bowtie.report,2024:models:implementation:id" },
-          {
-            "description": "Unsuccessful tests for a specific implementation.",
-
-            "type": "object",
-
-            "additionalProperties": false,
-            "required": ["failed", "errored", "skipped"],
-            "properties": {
-              "failed": { "$ref": "#count" },
-              "errored": { "$ref": "#count" },
-              "skipped": { "$ref": "#count" }
-            },
-
-            "$defs": {
-              "count": {
-                "description": "The total number of tests with a specific outcome.",
-
-                "$anchor": "count",
-
-                "type": "integer",
-                "minimum": 0
-              }
-            }
-          }
+          { "$ref": "#/$defs/unsuccessfulTests" }
         ]
       }
     }
-  ]
+  ],
+  "$defs": {
+    "unsuccessfulTests": {
+      "description": "Unsuccessful tests for a specific implementation.",
+
+      "$id": "tag:bowtie.report,2024:cli:summary:unsuccessfulTests",
+
+      "type": "object",
+
+      "additionalProperties": false,
+      "required": ["failed", "errored", "skipped"],
+      "properties": {
+        "failed": { "$ref": "#count" },
+        "errored": { "$ref": "#count" },
+        "skipped": { "$ref": "#count" }
+      },
+
+      "$defs": {
+        "count": {
+          "description": "The total number of tests with a specific outcome.",
+
+          "$anchor": "count",
+
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
 }

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/models/unsuccessfulTests.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/models/unsuccessfulTests.json
@@ -1,0 +1,26 @@
+{
+  "description": "Unsuccessful tests for a specific implementation.",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$id": "tag:bowtie.report,2024:models:unsuccessfulTests",
+
+  "type": "object",
+  "required": ["failed", "errored", "skipped"],
+  "properties": {
+    "failed": { "$ref": "#count" },
+    "errored": { "$ref": "#count" },
+    "skipped": { "$ref": "#count" }
+  },
+
+  "$defs": {
+    "count": {
+      "description": "The total number of tests with a specific outcome.",
+
+      "$anchor": "count",
+
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1485.org.readthedocs.build/en/1485/

<!-- readthedocs-preview bowtie-json-schema end -->