### PR TITLE
Remove deprecated `rust-jsonschema` features

### DIFF
--- a/implementations/rust-jsonschema/Cargo.toml
+++ b/implementations/rust-jsonschema/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 backtrace = "0.3"
-jsonschema = { version = "0.19", features = [ "draft201909", "draft202012" ] }
+jsonschema = "0.19"
 serde_json = "1.0"
 url = "2.5.2"
 os_info = "3.8.2"


### PR DESCRIPTION
As of `0.19` these features are deprecated and related functionality is enabled by default.

Btw, I see that [the report](https://bowtie.report/#/implementations/rust-jsonschema) still shows data for `0.18.1`, even though there were some updates for `rust-jsonschema` merged here:

![image](https://github.com/user-attachments/assets/faaf283f-8f27-4ae4-b86e-0e589e4a8593)

Is there something I am missing? recently there were a few fixes, so I was wondering when the badges will reflect them :)

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1527.org.readthedocs.build/en/1527/

<!-- readthedocs-preview bowtie-json-schema end -->