### PR TITLE
chore: fix pytest warnings

### DIFF
--- a/bowtie/tests/test_benchmarks.py
+++ b/bowtie/tests/test_benchmarks.py
@@ -7,6 +7,9 @@ from bowtie import HOMEPAGE, REPO, _benchmarks, benchmarks
 from bowtie._core import Dialect, ImplementationInfo, TestCase
 from bowtie._direct_connectable import Direct
 
+# Make pytest ignore this class matching Test*
+TestCase.__test__ = False
+
 validators = Direct.from_id("python-jsonschema").registry()
 
 benchmark_report_validator = validators.for_uri(

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -35,9 +35,10 @@ from bowtie._direct_connectable import IMPLEMENTATIONS as KNOWN_DIRECT, Direct
 from bowtie._report import EmptyReport, InvalidReport, Report
 from bowtie.tests import miniatures as _miniatures
 
-Test.__test__ = TestCase.__test__ = TestResult.__test__ = (
-    False  # frigging py.test
-)
+# Make pytest ignore these classes matching Test*
+Test.__test__ = False
+TestCase.__test__ = False
+TestResult.__test__ = False
 
 
 HERE = Path(__file__).parent

--- a/bowtie/tests/test_report.py
+++ b/bowtie/tests/test_report.py
@@ -8,7 +8,9 @@ from bowtie._core import Dialect, Example, ImplementationInfo, TestCase
 from bowtie._report import Report, RunMetadata
 from bowtie.hypothesis import dialects, implementations, known_dialects
 
-TestCase.__test__ = False  # frigging py.test
+# Make pytest ignore these classes matching Test*
+TestCase.__test__ = False
+TestResult.__test__ = False
 
 
 DIALECT_2020, DIALECT_2019 = (


### PR DESCRIPTION
Fixes pytest warning:
```
=============================== warnings summary ===============================
bowtie/_core.py:721
  /home/runner/work/bowtie/bowtie/bowtie/_core.py:721: PytestCollectionWarning: cannot collect test class 'TestCase' because it has a __init__ constructor (from: bowtie/tests/test_benchmarks.py)
    @frozen

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1868.org.readthedocs.build/en/1868/

<!-- readthedocs-preview bowtie-json-schema end -->