### PR TITLE
Fix TC006 and C420 ruff alerts

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1702,7 +1702,7 @@ def _info_table_for(metadata: dict[str, Any]):
         "dialects",
         "\n".join(
             Dialect.from_str(dialect).pretty_name
-            for dialect in cast(list[str], metadata.get("dialects"))
+            for dialect in cast("list[str]", metadata.get("dialects"))
         ),
         end_section=True,
     )
@@ -2101,7 +2101,7 @@ class _VersionedReportsTar(click.File):
         input = super().convert(value, param, ctx)
 
         id = cast(
-            _connectables.Connectable,
+            "_connectables.Connectable",
             ctx.params.get("connectable"),
         ).to_terse()
 
@@ -2166,7 +2166,7 @@ class _VersionedReportsTar(click.File):
                 )
                 dialects = (
                     cast(
-                        Iterable[Dialect] | None,
+                        "Iterable[Dialect] | None",
                         ctx.params.get("dialects"),
                     )
                     or Dialect.known()

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from contextlib import asynccontextmanager, suppress
 from datetime import date
 from functools import cache
@@ -40,6 +39,7 @@ if TYPE_CHECKING:
     from collections.abc import (
         AsyncIterator,
         Callable,
+        Iterable,
         Mapping,
         Sequence,
         Set,
@@ -76,7 +76,7 @@ class Dialect:
     short_name: str = field(repr=False)
     first_publication_date: date = field(repr=False)
     aliases: Set[str] = field(
-        default=cast(frozenset[str], frozenset()),
+        default=cast("frozenset[str]", frozenset()),
         repr=False,
     )
     has_boolean_schemas: bool = field(default=True, repr=False)
@@ -560,7 +560,7 @@ class Implementation:
         for page in pages:
             try:
                 tags = cast(
-                    Iterable[str],
+                    "Iterable[str]",
                     page.as_dict()["metadata"]["container"]["tags"],
                 )
             except KeyError:

--- a/bowtie/benchmarks/keywords/additionalProperties.py
+++ b/bowtie/benchmarks/keywords/additionalProperties.py
@@ -103,4 +103,4 @@ def get_benchmark():
 
 
 def _format_properties_as_instance(properties):
-    return {key: 1000 for key in properties}
+    return dict.fromkeys(properties, 1000)


### PR DESCRIPTION
PR fixes newly reported alerts:

- [TC006](https://docs.astral.sh/ruff/rules/runtime-cast-value/) [*] Add quotes to type expression in `typing.cast()`
- [C420](https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/) [*] Unnecessary dict comprehension for iterable; use `dict.fromkeys`

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1890.org.readthedocs.build/en/1890/

<!-- readthedocs-preview bowtie-json-schema end -->