### PR TITLE
fix: match dialects dropdown position

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -99,11 +99,6 @@ const NavBar = () => {
               )}
               {isBenchmarksPage && (
                 <>
-                  <li className="nav-item">
-                    <Link className="nav-link" to="/">
-                      Dialect Test Reports
-                    </Link>
-                  </li>
                   <NavDropdown title="Dialects" id="dialect-dropdown">
                     {Dialect.newestToOldest().map((dialect) => (
                       <NavDropdown.Item
@@ -115,6 +110,11 @@ const NavBar = () => {
                       </NavDropdown.Item>
                     ))}
                   </NavDropdown>
+                  <li className="nav-item">
+                    <Link className="nav-link" to="/">
+                      Dialect Test Reports
+                    </Link>
+                  </li>
                 </>
               )}
               <li className="nav-item d-block d-lg-none">


### PR DESCRIPTION
I think it might look better if the position of the dialects dropdown is consistent between the dialect and benchmarks page.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1810.org.readthedocs.build/en/1810/

<!-- readthedocs-preview bowtie-json-schema end -->