### PR TITLE
Enable cross-platform compilation for golang implementations

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -136,7 +136,9 @@ jobs:
             || (inputs.implementation)
           )
           && !startsWith(matrix.image, 'dotnet-')
+          && !startsWith(matrix.image, 'go-')
         # See https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/ for why not .NET
+        # See https://docs.docker.com/build/building/multi-platform/#cross-compiling-a-go-application for why not Golang
 
       - name: Build
         id: build_image

--- a/implementations/go-gojsonschema/Dockerfile
+++ b/implementations/go-gojsonschema/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.20-buster AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20-buster AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /usr/src/app
 
@@ -7,7 +9,7 @@ RUN go mod download && go mod verify
 
 COPY . .
 
-RUN go build -v -o bowtie-gojsonschema
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o bowtie-gojsonschema
 
 FROM gcr.io/distroless/base-debian10
 COPY --from=builder /usr/src/app/bowtie-gojsonschema /usr/local/bin/

--- a/implementations/go-jsonschema/Dockerfile
+++ b/implementations/go-jsonschema/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /usr/src/app
 
@@ -7,7 +9,7 @@ RUN go mod download && go mod verify
 
 COPY . .
 
-RUN go build -v -o bowtie-jsonschema
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o bowtie-jsonschema
 
 FROM gcr.io/distroless/base-debian10
 COPY --from=builder /usr/src/app/bowtie-jsonschema /usr/local/bin/


### PR DESCRIPTION
This PR updated Dockerfiles for golang harnesses to support cross-platform compilation. QEMU is not required in this case and can be disabled

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1885.org.readthedocs.build/en/1885/

<!-- readthedocs-preview bowtie-json-schema end -->