### PR TITLE
feat(cli): add --failures-only flag to smoke

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -2422,19 +2422,18 @@ async def smoke(
 
     filtered = (
         [(id, info, r) for id, info, r in results if not r.success]
-        if failures_only and format != "json"
+        if failures_only
         else results
     )
 
-    match results, format:
+    match filtered, format:
         case [(_, _, result)], "json":
             echo(json.dumps(result.serializable(), indent=2))
         case _, "json":
-            output = {id: result.serializable() for id, _, result in results}
+            output = {id: result.serializable() for id, _, result in filtered}
             echo(json.dumps(output, indent=2))
         case [(_, _, result)], "pretty":
-            if not failures_only or not result.success:
-                STDOUT.print(result)
+            STDOUT.print(result)
         case _, "pretty":
             for _, _, each in filtered:
                 STDOUT.print(each)

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -1763,7 +1763,7 @@ class TestSmoke:
         assert stdout, stderr
 
     @pytest.mark.asyncio
-    async def test_failures_only_does_not_filter_json(self):
+    async def test_failures_only_filters_json(self):
         jsonout, stderr = await bowtie(
             "smoke",
             "--failures-only",
@@ -1773,7 +1773,7 @@ class TestSmoke:
             miniatures.passes_smoke,
             json=True,
         )
-        assert jsonout, stderr
+        assert jsonout == {}, stderr
 
     @pytest.mark.asyncio
     async def test_json_multiple(self):


### PR DESCRIPTION
Adds a --failures-only flag to `bowtie smoke`.

When used with pretty or markdown output, only implementations that
fail smoke tests are displayed. JSON output remains unchanged so
machine consumers can filter results using tools like jq.

Fixes #1318.