### PR TITLE
fix: correctly set passed schema and all schemas from registry

### DIFF
--- a/implementations/php-justinrainbow-json-schema/src/TestHarness.php
+++ b/implementations/php-justinrainbow-json-schema/src/TestHarness.php
@@ -107,13 +107,19 @@ class TestHarness
     {
         $this->debug('Running test case');
 
-        $schemaStorage = new SchemaStorage();
-        $validator = new Validator(new Factory($schemaStorage));
-
         $results = [];
 
+        $schemaStorage = new SchemaStorage();
+        $validator = new Validator(new Factory($schemaStorage));
+        $schemaStorage->addSchema('internal://mySchema', $request->case->schema);
+
+        if (isset($request->case->registry)) {
+            foreach ($request->case->registry as $id => $schema) {
+                $schemaStorage->addSchema($id, $schema);
+            }
+        }
+
         foreach ($request->case->tests as $test) {
-            $schemaStorage->addSchema('internal://mySchema', $test);
             try {
                 $validator->validate(
                     $test->instance,


### PR DESCRIPTION
Previously a incorrect schema was registered in the schema registry and none of the provided schema registry entries where registered.

Copilot summarises it as follows:
---
This pull request to the `implementations/php-justinrainbow-json-schema` repository includes changes to improve the handling of schema storage and validation in the `TestHarness` class. The most important changes include initialising the results array earlier, adding a schema to the schema storage, and adding support for a registry of schemas.

Improvements to schema storage and validation:

* [`implementations/php-justinrainbow-json-schema/src/TestHarness.php`](diffhunk://#diff-667fb1f218bf8654e87850bf8eab9ebf588f73461f9b9eea7235c40c892e58d8R110-L116): Initialized the `$results` array earlier in the `run` method to ensure it is always available.
* [`implementations/php-justinrainbow-json-schema/src/TestHarness.php`](diffhunk://#diff-667fb1f218bf8654e87850bf8eab9ebf588f73461f9b9eea7235c40c892e58d8R110-L116): Added a schema to the `SchemaStorage` using the `internal://mySchema` URI.
* [`implementations/php-justinrainbow-json-schema/src/TestHarness.php`](diffhunk://#diff-667fb1f218bf8654e87850bf8eab9ebf588f73461f9b9eea7235c40c892e58d8R110-L116): Added support for a registry of schemas by iterating over the `registry` property and adding each schema to the `SchemaStorage`.