### PR TITLE
Use GitHub packages API to collect known implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,6 @@ jobs:
       contents: write
       id-token: write
       attestations: write
-      packages: read
 
     steps:
       - uses: actions/checkout@v4
@@ -170,7 +169,7 @@ jobs:
 
       - name: Build our distributions
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
         run: uv run --frozen --with 'build[uv]' -m build --installer=uv
 
       - name: Generate attestation for wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run nox
         env:
-          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uvx nox -s "${{ matrix.noxenv }}"
 
       - name: Upload Playwright Report
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run nox
         env:
-          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uvx nox -s tests-3.13 -- -m 'not containers'
 
   coverage:
@@ -173,7 +173,7 @@ jobs:
 
       - name: Build our distributions
         env:
-          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run --frozen --with 'build[uv]' -m build --installer=uv
 
       - name: Generate attestation for wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,20 @@ jobs:
           BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run --frozen --with 'build[uv]' -m build --installer=uv
 
+        # this is temporal step to make sure we don't lose any of the implementations during migration
+        # remove once all implementations are successfully migrated to separate repos
+      - name: Collect known implementations
+        env:
+          BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_IMPL_COUNT: 32
+        run: |
+          impl_count=$(uvx --from . --python 3.13 bowtie filter-implementations --format plain | wc -l)
+          if [ $impl_count -lt $EXPECTED_IMPL_COUNT ]; then
+            echo "bowtie collected less implementations than expected: $impl_count instead of $EXPECTED_IMPL_COUNT" >> $GITHUB_STEP_SUMMARY
+            uvx --from . --python 3.13 bowtie filter-implementations --format plain >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
       - name: Generate attestation for wheels
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         uses: actions/attest-build-provenance@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      packages: read
 
     steps:
       - uses: actions/checkout@v4
@@ -168,6 +169,8 @@ jobs:
           enable-cache: true
 
       - name: Build our distributions
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: uv run --frozen --with 'build[uv]' -m build --installer=uv
 
       - name: Generate attestation for wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Build our distributions
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run --frozen --with 'build[uv]' -m build --installer=uv
 
       - name: Generate attestation for wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run nox
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uvx nox -s "${{ matrix.noxenv }}"
 
       - name: Upload Playwright Report
@@ -109,7 +109,7 @@ jobs:
 
       - name: Run nox
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uvx nox -s tests-3.13 -- -m 'not containers'
 
   coverage:
@@ -173,7 +173,7 @@ jobs:
 
       - name: Build our distributions
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run --frozen --with 'build[uv]' -m build --installer=uv
 
       - name: Generate attestation for wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
           enable-cache: true
 
       - name: Run nox
+        env:
+          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
         run: uvx nox -s "${{ matrix.noxenv }}"
 
       - name: Upload Playwright Report
@@ -106,6 +108,8 @@ jobs:
         run: sudo apt-get purge docker podman
 
       - name: Run nox
+        env:
+          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
         run: uvx nox -s tests-3.13 -- -m 'not containers'
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run --frozen --with 'build[uv]' -m build --installer=uv
 
-        # this is temporal step to make sure we don't lose any of the implementations during migration
+        # this is temporary step to make sure we don't lose any of the implementations during migration
         # remove once all implementations are successfully migrated to separate repos
       - name: Collect known implementations
         env:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -51,8 +51,12 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Calculate which impages to build
+      - name: Calculate which images to build
         id: images-matrix
