### PR TITLE
Provide GITHUB_TOKEN during test suite execution

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -19,8 +19,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -198,6 +196,9 @@ jobs:
           path: site
 
   redeploy-frontend:
+    permissions:
+      pages: write
+      id-token: write
     needs: site
     uses: ./.github/workflows/ui.yml
     with:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -55,6 +55,8 @@ jobs:
           version: ${{ inputs.bowtie-version }}
 
       - name: Generate a New Report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           bowtie suite $(bowtie filter-implementations | sed 's/^/-i /') https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/${{ matrix.version }} >${{ matrix.version }}.json
 


### PR DESCRIPTION
The PR adds a GITHUB_TOKEN into env variables during test suite execution. There is a chance that without a token we hit a rate limit. Example here:
https://github.com/bowtie-json-schema/bowtie/actions/runs/14143123995/job/39627152056

PR also reduces the scope of write permissions only to the job responsible for site deployment

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1922.org.readthedocs.build/en/1922/

<!-- readthedocs-preview bowtie-json-schema end -->