### PR TITLE
Fix the Blaze run image to have `libstdc++`

### DIFF
--- a/implementations/cpp-blaze/Dockerfile
+++ b/implementations/cpp-blaze/Dockerfile
@@ -14,5 +14,6 @@ RUN cmake -S /tmp -B /tmp/build -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED
 RUN cmake --build /tmp/build --config Release --parallel 4
 
 FROM alpine:3.20
+RUN apk add --no-cache libstdc++ libgcc
 COPY --from=builder /tmp/build/bowtie_blaze /usr/local/bin/bowtie
 CMD [ "bowtie" ]


### PR DESCRIPTION
See: https://github.com/bowtie-json-schema/bowtie/pull/1593#issuecomment-2418082033

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1607.org.readthedocs.build/en/1607/

<!-- readthedocs-preview bowtie-json-schema end -->