+        env:
+          # The token is required because bowtie is built during the step,
+          # and we need access to packages to collect known implementations
+          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
         run: |
           implementation=${{ inputs.implementation }}
           version=${{ inputs.version }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           # The token is required because bowtie is built during the step,
           # and we need access to packages to collect known implementations
-          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           implementation=${{ inputs.implementation }}
           version=${{ inputs.version }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           # The token is required because bowtie is built during the step,
           # and we need access to packages to collect known implementations
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           implementation=${{ inputs.implementation }}
           version=${{ inputs.version }}

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -4,6 +4,8 @@ Bowtie's Hatchling plugin, used for pregenerating implementation data.
 
 from __future__ import annotations
 
+import os
+import requests
 from pathlib import Path
 from typing import Any
 import json
@@ -37,6 +39,8 @@ class BowtieDataIncluder(BuildHookInterface):
         path = Path(__file__).parent.joinpath("implementations")
         known = [d.name for d in path.iterdir() if not d.name.startswith(".")]
 
+        known = self._known_implementations_from_packages_api(known)
+
         target_path = "bowtie/data/known_implementations.json"
 
         out = self.known_implementations()
@@ -53,3 +57,61 @@ class BowtieDataIncluder(BuildHookInterface):
         Clean up any generated temporary files.
         """
         self.known_implementations().unlink()
+
+    @staticmethod
+    def _known_implementations_from_packages_api(known_local: list[str]) -> list[str]:
+        """
+        Collects available implementation using GitHub packages API.
+        """
+        gh_token_env_var = "GITHUB_TOKEN"
+        gh_token = os.getenv(gh_token_env_var)
+
+        if not gh_token:
+            print(f"WARN: {gh_token_env_var} env variable was not provided. "
+                  f"It will be REQUIRED in the future to collect known implementations")
+            return known_local
+
+        try:
+            packages = BowtieDataIncluder._collect_packages(gh_token)
+        except requests.HTTPError as e:
+            print(f"ERROR: fallback to using local implementations: {e.response.text}")
+            return known_local
+
+        packages_set = set(packages)
+        local_set = set(known_local)
+        if not packages_set.issuperset(local_set):
+            print(f"WARN: local implementations contain additional implementations: {local_set.difference(packages_set)}")
+            # return local implementation until fully migrated to packages API
+            # https://github.com/bowtie-json-schema/bowtie/issues/1849
+            return known_local
+
+        return packages
+
+    @staticmethod
+    def _collect_packages(gh_token):
+        packages = []
+        page = 1
+        while True:
+            # https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#list-packages-for-an-organization
+            response = requests.get(
+                url="https://api.github.com/orgs/bowtie-json-schema/packages",
+                params={
+                    "package_type": "container",
+                    "page": page,
+                },
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    "Authorization": f"Bearer {gh_token}"
+                }
+            )
+
+            with response:
+                response.raise_for_status()
+                payload = response.json()
+
+            packages.extend(p["name"] for p in payload)
+            page += 1
+            if not payload:
+                break
+        return packages

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -72,7 +72,8 @@ class BowtieDataIncluder(BuildHookInterface):
         marked with 'bowtie-harness' topic.
         """
         gh_token = os.getenv(
-            "BUILD_GITHUB_TOKEN", default=os.getenv("GITHUB_TOKEN")
+            "BUILD_GITHUB_TOKEN",
+            default=os.getenv("GITHUB_TOKEN"),
         )
 
         if not gh_token:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -79,8 +79,7 @@ class BowtieDataIncluder(BuildHookInterface):
             packages = self._collect_packages(gh_token)
         except requests.HTTPError as e:
             self.app.display_error(
-                f"fallback to using local implementations: "
-                f"params={e.request.params}"
+                f"fallback to using local implementations: {e}"
                 f"{e.response.text}",
             )
             return known_local

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -71,11 +71,12 @@ class BowtieDataIncluder(BuildHookInterface):
         The method uses GitHub repositories API to filter our repositories
         marked with 'bowtie-harness' topic.
         """
-        gh_token = os.getenv("GITHUB_TOKEN")
+        gh_token = os.getenv("BUILD_GITHUB_TOKEN",
+                             default=os.getenv("GITHUB_TOKEN"))
 
         if not gh_token:
             self.app.display_warning(
-                "GITHUB_TOKEN is not provided. "
+                "neither BUILD_GITHUB_TOKEN nor GITHUB_TOKEN are provided. "
                 "You can reach the GitHub rate limit",
             )
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -79,8 +79,8 @@ class BowtieDataIncluder(BuildHookInterface):
             packages = self._collect_packages(gh_token)
         except requests.HTTPError as e:
             self.app.display_error(
-                f"fallback to using local implementations: {e}"
-                f"{e.response.text}",
+                f"fallback to using local implementations: {e} "
+                f"({e.response.text})",
             )
             return known_local
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -59,7 +59,8 @@ class BowtieDataIncluder(BuildHookInterface):
         self.known_implementations().unlink()
 
     def _known_implementations_from_packages_api(
-        self, known_local: list[str],
+        self,
+        known_local: list[str],
     ) -> list[str]:
         """
         Collects available implementation using GitHub packages API.

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -111,5 +111,6 @@ class BowtieDataIncluder(BuildHookInterface):
         )
         return [p["name"] for p in packages_iter]
 
+
 class _TokenNotProvidedException(Exception):
     pass

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -76,10 +76,11 @@ class BowtieDataIncluder(BuildHookInterface):
             return known_local
 
         try:
-            packages = BowtieDataIncluder._collect_packages(gh_token)
+            packages = self._collect_packages(gh_token)
         except requests.HTTPError as e:
             self.app.display_error(
                 f"fallback to using local implementations: "
+                f"params={e.request.params}"
                 f"{e.response.text}",
             )
             return known_local
@@ -97,8 +98,7 @@ class BowtieDataIncluder(BuildHookInterface):
 
         return packages
 
-    @staticmethod
-    def _collect_packages(gh_token):
+    def _collect_packages(self, gh_token):
         packages = []
         page = 1
         while True:
@@ -120,6 +120,7 @@ class BowtieDataIncluder(BuildHookInterface):
             with response:
                 response.raise_for_status()
                 payload = response.json()
+                self.app.display_info(f"{payload}")
 
             packages.extend(p["name"] for p in payload)
             page += 1

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -25,9 +25,9 @@ class BowtieDataIncluder(BuildHookInterface):
         return Path(self.directory) / "known_implementations.json"
 
     def initialize(
-            self,
-            version: str,
-            build_data: dict[str, Any],
+        self,
+        version: str,
+        build_data: dict[str, Any],
     ) -> None:
         """
         Tell Hatchling to store data we'll need at runtime within the package.
@@ -48,10 +48,10 @@ class BowtieDataIncluder(BuildHookInterface):
         build_data["force_include"][str(out)] = target_path
 
     def finalize(
-            self,
-            version: str,
-            build_data: dict[str, Any],
-            artifact_path: str,
+        self,
+        version: str,
+        build_data: dict[str, Any],
+        artifact_path: str,
     ) -> None:
         """
         Clean up any generated temporary files.
@@ -59,7 +59,8 @@ class BowtieDataIncluder(BuildHookInterface):
         self.known_implementations().unlink()
 
     def _known_implementations_from_packages_api(
-            self, known_local: list[str]) -> list[str]:
+        self, known_local: list[str]
+    ) -> list[str]:
         """
         Collects available implementation using GitHub packages API.
         """
