### PR TITLE
dump the exact version for the latest tag instead of tag itself

### DIFF
--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -100,14 +100,14 @@ jobs:
           if [ ! -f $MATRIX_VERSIONS_FILE ]; then
             echo "Dump versions for remote test harness $impl"
             mkdir -p $(dirname "$MATRIX_VERSIONS_FILE")
-            tagged_version=$(gh api \
+            tagged_versions=$(gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               /repos/$GH_ORGANIZATION/$impl/git/matching-refs/tags/harness-release- | jq -c '[ .[].ref | ltrimstr("refs/tags/harness-release-") ]')
             latest_version=$(bowtie info \
                 --implementation image:$impl \
                 --format json | jq -r '.version // empty')
-            echo $tagged_version | jq -c --arg latest "$latest_version" '. + [$latest]' > $MATRIX_VERSIONS_FILE
+            echo $tagged_versions | jq -c --arg latest "$latest_version" '. + [$latest]' > $MATRIX_VERSIONS_FILE
           fi
           cp $MATRIX_VERSIONS_FILE $impl
           for version in $(jq -r '.[]' $MATRIX_VERSIONS_FILE); do

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -100,18 +100,17 @@ jobs:
           if [ ! -f $MATRIX_VERSIONS_FILE ]; then
             echo "Dump versions for remote test harness $impl"
             mkdir -p $(dirname "$MATRIX_VERSIONS_FILE")
-            gh api \
+            tagged_version=$(gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/$GH_ORGANIZATION/$impl/git/matching-refs/tags/harness-release- | jq -c '[ .[].ref | ltrimstr("refs/tags/harness-release-") ] + ["latest"]' > $MATRIX_VERSIONS_FILE
+              /repos/$GH_ORGANIZATION/$impl/git/matching-refs/tags/harness-release- | jq -c '[ .[].ref | ltrimstr("refs/tags/harness-release-") ]')
+            latest_version=$(bowtie info \
+                --implementation image:$impl \
+                --format json | jq -r '.version // empty')
+            echo $tagged_version | jq -c --arg latest "$latest_version" '. + [$latest]' > $MATRIX_VERSIONS_FILE
           fi
           cp $MATRIX_VERSIONS_FILE $impl
           for version in $(jq -r '.[]' $MATRIX_VERSIONS_FILE); do
-            if [ "$version" = "latest" ]; then
-              version=$(bowtie info \
-                --implementation image:$impl:$version \
-                --format json | jq -r '.version // empty')
-            fi
             SUPPORTED_DIALECTS=$(bowtie filter-dialects -i image:$impl:$version | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
             if [ -n "$SUPPORTED_DIALECTS" ]; then
               mkdir "$impl/v$version"


### PR DESCRIPTION
PR fixes the problem caused by #1916 during report verification. Instead of the version, the step used the `latest` tag and tried to check if the report for that tag existed (but when generating the report, we replaced the `latest` tag with the actual version).
Now, instead of replacing the `latest` tag during report generation, we replace it before dumping the versions into the matix-versions.json file

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--2020.org.readthedocs.build/en/2020/

<!-- readthedocs-preview bowtie-json-schema end -->