### PR TITLE
Update to use jsonschex ~> 0.5.0

### DIFF
--- a/implementations/elixir-jsonschex/mix.exs
+++ b/implementations/elixir-jsonschex/mix.exs
@@ -26,7 +26,7 @@ defmodule BowtieJSONSchex.MixProject do
 
   defp deps do
     [
-      {:jsonschex, "~> 0.4"},
+      {:jsonschex, "~> 0.5"},
       {:idna, "~> 7.1"},
       {:decimal, "~> 2.0"}
     ]


### PR DESCRIPTION
Update `jsonschex` to 0.5.0 to fix two failure cases of the `elixir-jsonschex` implementations from the bowtie report v2026.4.16, please review.

Issue tracked in https://github.com/xinz/jsonschex/issues/1, and its [changelog](https://github.com/xinz/jsonschex/blob/main/CHANGELOG.md).