### PR TITLE
feat: Update Json Schema for PHP to latest version and use non RC image for docker container

### DIFF
--- a/implementations/php-justinrainbow-json-schema/Dockerfile
+++ b/implementations/php-justinrainbow-json-schema/Dockerfile
@@ -8,7 +8,7 @@ COPY composer.* .
 RUN composer install --no-dev --no-scripts --no-interaction --prefer-dist --optimize-autoloader
 RUN composer dump-autoload --no-dev --optimize --classmap-authoritative
 
-FROM php:8.5.0RC2-alpine
+FROM php:8.5-cli-alpine3.22
 
 WORKDIR /usr/src/json-schema
 

--- a/implementations/php-justinrainbow-json-schema/composer.json
+++ b/implementations/php-justinrainbow-json-schema/composer.json
@@ -3,7 +3,7 @@
   "description": "These sources contains the test harness implementation for Bowtie",
   "license": "MIT",
   "require": {
-    "justinrainbow/json-schema": "^6.6"
+    "justinrainbow/json-schema": "^6.7"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^4.0"

--- a/implementations/php-justinrainbow-json-schema/composer.lock
+++ b/implementations/php-justinrainbow-json-schema/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b0085c5ae1b772471f0adecf0c62915",
+    "content-hash": "538e13946aedac888d4c21a3411106ee",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.6.4",
+            "version": "v6.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7"
+                "reference": "cd3137ab4ad45033230f530ab7d5618d583c17be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2eeb75d21cf73211335888e7f5e6fd7440723ec7",
-                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/cd3137ab4ad45033230f530ab7d5618d583c17be",
+                "reference": "cd3137ab4ad45033230f530ab7d5618d583c17be",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.4"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/v6.7.1"
             },
-            "time": "2025-12-19T15:01:32+00:00"
+            "time": "2026-02-13T16:16:54+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -243,5 +243,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/implementations/php-justinrainbow-json-schema/src/TestHarness.php
+++ b/implementations/php-justinrainbow-json-schema/src/TestHarness.php
@@ -82,6 +82,7 @@ class TestHarness
                 'source' => 'https://github.com/jsonrainbow/json-schema',
                 'issues' => 'https://github.com/jsonrainbow/json-schema/issues',
                 'dialects' => [
+                    'http://json-schema.org/draft-07/schema#',
                     'http://json-schema.org/draft-06/schema#',
                     'http://json-schema.org/draft-04/schema#',
                     'http://json-schema.org/draft-03/schema#',


### PR DESCRIPTION
This PR will:
- Update to JSON Schema for PHP version 6.7 which includes support for draft 7
- Update the docker image from RC to the latest official image (PHP 8.5.3 at the time of writing)