### PR TITLE
Added DuplicateCase Error handing in _Report.convert()

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -616,6 +616,7 @@ class _Report(click.File):
             STDERR.print(error)
             ctx.exit(EX.DATAERR)
 
+
 @subcommand
 @format_option()
 @click.option(


### PR DESCRIPTION
Fixes: #2470

What was happening?

The _Report.convert() method in _cli.py already handles several errors, but it didn’t account for _report.DuplicateCase.

As a result, if a report contained duplicate seq values, commands like bowtie summary would crash and show a raw Python traceback instead of a helpful message.
<img width="1568" height="266" alt="image" src="https://github.com/user-attachments/assets/3a7106e1-66eb-4efe-b6ed-390667f48640" />

What’s changed?

I have added an except _report.DuplicateCase block to _Report.convert().
Now, instead of a traceback, users get a clear and actionable error message:
<img width="1384" height="240" alt="image" src="https://github.com/user-attachments/assets/6a114172-a276-43c5-a000-23082ec4e463" />

Testing

To verify the fix, I manually introduced a duplicate seq entry into a valid report and ran bowtie summary.
Previously, this caused a traceback. With this change, it now shows the clean diagnostic error as expected.