### PR TITLE
Explicit type parameters in factory function

### DIFF
--- a/bowtie/_benchmarks.py
+++ b/bowtie/_benchmarks.py
@@ -452,7 +452,10 @@ class BenchmarkMetadata:
     num_values: int
     num_warmups: int
     num_loops: int
-    system_metadata: dict[str, Any] = field(factory=dict, repr=False)
+    system_metadata: dict[str, Any] = field(
+        factory=dict[str, "Any"],
+        repr=False,
+    )
 
     bowtie_version: str = field(
         default=importlib.metadata.version("bowtie-json-schema"),
@@ -505,7 +508,7 @@ class BenchmarkMetadata:
 class BenchmarkReport:
     metadata: BenchmarkMetadata
     results: dict[Benchmark_Group_Name, BenchmarkGroupResult] = field(
-        factory=dict,
+        factory=dict[Benchmark_Group_Name, BenchmarkGroupResult],
     )
 
     def serializable(self):
@@ -552,7 +555,7 @@ class BenchmarkReporter:
     _quiet: bool = field(alias="quiet", default=False)
     _format: str = field(alias="format", default="pretty")
     _benchmark_group_uri: dict[str, URL | None] = field(
-        factory=dict,
+        factory=dict[str, URL | None],
     )
     _mean_threshold: float = field(alias="mean_threshold", default=0.10)
 

--- a/bowtie/_commands.py
+++ b/bowtie/_commands.py
@@ -32,9 +32,9 @@ Message = dict[str, Any]
 
 @frozen
 class Unsuccessful:
-    failed: list[TestResult] = field(factory=list)
-    errored: list[ErroredTest] = field(factory=list)
-    skipped: list[SkippedTest] = field(factory=list)
+    failed: list[TestResult] = field(factory=list["TestResult"])
+    errored: list[ErroredTest] = field(factory=list["ErroredTest"])
+    skipped: list[SkippedTest] = field(factory=list["SkippedTest"])
 
     def __add__(self, other: Unsuccessful):
         return Unsuccessful(
@@ -250,7 +250,7 @@ class SkippedTest:
 
 @frozen
 class ErroredTest:
-    context: dict[str, Any] = field(factory=dict)
+    context: dict[str, Any] = field(factory=dict[str, "Any"])
 
     errored: bool = field(init=False, default=True)
     skipped: bool = False

--- a/bowtie/_containers.py
+++ b/bowtie/_containers.py
@@ -65,7 +65,7 @@ class Stream:
         repr=False,
         alias="read_timeout_sec",
     )
-    _buffer: deque[bytes] = field(factory=deque, alias="buffer")
+    _buffer: deque[bytes] = field(factory=deque[bytes], alias="buffer")
     _last: bytes = b""
 
     @classmethod

--- a/bowtie/_report.py
+++ b/bowtie/_report.py
@@ -233,7 +233,7 @@ class Report:
             raise EmptyReport()
         metadata = RunMetadata.from_dict(**validator.validated(header))
 
-        results: HashTrieMap[
+        results: HashTrieMap[  # type: ignore[reportUnknownVariableType] # pyright cannot infer the type returned by HashTrieMap.fromkeys
             ConnectableId,
             HashTrieMap[Seq, SeqResult],
         ] = HashTrieMap.fromkeys(  # type: ignore[reportUnknownMemberType]


### PR DESCRIPTION
The new version of `pyright` checks that the function return type matches the defined type. For that we need to specify type parameters in the factory function.

We didn't ignore the error because this new check is added to existing one and ignoring the new error would mean we completely disable the type checking for those fields

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--1950.org.readthedocs.build/en/1950/

<!-- readthedocs-preview bowtie-json-schema end -->