@@ -76,8 +77,10 @@ class BowtieDataIncluder(BuildHookInterface):
         try:
             packages = BowtieDataIncluder._collect_packages(gh_token)
         except requests.HTTPError as e:
-            self.app.display_error(f"fallback to using local implementations: "
-                                   f"{e.response.text}")
+            self.app.display_error(
+                f"fallback to using local implementations: "
+                f"{e.response.text}"
+            )
             return known_local
 
         packages_set = set(packages)
@@ -85,7 +88,8 @@ class BowtieDataIncluder(BuildHookInterface):
         if not packages_set.issuperset(local_set):
             self.app.display_warning(
                 f"local implementations contain additional implementations: "
-                f"{local_set.difference(packages_set)}")
+                f"{local_set.difference(packages_set)}"
+            )
             # return local implementation until fully migrated to packages API
             # https://github.com/bowtie-json-schema/bowtie/issues/1849
             return known_local

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -98,11 +98,9 @@ class BowtieDataIncluder(BuildHookInterface):
 
         # join with local implementation until fully migrated to packages API
         # https://github.com/bowtie-json-schema/bowtie/issues/1849
-        all_harnesses = list(local_set.union(harnesses_set))
         # sorting is done just to simplify debugging
         # if some harnesses are missed for some reason
-        all_harnesses.sort()
-        return all_harnesses
+        return sorted(local_set | harnesses_set)
 
     @staticmethod
     def _collect_harnesses(gh_token) -> list[str]:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -4,13 +4,13 @@ Bowtie's Hatchling plugin, used for pregenerating implementation data.
 
 from __future__ import annotations
 
