### PR TITLE
Use GH API to collect versions from remote test harnesses

### DIFF
--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -29,7 +29,7 @@ jobs:
       - name: List all Bowtie Supported Implementations having a "matrix-versions.json" file
         id: implementations-matrix
         env:
-          GH_TOKEN: ${{ github.token }} # for GH API access
+          GH_TOKEN: ${{ github.token }} # because we use gh CLI in the script (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows)
         run: |
           implementation=${{ inputs.implementation }}
           IMPLEMENTATIONS=$(bowtie filter-implementations --format json)
@@ -93,7 +93,7 @@ jobs:
       - name: Generate New Versioned Reports for all Supported Dialects of ${{ matrix.implementation }}
         id: generate-new-versioned-report
         env:
-          GH_TOKEN: ${{ github.token }} # for GH API access
+          GH_TOKEN: ${{ github.token }} # because we use gh CLI in the script (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows)
         run: |
           impl=${{ matrix.implementation }}
           MATRIX_VERSIONS_FILE="implementations/$impl/matrix-versions.json"


### PR DESCRIPTION
The PR adds a collection of version information from remote test harnesses. It collects all available version tags (like `harness-release-*`), plus it uses the `latest` tag to get the latest available test harness version.

Related to #1849 

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1916.org.readthedocs.build/en/1916/

<!-- readthedocs-preview bowtie-json-schema end -->