### PR TITLE
Add M3 JSON Schema validator (Clojure + ClojureScript)

### DIFF
--- a/implementations/clojure-m3/Dockerfile
+++ b/implementations/clojure-m3/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine AS builder
+RUN apk add --no-cache leiningen
+WORKDIR /usr/src/app
+COPY project.clj /usr/src/app/
+RUN lein deps
+COPY . .
+RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" app-standalone.jar
+
+FROM bellsoft/liberica-openjdk-alpine:25
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/app/app-standalone.jar .
+CMD ["java", "-Dpolyglot.engine.WarnInterpreterOnly=false", "-Dorg.slf4j.simpleLogger.defaultLogLevel=off", "-jar", "app-standalone.jar"]

--- a/implementations/clojure-m3/project.clj
+++ b/implementations/clojure-m3/project.clj
@@ -1,0 +1,9 @@
+(defproject bowtie-m3 "0.1.0"
+  :description "Bowtie harness for M3 JSON Schema validator"
+  :dependencies [[org.clojure/clojure "1.12.4"]
+                 [org.clojure/data.json "2.5.2"]
+                 [org.clojars.jules_gosnell/m3 "1.0.0-beta3"]]
+  :main bowtie.harness
+  :aot [bowtie.harness]
+  :uberjar-name "bowtie-m3-standalone.jar"
+  :profiles {:uberjar {:aot :all}})

--- a/implementations/clojure-m3/src/bowtie/harness.clj
+++ b/implementations/clojure-m3/src/bowtie/harness.clj
@@ -1,0 +1,84 @@
+(ns bowtie.harness
+  "Bowtie IHOP protocol harness for M3 JSON Schema validator (JVM)."
+  (:require
+   [clojure.data.json :as json]
+   [m3.json-schema :as m3])
+  (:gen-class))
+
+(def dialect->draft
+  {"https://json-schema.org/draft/2020-12/schema" :draft2020-12
+   "https://json-schema.org/draft/2019-09/schema" :draft2019-09
+   "http://json-schema.org/draft-07/schema#"       :draft7
+   "http://json-schema.org/draft-06/schema#"       :draft6
+   "http://json-schema.org/draft-04/schema#"       :draft4
+   "http://json-schema.org/draft-03/schema#"       :draft3})
+
+(def supported-dialects (keys dialect->draft))
+
+(def ^:dynamic *current-draft* :draft2020-12)
+
+(defn cmd-start [_request]
+  {"version" 1
+   "implementation"
+   {"language"         "clojure"
+    "name"             "m3"
+    "version"          (or (System/getProperty "m3.version") "1.0.0-beta3")
+    "homepage"         "https://github.com/JulesGosnell/m3"
+    "issues"           "https://github.com/JulesGosnell/m3/issues"
+    "source"           "https://github.com/JulesGosnell/m3"
+    "dialects"         supported-dialects
+    "os"               (System/getProperty "os.name")
+    "os_version"       (System/getProperty "os.version")
+    "language_version" (clojure-version)}})
+
+(defn cmd-dialect [{dialect "dialect"}]
+  (if-let [draft (dialect->draft dialect)]
+    (do (alter-var-root #'*current-draft* (constantly draft))
+        {"ok" true})
+    {"ok" false}))
+
+(defn run-test [validator instance]
+  (try
+    (let [result (validator instance)]
+      {"valid" (:valid? result)})
+    (catch Throwable t
+      {"errored" true
+       "context" {"message"   (ex-message t)
+                  "traceback" (with-out-str (.printStackTrace t))}})))
+
+(defn cmd-run [{seq-val "seq" test-case "case"}]
+  (try
+    (let [schema   (get test-case "schema")
+          registry (get test-case "registry")
+          tests    (get test-case "tests")
+          opts     (cond-> {:draft *current-draft* :quiet? true}
+                     registry (assoc :registry registry))
+          validator (m3/validator schema opts)
+          results   (mapv #(run-test validator (get % "instance")) tests)]
+      {"seq" seq-val "results" results})
+    (catch Throwable t
+      {"seq"     seq-val
+       "errored" true
+       "context" {"message"   (ex-message t)
+                  "traceback" (with-out-str (.printStackTrace t))}})))
+
+(defn process-line [line]
+  (let [request (json/read-str line)
+        cmd     (get request "cmd")]
+    (case cmd
+      "start"   (cmd-start request)
+      "dialect" (cmd-dialect request)
+      "run"     (cmd-run request)
+      "stop"    nil)))
+
+(defn -main [& _args]
+  (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in))]
+    (loop []
+      (when-let [line (.readLine reader)]
+        (when-not (clojure.string/blank? line)
+          (if-let [response (process-line line)]
+            (do (println (json/write-str response))
+                (.flush System/out)
+                (recur))
+            ;; stop command — exit
+            (System/exit 0)))))))

--- a/implementations/clojurescript-m3/Dockerfile
+++ b/implementations/clojurescript-m3/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:22-alpine AS builder
+RUN apk add --no-cache openjdk21-jre git
+
+WORKDIR /usr/src
+RUN git clone https://github.com/JulesGosnell/m3.git
+
+WORKDIR /usr/src/m3
+RUN npm install
+
+# Copy harness source
+COPY src/bowtie /usr/src/m3/src/cljs/bowtie
+
+# Write a standalone shadow-cljs config that includes harness
+RUN echo '{:source-paths ["src/cljc" "src/cljs"] \
+           :dependencies [[com.widdindustries/cljc.java-time "0.1.21"]] \
+           :builds {:harness {:target :node-script \
+                              :output-dir "target/bowtie" \
+                              :output-to "target/bowtie/bowtie-m3.js" \
+                              :main bowtie.harness/-main}}}' > shadow-cljs.edn
+
+RUN npx shadow-cljs release harness
+
+FROM node:22-alpine
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/m3/target/bowtie/bowtie-m3.js .
+COPY --from=builder /usr/src/m3/node_modules ./node_modules
+COPY --from=builder /usr/src/m3/resources/schemas ./resources/schemas
+CMD ["node", "bowtie-m3.js"]