-import os
-import requests
 from pathlib import Path
 from typing import Any
 import json
+import os
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+import requests
 
 
 class BowtieDataIncluder(BuildHookInterface):
@@ -25,9 +25,9 @@ class BowtieDataIncluder(BuildHookInterface):
         return Path(self.directory) / "known_implementations.json"
 
     def initialize(
-        self,
-        version: str,
-        build_data: dict[str, Any],
+            self,
+            version: str,
+            build_data: dict[str, Any],
     ) -> None:
         """
         Tell Hatchling to store data we'll need at runtime within the package.
@@ -48,39 +48,44 @@ class BowtieDataIncluder(BuildHookInterface):
         build_data["force_include"][str(out)] = target_path
 
     def finalize(
-        self,
-        version: str,
-        build_data: dict[str, Any],
-        artifact_path: str,
+            self,
+            version: str,
+            build_data: dict[str, Any],
+            artifact_path: str,
     ) -> None:
         """
         Clean up any generated temporary files.
         """
         self.known_implementations().unlink()
 
-    @staticmethod
-    def _known_implementations_from_packages_api(known_local: list[str]) -> list[str]:
+    def _known_implementations_from_packages_api(
+            self, known_local: list[str]) -> list[str]:
         """
         Collects available implementation using GitHub packages API.
         """
-        gh_token_env_var = "GITHUB_TOKEN"
-        gh_token = os.getenv(gh_token_env_var)
+        gh_token = os.getenv("GITHUB_TOKEN")
 
         if not gh_token:
-            print(f"WARN: {gh_token_env_var} env variable was not provided. "
-                  f"It will be REQUIRED in the future to collect known implementations")
+            self.app.display_warning(
+                "GITHUB_TOKEN env variable was not provided. "
+                "It will be REQUIRED in the future "
+                "to collect known implementations",
+            )
             return known_local
 
         try:
             packages = BowtieDataIncluder._collect_packages(gh_token)
         except requests.HTTPError as e:
-            print(f"ERROR: fallback to using local implementations: {e.response.text}")
+            self.app.display_error(f"fallback to using local implementations: "
+                                   f"{e.response.text}")
             return known_local
 
         packages_set = set(packages)
         local_set = set(known_local)
         if not packages_set.issuperset(local_set):
-            print(f"WARN: local implementations contain additional implementations: {local_set.difference(packages_set)}")
+            self.app.display_warning(
+                f"local implementations contain additional implementations: "
+                f"{local_set.difference(packages_set)}")
             # return local implementation until fully migrated to packages API
             # https://github.com/bowtie-json-schema/bowtie/issues/1849
             return known_local
@@ -94,6 +99,7 @@ class BowtieDataIncluder(BuildHookInterface):
         while True:
             # https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#list-packages-for-an-organization
             response = requests.get(
+                timeout=10,
                 url="https://api.github.com/orgs/bowtie-json-schema/packages",
                 params={
                     "package_type": "container",
@@ -102,8 +108,8 @@ class BowtieDataIncluder(BuildHookInterface):
                 headers={
                     "Accept": "application/vnd.github+json",
                     "X-GitHub-Api-Version": "2022-11-28",
-                    "Authorization": f"Bearer {gh_token}"
-                }
+                    "Authorization": f"Bearer {gh_token}",
+                },
             )
 
             with response:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -93,6 +93,7 @@ class BowtieDataIncluder(BuildHookInterface):
         harnesses_set = set(harnesses)
         local_set = set(known_local)
         if harnesses_set.issubset(local_set):
+            known_local.sort()
             return known_local
 
         # join with local implementation until fully migrated to packages API

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -59,7 +59,7 @@ class BowtieDataIncluder(BuildHookInterface):
         self.known_implementations().unlink()
 
     def _known_implementations_from_packages_api(
-        self, known_local: list[str]
+        self, known_local: list[str],
     ) -> list[str]:
         """
         Collects available implementation using GitHub packages API.
