### PR TITLE
feat(js-ajv): add standard ajv-formats with ajv

### DIFF
--- a/implementations/js-ajv/bowtie_ajv.js
+++ b/implementations/js-ajv/bowtie_ajv.js
@@ -2,6 +2,7 @@ const path = require("path");
 const readline = require("readline");
 const os = require("os");
 const process = require("process");
+const addFormats = require("ajv-formats")
 
 const ajv_version = require(
   path.join(path.dirname(path.dirname(require.resolve("ajv"))), "package.json"),
@@ -62,12 +63,14 @@ const cmds = {
     // For some reason ajv's process for Draft 6 is different, so split.
     if (args.dialect !== "http://json-schema.org/draft-06/schema#") {
       ajv = new DRAFTS[args.dialect]();
+      addFormats(ajv);
     } else {
       const Ajv = require("ajv");
       const draft6MetaSchema = require("ajv/dist/refs/json-schema-draft-06.json");
 
       ajv = new Ajv();
       ajv.addMetaSchema(draft6MetaSchema);
+      addFormats(ajv);
     }
     return { ok: true };
   },

--- a/implementations/js-ajv/package-lock.json
+++ b/implementations/js-ajv/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "ajv": "^8.17.1",
-        "ajv-draft-04": "^1.0.0"
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^3.0.1"
       }
     },
     "node_modules/ajv": {
@@ -33,6 +34,23 @@
       "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "peerDependencies": {
         "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
       },
       "peerDependenciesMeta": {
         "ajv": {
@@ -81,6 +99,14 @@
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "requires": {}
+    },
+    "ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "requires": {
+        "ajv": "^8.0.0"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/implementations/js-ajv/package.json
+++ b/implementations/js-ajv/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "ajv": "^8.17.1",
-    "ajv-draft-04": "^1.0.0"
+    "ajv-draft-04": "^1.0.0",
+    "ajv-formats": "^3.0.1"
   }
 }


### PR DESCRIPTION
AJV is often paired up with the recommended ajv-formats:
https://ajv.js.org/packages/ajv-formats.html

I noticed AJV has MANY failures, and some of them are because formatting isn't supported out-of-the-box. This brings AJV more in parity with other libraries.

<!-- readthedocs-preview bowtie-json-schema start -->
----
📚 Documentation preview 📚: https://bowtie-json-schema--2287.org.readthedocs.build/en/2287/

<!-- readthedocs-preview bowtie-json-schema end -->