--- a/implementations/clojurescript-m3/src/bowtie/harness.cljs
+++ b/implementations/clojurescript-m3/src/bowtie/harness.cljs
@@ -1,0 +1,87 @@
+(ns bowtie.harness
+  "Bowtie IHOP protocol harness for M3 JSON Schema validator (ClojureScript/Node.js)."
+  (:require
+   [m3.json-schema :as m3]))
+
+(def dialect->draft
+  {"https://json-schema.org/draft/2020-12/schema" :draft2020-12
+   "https://json-schema.org/draft/2019-09/schema" :draft2019-09
+   "http://json-schema.org/draft-07/schema#"       :draft7
+   "http://json-schema.org/draft-06/schema#"       :draft6
+   "http://json-schema.org/draft-04/schema#"       :draft4
+   "http://json-schema.org/draft-03/schema#"       :draft3})
+
+(def supported-dialects (clj->js (keys dialect->draft)))
+
+(def current-draft (atom :draft2020-12))
+
+(defn cmd-start [_request]
+  #js {"version" 1
+       "implementation"
+       #js {"language"         "clojurescript"
+            "name"             "m3"
+            "version"          "1.0.0-beta3"
+            "homepage"         "https://github.com/JulesGosnell/m3"
+            "issues"           "https://github.com/JulesGosnell/m3/issues"
+            "source"           "https://github.com/JulesGosnell/m3"
+            "dialects"         supported-dialects
+            "language_version" (str "Node.js " js/process.version)}})
+
+(defn cmd-dialect [request]
+  (let [dialect (aget request "dialect")]
+    (if-let [draft (dialect->draft dialect)]
+      (do (reset! current-draft draft)
+          #js {"ok" true})
+      #js {"ok" false})))
+
+(defn run-test [validator instance]
+  (try
+    (let [result (validator instance)]
+      #js {"valid" (:valid? result)})
+    (catch :default t
+      #js {"errored" true
+           "context" #js {"message" (ex-message t)}})))
+
+(defn cmd-run [request]
+  (try
+    (let [seq-val  (aget request "seq")
+          test-case (aget request "case")
+          schema   (js->clj (aget test-case "schema"))
+          registry-js (aget test-case "registry")
+          registry (when registry-js (js->clj registry-js))
+          tests    (array-seq (aget test-case "tests"))
+          opts     (cond-> {:draft @current-draft :quiet? true}
+                     registry (assoc :registry registry))
+          validator (m3/validator schema opts)
+          results   (into-array (map #(run-test validator (js->clj (aget % "instance"))) tests))]
+      #js {"seq" seq-val "results" results})
+    (catch :default t
+      #js {"seq"     (aget request "seq")
+           "errored" true
+           "context" #js {"message" (ex-message t)}})))
+
+(defn process-line [line]
+  (let [request (js/JSON.parse line)
+        cmd     (aget request "cmd")]
+    (case cmd
+      "start"   (cmd-start request)
+      "dialect" (cmd-dialect request)
+      "run"     (cmd-run request)
+      "stop"    nil)))
+
+(defn -main []
+  (let [readline (js/require "readline")
+        rl (.createInterface readline
+             #js {:input  js/process.stdin
+                  :output js/process.stdout
+                  :terminal false})]
+    (.on rl "line"
+      (fn [line]
+        (when-not (empty? line)
+          (if-let [response (process-line line)]
+            (.write js/process.stdout
+              (str (js/JSON.stringify response) "\n"))
+            ;; stop command
+            (js/process.exit 0)))))))
+
+(-main)


### PR DESCRIPTION
## Summary

Adds [M3](https://github.com/JulesGosnell/m3), a cross-platform JSON Schema validator written in Clojure/ClojureScript, as two Bowtie implementations:

- **clojure-m3** — JVM (Clojure), built as an uberjar via Leiningen
- **clojurescript-m3** — Node.js (ClojureScript), compiled via shadow-cljs

M3 supports all seven JSON Schema drafts: draft-03, draft-04, draft-06, draft-07, draft-2019-09, draft-2020-12, and draft-next (though draft-next is not declared to Bowtie since it isn't a standard dialect URI).

Both implementations support the full IHOP v1 protocol including `registry` for `$ref` resolution.

### Tested locally

```
$ echo '{"cmd":"start","version":1}
{"cmd":"dialect","dialect":"https://json-schema.org/draft/2020-12/schema"}
{"cmd":"run","seq":1,"case":{"schema":{"type":"string"},"tests":[{"description":"a string","instance":"hello"},{"description":"a number","instance":42}]}}
{"cmd":"run","seq":2,"case":{"schema":{"$ref":"http://example.com/s"},"registry":{"http://example.com/s":{"type":"integer"}},"tests":[{"description":"valid int","instance":7},{"description":"invalid string","instance":"nope"}]}}
{"cmd":"stop"}' | docker run --rm -i bowtie-m3-jvm

{"version":1,"implementation":{"language":"clojure","name":"m3","version":"1.0.0-beta3",...}}
{"ok":true}
{"seq":1,"results":[{"valid":true},{"valid":false}]}
{"seq":2,"results":[{"valid":true},{"valid":false}]}
```

ClojureScript output is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)