### PR TITLE
Add `--versions` option to `bowtie info` for fetching versions from ghcr registry

### DIFF
--- a/bowtie/__init__.py
+++ b/bowtie/__init__.py
@@ -10,3 +10,8 @@ DOCS = URL.parse("https://docs.bowtie.report/")
 GITHUB = URL.parse("https://github.com/")
 ORG = GITHUB / "bowtie-json-schema"
 REPO = ORG / "bowtie"
+
+GITHUB_API = URL.parse("https://api.github.com/")
+ORG_API = GITHUB_API / "orgs" / "bowtie-json-schema"
+PACKAGES_API = ORG_API / "packages"
+CONTAINER_PACKAGES_API = PACKAGES_API / "container"

--- a/bowtie/__init__.py
+++ b/bowtie/__init__.py
@@ -10,8 +10,3 @@ DOCS = URL.parse("https://docs.bowtie.report/")
 GITHUB = URL.parse("https://github.com/")
 ORG = GITHUB / "bowtie-json-schema"
 REPO = ORG / "bowtie"
-
-GITHUB_API = URL.parse("https://api.github.com/")
-ORG_API = GITHUB_API / "orgs" / "bowtie-json-schema"
-PACKAGES_API = ORG_API / "packages"
-CONTAINER_PACKAGES_API = PACKAGES_API / "container"

--- a/bowtie/__init__.py
+++ b/bowtie/__init__.py
@@ -8,5 +8,6 @@ HOMEPAGE = URL.parse("https://bowtie.report/")
 DOCS = URL.parse("https://docs.bowtie.report/")
 
 GITHUB = URL.parse("https://github.com/")
-ORG = GITHUB / "bowtie-json-schema"
+ORG_NAME = "bowtie-json-schema"
+ORG = GITHUB / ORG_NAME
 REPO = ORG / "bowtie"

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1641,7 +1641,9 @@ def latest_report(dialect: Dialect):
     "--versions",
     "show_versions",
     is_flag=True,