@@ -79,7 +79,7 @@ class BowtieDataIncluder(BuildHookInterface):
         except requests.HTTPError as e:
             self.app.display_error(
                 f"fallback to using local implementations: "
-                f"{e.response.text}"
+                f"{e.response.text}",
             )
             return known_local
 
@@ -88,7 +88,7 @@ class BowtieDataIncluder(BuildHookInterface):
         if not packages_set.issuperset(local_set):
             self.app.display_warning(
                 f"local implementations contain additional implementations: "
-                f"{local_set.difference(packages_set)}"
+                f"{local_set.difference(packages_set)}",
             )
             # return local implementation until fully migrated to packages API
             # https://github.com/bowtie-json-schema/bowtie/issues/1849

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -113,7 +113,7 @@ class BowtieDataIncluder(BuildHookInterface):
                 headers={
                     "Accept": "application/vnd.github+json",
                     "X-GitHub-Api-Version": "2022-11-28",
-                    "Authorization": f"Bearer {gh_token}",
+                    "Authorization": f"Token {gh_token}",
                 },
             )
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -71,8 +71,9 @@ class BowtieDataIncluder(BuildHookInterface):
         The method uses GitHub repositories API to filter our repositories
         marked with 'bowtie-harness' topic.
         """
-        gh_token = os.getenv("BUILD_GITHUB_TOKEN",
-                             default=os.getenv("GITHUB_TOKEN"))
+        gh_token = os.getenv(
+            "BUILD_GITHUB_TOKEN", default=os.getenv("GITHUB_TOKEN")
+        )
 
         if not gh_token:
             self.app.display_warning(
@@ -106,6 +107,8 @@ class BowtieDataIncluder(BuildHookInterface):
         gh = login(token=gh_token) if gh_token else GitHub()
         org = gh.organization("bowtie-json-schema")
         repositories = org.repositories()
+
         def is_harness(repo) -> bool:
             return "bowtie-harness" in repo.topics().names
+
         return [repo.name for repo in repositories if is_harness(repo)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = ["bowtie"]
 
 [tool.hatch.build.targets.wheel.hooks.custom]
 dependencies = [
-  "requests"
+  "github3.py"
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ exclude = [".github"]
 packages = ["bowtie"]
 
 [tool.hatch.build.targets.wheel.hooks.custom]
+dependencies = [
+  "requests"
+]
 
 [tool.hatch.build.targets.wheel.force-include]
 data = "bowtie/data"


### PR DESCRIPTION
A part of POC #1849 is a modification of how bowtie collects the information about known implementation.
This PR adds functionality to collect known implementations using [GitHub Packages API](https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#list-packages-for-an-organization).

I am not a Python developer - sorry in advance if I made some stupid mistakes)

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1867.org.readthedocs.build/en/1867/

<!-- readthedocs-preview bowtie-json-schema end -->