### PR TITLE
update jsonschema.net to 9.1.0

### DIFF
--- a/implementations/dotnet-jsonschema-net/bowtie_json_everything.csproj
+++ b/implementations/dotnet-jsonschema-net/bowtie_json_everything.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="8.0.5" />
+    <PackageReference Include="JsonSchema.Net" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Had someone [let me know](https://github.com/json-everything/json-everything/issues/992) that a test was reported as failing on the site.  Not sure what's going on because it passes locally (windows) and on the server build (linux).

Maybe updating will work.