### PR TITLE
Fix bug in hyperjump harness

### DIFF
--- a/implementations/js-hyperjump/bowtie_hyperjump.js
+++ b/implementations/js-hyperjump/bowtie_hyperjump.js
@@ -2,6 +2,7 @@ import readline from "readline/promises";
 import os from "os";
 import process from "process";
 import { createRequire } from "node:module";
+import * as semver from "semver";
 const packageJson = createRequire(import.meta.url)(
   "./node_modules/@hyperjump/json-schema/package.json",
 );
@@ -14,7 +15,7 @@ var unregisterSchema;
 var getRetrievalURI;
 
 await (async () => {
-  if (hyperjump_version >= "1.7.0") {
+  if (semver.satisfies(hyperjump_version, ">=1.7.0")) {
     await Promise.all([
       import("@hyperjump/json-schema/draft-2019-09"),
       import("@hyperjump/json-schema/draft-07"),
@@ -40,7 +41,7 @@ await (async () => {
     getRetrievalURI = (_, __, args) =>
       `https://example.com/bowtie-sent-schema-${args.seq.toString()}`;
   } else {
-    if (hyperjump_version >= "1.0.0") {
+    if (semver.satisfies(hyperjump_version, ">=1.0.0")) {
       await Promise.all([
         import("@hyperjump/json-schema/draft-2019-09"),
         import("@hyperjump/json-schema/draft-07"),
@@ -60,7 +61,7 @@ await (async () => {
 
         return await JsonSchema.validate(retrievalURI);
       };
-    } else if (hyperjump_version >= "0.18.0") {
+    } else if (semver.satisfies(hyperjump_version, ">=0.18.0")) {
       const JsonSchema = await import("@hyperjump/json-schema");
 
       registerSchemaAndValidate = async (testCase, dialect, retrievalURI) => {

--- a/implementations/js-hyperjump/package.json
+++ b/implementations/js-hyperjump/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "@hyperjump/json-schema": "^1.0.0"
+    "@hyperjump/json-schema": "^1.0.0",
+    "semver": "^7.6.3"
   }
 }


### PR DESCRIPTION
String comparison is not sufficient for version checks. The current code broke when I added v1.10.0.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1747.org.readthedocs.build/en/1747/

<!-- readthedocs-preview bowtie-json-schema end -->