### PR TITLE
Add schedule trigger for versioned report workflow

### DIFF
--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -3,6 +3,9 @@
 name: Collect New Versioned Test Results
 
 on:
+  schedule:
+    # every Sunday at 23:30 UTC (45 minutes before a report workflow is scheduled)
+    - cron: "30 23 * * 0"
   workflow_dispatch:
     inputs:
       implementation:


### PR DESCRIPTION
PR adds a schedule trigger to the [versioned-report.yml](https://github.com/bowtie-json-schema/bowtie/blob/main/.github/workflows/versioned-report.yml) workflow (as suggested in #1915).

The automatic build is scheduled for Sunday at 23:30 (45 minutes before the report workflow is scheduled) to provide the fresh artifacts with versioned reports (the latest versioned report runs took about 40 minutes, so I have added 5 more minutes just in case).

I don't think there is a point in triggering the workflow more often than once a week - we don't have many test harnesses with different versions' support

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1920.org.readthedocs.build/en/1920/

<!-- readthedocs-preview bowtie-json-schema end -->