### PR TITLE
chore(deps): bump jsv library in elixir-jsv implementation

### DIFF
--- a/implementations/elixir-jsv/mix.exs
+++ b/implementations/elixir-jsv/mix.exs
@@ -26,7 +26,7 @@ defmodule BowtieJSV.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jsv, "~> 0.3"}
+      {:jsv, "~> 0.7"}
     ]
   end
 end


### PR DESCRIPTION
The [latest report is still using JSV 0.5.1](https://bowtie.report/#/?language=elixir) whereas a `0.7.1` exists.

So let's try to force the update.

But I am not sure why it is the case. The orginal code uses `~> 0.3` which sucessfully pulled the `0.5.1`, so it should pull `0.7.x` as well.

It's probably because of the Docker cache. JSV 0.5.1 was released on Mar 28, 2025 ; do you remember clearing the cache around that time?

What could we do to bust the docker cache every month or so? Could you for instance pass a build arg with `2025-05` that we can use in a Dockerfile so it's busted automatically?

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--2005.org.readthedocs.build/en/2005/

<!-- readthedocs-preview bowtie-json-schema end -->