### PR TITLE
Fix version displayed for PHP JustinRainbow Json-Schema

### DIFF
--- a/implementations/php-justinrainbow-json-schema/Dockerfile
+++ b/implementations/php-justinrainbow-json-schema/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /usr/src/json-schema
 
 COPY ./src ./src
 COPY ./bootstrap.php .
+COPY composer.* .
 COPY --from=builder /usr/src/json-schema/vendor /usr/src/json-schema/vendor
 
 CMD ["php", "bootstrap.php"]


### PR DESCRIPTION
Due to missing composer files the container reported `dev-master` in the start command reply instead of the installed version.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1917.org.readthedocs.build/en/1917/

<!-- readthedocs-preview bowtie-json-schema end -->