### PR TITLE
build: Move from dev-master to 6.1 version

### DIFF
--- a/implementations/php-justinrainbow-json-schema/composer.json
+++ b/implementations/php-justinrainbow-json-schema/composer.json
@@ -3,7 +3,7 @@
   "description": "These sources contains the test harness implementation for Bowtie",
   "license": "MIT",
   "require": {
-    "justinrainbow/json-schema": "dev-master"
+    "justinrainbow/json-schema": "^6.1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.10"


### PR DESCRIPTION
This is following up on https://github.com/bowtie-json-schema/bowtie/pull/1512 and moves from the `dev-master` version to the version `6.1`