### PR TITLE
fix: fixes a missing new line before the h3 and wrap schema in a codefence in bowtie summary command

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -852,7 +852,9 @@ def _validation_results_table_in_markdown(
         rows_data.append(row_data)
 
     for idx, row_data in enumerate(rows_data):
-        final_content += f"### {idx+1}. Schema:\n ```json\n{row_data[0]}\n```\n\n"
+        final_content += (
+            f"### {idx+1}. Schema:\n ```json\n{row_data[0]}\n```\n\n"
+        )
         final_content += "### Results:"
         final_content += row_data[1]
         final_content += "\n"

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -852,9 +852,10 @@ def _validation_results_table_in_markdown(
         rows_data.append(row_data)
 
     for idx, row_data in enumerate(rows_data):
-        final_content += f"### {idx+1}. Schema:\n {row_data[0]}\n\n"
+        final_content += f"### {idx+1}. Schema:\n ```\n{row_data[0]}\n```\n\n"
         final_content += "### Results:"
         final_content += row_data[1]
+        final_content += "\n"
 
     return final_content
 

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -852,7 +852,7 @@ def _validation_results_table_in_markdown(
         rows_data.append(row_data)
 
     for idx, row_data in enumerate(rows_data):
-        final_content += f"### {idx+1}. Schema:\n ```\n{row_data[0]}\n```\n\n"
+        final_content += f"### {idx+1}. Schema:\n ```json\n{row_data[0]}\n```\n\n"
         final_content += "### Results:"
         final_content += row_data[1]
         final_content += "\n"


### PR DESCRIPTION
I was testing with the summary output in Markdown and notice an issue with the header for each schema. As it was without a newline and directly added to the end of the earlier output, which in this case was a table. While fixing this I also noticed the schema was without a code fence so I've added them as well.

<details><summary>Misformatted Markdown</summary>
<p>
See the final line where the header is added directly after the table.
```
### 1. Schema:
{
  "items": [
    {}
  ],
  "additionalItems": {
    "type": "integer"
  }
}

### Results:
| Instance | justinrainbow-json-schema (php) |
|:-------------------:|:-------:|
|      |  valid  |
|  | invalid |### 2. Schema:
```

</p>
</details> 

This is my first time contributing to Python code. So could be it requires some tweaks, in which case just let me know.


<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1918.org.readthedocs.build/en/1918/

<!-- readthedocs-preview bowtie-json-schema end -->