-    help="Show all versions of an implementation that its harness can build.",
+    help=(
+        "Also show all versions of this implementation which Bowtie supports."
+    ),
 )
 async def info(
     start: Starter,
@@ -1654,18 +1656,16 @@ async def info(
     serializable: dict[ConnectableId, dict[str, Any]] = {}
 
     async for _, each in start():
-        metadata = [
-            (k, v)
-            for k, v in {
-                **each.info.serializable(),
-                **(
-                    {"versions": list(await each.get_versions())}
-                    if show_versions
-                    else {}
+        metadata = [(k, v) for k, v in each.info.serializable().items() if v]
+        if show_versions:
+            versions = await each.get_versions()
+            metadata.append(
+                (
+                    "versions",
+                    list(versions) if versions else [each.info.version],
                 ),
-            }.items()
-            if v
-        ]
+            )
+
         metadata.sort(
             key=lambda kv: (
                 kv[0] != "name",

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1660,7 +1660,8 @@ async def info(
                 **each.info.serializable(),
                 **(
                     {"versions": list(await each.get_versions())}
-                    if show_versions else {}
+                    if show_versions
+                    else {}
                 ),
             }.items()
             if v

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1660,8 +1660,7 @@ async def info(
                 **each.info.serializable(),
                 **(
                     {"versions": list(await each.get_versions())}
-                    if show_versions
-                    else {}
+                    if show_versions else {}
                 ),
             }.items()
             if v

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1658,13 +1658,7 @@ async def info(
     async for _, each in start():
         metadata = [(k, v) for k, v in each.info.serializable().items() if v]
         if show_versions:
-            versions = await each.get_versions()
-            metadata.append(
-                (
-                    "versions",
-                    list(versions) if versions else [each.info.version],
-                ),
-            )
+            metadata.append(("versions", list(await each.get_versions())))
 
         metadata.sort(
             key=lambda kv: (

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1658,7 +1658,9 @@ async def info(
     async for _, each in start():
         metadata = [(k, v) for k, v in each.info.serializable().items() if v]
         if show_versions:
-            metadata.append(("versions", list(await each.get_versions())))
+            metadata.append(
+                ("versions", next(iter(await each.get_versions()))),
+            )
 
         metadata.sort(
             key=lambda kv: (

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1638,12 +1638,9 @@ def latest_report(dialect: Dialect):
 @implementation_subcommand()  # type: ignore[reportArgumentType]
 @format_option()
 @click.option(
-    "--versions",
+    "--versions/--no-versions",
     "show_versions",
-    is_flag=True,
-    help=(
-        "Also show all versions of this implementation which Bowtie supports."
-    ),
+    help="Also show all implementation versions which Bowtie supports.",
 )
 async def info(
     start: Starter,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1658,9 +1658,7 @@ async def info(
     async for _, each in start():
         metadata = [(k, v) for k, v in each.info.serializable().items() if v]
         if show_versions:
-            metadata.append(
-                ("versions", next(iter(await each.get_versions()))),
-            )
+            metadata.append(("versions", await each.get_versions()))
 
         metadata.sort(
             key=lambda kv: (

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import date
 from functools import cache
 from importlib.resources import files
@@ -555,10 +555,8 @@ class Implementation:
 
         gh = _github()
         pages: list[GitHubCore] = []
-        try:
+        with suppress(GitHubError):
             pages = gh._iter(count=-1, url=str(url), cls=GitHubCore)  # type: ignore[reportPrivateUsage]
-        except GitHubError:
-            pass
 
         versions: Set[str] = (
             {self.info.version} if self.info.version else set()
@@ -859,4 +857,5 @@ def _github():
     presumably if ``github3.py`` was more active would be default behavior.
     """
     from github3 import GitHub  # type: ignore[reportMissingTypeStubs]
+
     return GitHub(token=os.environ.get("GITHUB_TOKEN", ""))

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -561,7 +561,7 @@ class Implementation:
 
         url = CONTAINER_PACKAGES_API / self.id / "versions"
         versions = SortedSet(
-            key=lambda version: ( # type: ignore[reportUnknownLambdaType]
+            key=lambda version: (  # type: ignore[reportUnknownLambdaType]
                 [
                     -int(part) if part.isdigit() else part
                     for part in cast(str, version).split(".")
@@ -578,15 +578,20 @@ class Implementation:
                     page: dict[str, Any],
                     session: GitHubSession,
                 ):
-                    super().__init__(page, session) # type: ignore[reportUnknownMemberType]
+                    super().__init__(page, session)  # type: ignore[reportUnknownMemberType]
                     self.tags = (
                         page.get(
-                                "metadata", {},
-                            ).get(
-                                "container", {},
-                            ).get(
-                                "tags", [],
-                            )
+                            "metadata",
+                            {},
+                        )
+                        .get(
+                            "container",
+                            {},
+                        )
+                        .get(
+                            "tags",
+                            [],
+                        )
                     )
 
             for page in GitHubIterator(  # type: ignore[reportUnknownVariableType]
@@ -595,10 +600,10 @@ class Implementation:
                 cls=_TagsWrapper,
                 session=gh.session,
             ):
-                versions.update( # type: ignore[reportUnknownMemberType]
+                versions.update(  # type: ignore[reportUnknownMemberType]
                     [
                         tag
-                        for tag in cast(Iterable[str], page.tags) # type: ignore[reportUnknownMemberType]
+                        for tag in cast(Iterable[str], page.tags)  # type: ignore[reportUnknownMemberType]
                         if "." in tag
                     ],
                 )

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -18,7 +18,7 @@ from url import URL
 import httpx
 import referencing_loaders
 
-from bowtie import HOMEPAGE
+from bowtie import HOMEPAGE, ORG_NAME
 from bowtie._commands import (
     START_V1,
     CaseErrored,
@@ -61,8 +61,7 @@ if TYPE_CHECKING:
     from bowtie._registry import ValidatorRegistry
     from bowtie._report import Reporter
 
-GITHUB_API = URL.parse("https://api.github.com/")
-ORG_API = GITHUB_API / "orgs" / "bowtie-json-schema"
+ORG_API = URL.parse("https://api.github.com/orgs/") / ORG_NAME
 CONTAINER_PACKAGES_API = ORG_API / "packages" / "container"
 
 

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import (
-    Iterable,
-)
+from collections.abc import Iterable
 from contextlib import asynccontextmanager
 from datetime import date
 from functools import cache

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -67,6 +67,7 @@ GITHUB_API = URL.parse("https://api.github.com/")
 ORG_API = GITHUB_API / "orgs" / "bowtie-json-schema"
 CONTAINER_PACKAGES_API = ORG_API / "packages" / "container"
 
+
 @frozen
 class Dialect:
     """
@@ -576,11 +577,7 @@ class Implementation:
                             page.as_dict()["metadata"]["container"]["tags"],
                         )
                         versions.update(  # type: ignore[reportUnknownMemberType]
-                            [
-                                tag
-                                for tag in tags
-                                if "." in tag
-                            ],
+                            [tag for tag in tags if "." in tag],
                         )
                     except KeyError:
                         continue
@@ -855,6 +852,7 @@ def convert_table_to_markdown(
 
     return f"\n{header}\n{separator}\n{body}"
 
+
 def version_key(reverse: bool):
     def key_func(version: str):
         parts = version.split(".")
@@ -868,4 +866,5 @@ def version_key(reverse: bool):
                 value = part
             result.append(value)
         return result
+
     return key_func

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -561,10 +561,10 @@ class Implementation:
 
         url = CONTAINER_PACKAGES_API / self.id / "versions"
         versions = SortedSet(
-            key=lambda version: (  # type: ignore[reportUnknownLambdaType]
+            key=lambda tag: (  # type: ignore[reportUnknownLambdaType]
                 [
                     -int(part) if part.isdigit() else part
-                    for part in cast(str, version).split(".")
+                    for part in cast(str, tag).split(".")
                 ]
             ),
         )

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -558,7 +558,7 @@ class Implementation:
         pages: list[GitHubCore] = []
         try:
             gh = GitHub(token=os.environ.get("GITHUB_TOKEN", ""))
-            pages = gh._iter(count=-1, url=str(url), cls=GitHubCore) # type: ignore[reportPrivateUsage]
+            pages = gh._iter(count=-1, url=str(url), cls=GitHubCore)  # type: ignore[reportPrivateUsage]
         except GitHubError:
             pass
 
@@ -579,7 +579,6 @@ class Implementation:
         return frozenset(
             sorted(versions, key=sortable_version_key, reverse=True),
         )
-
 
     async def validate(
         self,
@@ -853,7 +852,4 @@ def sortable_version_key(version: str):
     Generate a sortable key for version strings like "1.2.3".
     """
     parts = version.split(".")
-    return [
-        int(part) if part.isdigit() else part
-        for part in parts
-    ]
+    return [int(part) if part.isdigit() else part for part in parts]

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -543,7 +543,7 @@ class Implementation:
         """
         return self.info.dialects.issuperset(dialects)
 
-    async def get_versions(self):
+    async def get_versions(self) -> frozenset[zip[tuple[str, ...]]]:
         from github3 import GitHub  # type: ignore[reportMissingTypeStubs]
         from github3.exceptions import (  # type: ignore[reportMissingTypeStubs]
             GitHubError,
@@ -577,7 +577,9 @@ class Implementation:
             versions.add(self.info.version)
 
         return frozenset(
-            sorted(versions, key=sortable_version_key, reverse=True),
+            zip(
+                *zip(sorted(versions, key=sortable_version_key, reverse=True)),
+            ),
         )
 
     async def validate(

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -552,7 +552,7 @@ class Implementation:
 
         url = CONTAINER_PACKAGES_API / self.id / "versions"
 
-        gh = _github()
+        gh = github()
         pages: list[GitHubCore] = []
         with suppress(GitHubError):
             pages = gh._iter(count=-1, url=str(url), cls=GitHubCore)  # type: ignore[reportPrivateUsage]
@@ -848,7 +848,7 @@ def sortable_version_key(version: str):
     return [int(part) if part.isdigit() else part for part in parts]
 
 
-def _github():
+def github():
     """
     Construct a GitHub client, optionally looking for a token.
 

--- a/bowtie/_report.py
+++ b/bowtie/_report.py
@@ -13,7 +13,7 @@ from url import URL
 import structlog.stdlib
 
 from bowtie._commands import Seq, SeqCase, SeqResult, Unsuccessful
-from bowtie._core import Dialect, TestCase, version_key
+from bowtie._core import Dialect, TestCase, sortable_version_key
 from bowtie._direct_connectable import Direct
 
 if TYPE_CHECKING:
@@ -379,8 +379,9 @@ class Report:
         ]
         unsuccessful.sort(
             key=lambda version_compliance: (
-                version_key(reverse=True)(version_compliance[0])
+                sortable_version_key(version_compliance[0])
             ),
+            reverse=True,
         )
         return unsuccessful
 

--- a/bowtie/_report.py
+++ b/bowtie/_report.py
@@ -13,7 +13,7 @@ from url import URL
 import structlog.stdlib
 
 from bowtie._commands import Seq, SeqCase, SeqResult, Unsuccessful
-from bowtie._core import Dialect, TestCase
+from bowtie._core import Dialect, TestCase, version_key
 from bowtie._direct_connectable import Direct
 
 if TYPE_CHECKING:
@@ -378,13 +378,9 @@ class Report:
             if implementation.version is not None
         ]
         unsuccessful.sort(
-            key=lambda version: (
-                [
-                    int(part) if part.isdigit() else part
-                    for part in version[0].split(".")
-                ]
+            key=lambda version_compliance: (
+                version_key(reverse=True)(version_compliance[0])
             ),
-            reverse=True,
         )
         return unsuccessful
 

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -11,7 +11,6 @@ from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING
 import json
-import os
 import zipfile
 
 from diagnostic import DiagnosticError
@@ -20,7 +19,7 @@ import click
 import rich
 
 from bowtie import GITHUB
-from bowtie._core import Dialect, TestCase
+from bowtie._core import Dialect, TestCase, _github
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -65,12 +64,11 @@ class ClickParam(click.ParamType):
             cases, dialect = self._cases_and_dialect(path=Path(value))
             run_metadata = {}
         else:
-            from github3 import GitHub  # type: ignore[reportMissingTypeStubs]
             from github3.exceptions import (  # type: ignore[reportMissingTypeStubs]
                 NotFoundError,
             )
 
-            gh = GitHub(token=os.environ.get("GITHUB_TOKEN", ""))
+            gh = _github()
             org, repo_name, *rest = value.path_segments
             repo = gh.repository(org, repo_name)  # type: ignore[reportUnknownMemberType]
 

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -19,7 +19,7 @@ import click
 import rich
 
 from bowtie import GITHUB
-from bowtie._core import Dialect, TestCase, _github
+from bowtie._core import Dialect, TestCase, github
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -68,7 +68,7 @@ class ClickParam(click.ParamType):
                 NotFoundError,
             )
 
-            gh = _github()
+            gh = github()
             org, repo_name, *rest = value.path_segments
             repo = gh.repository(org, repo_name)  # type: ignore[reportUnknownMemberType]
 


### PR DESCRIPTION
![Screenshot (184)](https://github.com/user-attachments/assets/8e904c6c-baf2-4855-924c-892785e5f5a8)

@Julian I tried getting this to work.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1487.org.readthedocs.build/en/1487/

<!-- readthedocs-preview bowtie-json-schema end -->