### PR TITLE
Feat: add schema eval TUI

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -46,6 +46,7 @@ from bowtie import DOCS, HOMEPAGE, _benchmarks, _connectables, _report, _suite
 from bowtie._commands import SeqCase, TestResult, Unsuccessful
 from bowtie._core import (
     Dialect,
+    DialectRunner,
     Example,
     Implementation,
     Test,
@@ -1389,7 +1390,7 @@ async def tui(start: Any, dialect: Dialect, **kwargs: Any):
     Starts a REPL that keeps implementations running between validations,
     prompting for a JSON Schema and an instance on each iteration
     """
-    runners = []
+    runners: list[tuple[str, str, DialectRunner]] = []
     async for impl_id, implementation in start():
         try:
             runner = await implementation.start_speaking(dialect)

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -32,6 +32,7 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
+from rich.prompt import Prompt
 from rich.table import Column, Table
 from rich.text import Text
 from rich_click.utils import CommandGroupDict, OptionGroupDict
@@ -52,6 +53,7 @@ from bowtie._core import (
     convert_table_to_markdown,
 )
 from bowtie._direct_connectable import Direct
+from bowtie._tui import TuiSession
 from bowtie.exceptions import (
     CannotConnect,
     DialectError,
@@ -125,7 +127,7 @@ _COMMAND_GROUPS = {
     "bowtie": [
         CommandGroupDict(
             name="Basic Commands",
-            commands=["validate", "suite", "summary", "info"],
+            commands=["tui", "validate", "suite", "summary", "info"],
         ),
         CommandGroupDict(
             name="Advanced Usage",
@@ -1376,6 +1378,47 @@ def run(
     return asyncio.run(
         _run_parallel(**kwargs, cases=cases, dialect=dialect, jobs=jobs),
     )
+
+
+@subcommand
+@implementation_subcommand()
+@dialect_option()
+def tui(start: Any, dialect: Dialect, **kwargs: Any):
+    """
+    Interactively evaluate schemas against instances across implementations.
+
+    Starts a REPL that keeps implementations running between validations,
+    prompting for a JSON Schema and an instance on each iteration
+    """
+
+    async def _tui(start: Any, dialect: Dialect, **kwargs: Any):
+        runners = []
+        async for impl_id, implementation in start():
+            try:
+                runner = await implementation.start_speaking(dialect)
+            except UnsupportedDialect as error:
+                STDERR.print(error)
+                continue
+            runners.append((
+                impl_id,
+                implementation.info.version or "?",
+                runner,
+            ))
+
+        if not runners:
+            STDERR.print(
+                "[bold red]No implementation started successfully![/]",
+                )
+            return EX.CONFIG
+        session = TuiSession(
+            runners=runners,
+            dialect=dialect,
+            console=STDOUT,
+            prompt=lambda msg: Prompt.ask(msg),
+        )
+        await session.repl()
+
+    return asyncio.run(_tui(start=start, dialect=dialect, **kwargs))
 
 
 @subcommand

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1404,7 +1404,7 @@ def tui(start: Any, dialect: Dialect, **kwargs: Any):
                     impl_id,
                     implementation.info.version or "?",
                     runner,
-                )
+                ),
             )
 
         if not runners:

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1399,16 +1399,18 @@ def tui(start: Any, dialect: Dialect, **kwargs: Any):
             except UnsupportedDialect as error:
                 STDERR.print(error)
                 continue
-            runners.append((
-                impl_id,
-                implementation.info.version or "?",
-                runner,
-            ))
+            runners.append(
+                (
+                    impl_id,
+                    implementation.info.version or "?",
+                    runner,
+                )
+            )
 
         if not runners:
             STDERR.print(
                 "[bold red]No implementation started successfully![/]",
-                )
+            )
             return EX.CONFIG
         session = TuiSession(
             runners=runners,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1380,47 +1380,42 @@ def run(
     )
 
 
-@subcommand
 @implementation_subcommand()
 @dialect_option()
-def tui(start: Any, dialect: Dialect, **kwargs: Any):
+async def tui(start: Any, dialect: Dialect, **kwargs: Any):
     """
     Interactively evaluate schemas against instances across implementations.
 
     Starts a REPL that keeps implementations running between validations,
     prompting for a JSON Schema and an instance on each iteration
     """
-
-    async def _tui(start: Any, dialect: Dialect, **kwargs: Any):
-        runners = []
-        async for impl_id, implementation in start():
-            try:
-                runner = await implementation.start_speaking(dialect)
-            except UnsupportedDialect as error:
-                STDERR.print(error)
-                continue
-            runners.append(
-                (
-                    impl_id,
-                    implementation.info.version or "?",
-                    runner,
-                ),
-            )
-
-        if not runners:
-            STDERR.print(
-                "[bold red]No implementation started successfully![/]",
-            )
-            return EX.CONFIG
-        session = TuiSession(
-            runners=runners,
-            dialect=dialect,
-            console=STDOUT,
-            prompt=lambda msg: Prompt.ask(msg),
+    runners = []
+    async for impl_id, implementation in start():
+        try:
+            runner = await implementation.start_speaking(dialect)
+        except UnsupportedDialect as error:
+            STDERR.print(error)
+            continue
+        runners.append(
+            (
+                impl_id,
+                implementation.info.version or "?",
+                runner,
+            ),
         )
-        await session.repl()
 
-    return asyncio.run(_tui(start=start, dialect=dialect, **kwargs))
+    if not runners:
+        STDERR.print(
+            "[bold red]No implementation started successfully![/]",
+        )
+        return EX.CONFIG
+    session = TuiSession(
+        runners=runners,
+        dialect=dialect,
+        console=STDOUT,
+        prompt=lambda msg: Prompt.ask(msg),
+    )
+    await session.repl()
 
 
 @subcommand

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1413,7 +1413,7 @@ async def tui(start: Any, dialect: Dialect, **kwargs: Any):
         runners=runners,
         dialect=dialect,
         console=STDOUT,
-        prompt=lambda msg: Prompt.ask(msg),
+        prompt=Prompt.ask,
     )
     await session.repl()
 

--- a/bowtie/_tui.py
+++ b/bowtie/_tui.py
@@ -111,7 +111,7 @@ class TuiSession:
                 "[dim]Enter a JSON schema, then one instance to validate.\n"
                 "Type [bold]q[/bold] to quit.[/dim]",
                 title="bowtie tui",
-            )
+            ),
         )
 
         while True:

--- a/bowtie/_tui.py
+++ b/bowtie/_tui.py
@@ -1,0 +1,169 @@
+"""
+An interactive TUI for evaluating JSON Schema across implementations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+import asyncio
+import json
+
+from rich.panel import Panel
+from rich.table import Table
+
+from bowtie._commands import SeqCase
+from bowtie._core import Dialect, Example, TestCase
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from rich.console import Console
+
+    from bowtie._core import DialectRunner
+
+_QUIT = {"q", "quit", "exit"}
+
+_SINGLE = 0
+
+
+class TuiSession:
+    """
+    An interactive TUI session over a set of running implementations.
+
+    Keeps DialectRunners alive across multiple validate calls.
+    Accepts injected I/O so the session logic is testable without a terminal.
+    """
+
+    def __init__(
+            self,
+            runners: list[tuple[str, str, DialectRunner]],
+            dialect: Dialect,
+            console: Console,
+            prompt: Callable[[str], str],
+            ) -> None:
+        self._runners = runners
+        self._dialect = dialect
+        self._console = console
+        self._prompt = prompt
+        self._seq = 0
+
+    async def run_once(
+            self,
+            schema: Any,
+            instance: Any,
+    ) -> list[tuple[str, str, bool | None]]:
+        """
+        Validate one instance against one schema across all runners.
+        """
+        self._seq += 1
+        case = TestCase(
+            description="bowtie tui",
+            schema=schema,
+            tests=[Example(description="", instance=instance)],
+        )
+        seq_case = SeqCase(seq=self._seq, case=case)
+
+        tasks = [
+            seq_case.run(runner=runner)
+            for _, _, runner in self._runners
+        ]
+
+        raw_results = await asyncio.gather(*tasks)
+
+        output = []
+        for (impl_id, version, _), result in zip(self._runners, raw_results):
+            try:
+                valid: bool | None = result.result.results[_SINGLE].valid
+            except (AttributeError, IndexError):
+                valid = None
+            output.append((impl_id, version, valid))
+        return output
+
+    def show_results(
+            self,
+            results: list[tuple[str, str, bool | None]],
+    ) -> None:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Implementation")
+        table.add_column("Version", style="dim")
+        table.add_column("Result")
+
+        for impl_id, version, valid in results:
+            if valid is True:
+                result_str = "[green] valid[/green]"
+            elif valid is False:
+                result_str = "[red] invalid[/red]"
+            else:
+                result_str = "[yellow] error[/yellow]"
+            table.add_row(impl_id, version, result_str)
+
+        self._console.print()
+        self._console.print(table)
+
+    async def repl(self) -> None:
+        """
+        Main loop: prompt for schema and instance, validate, display, repeat.
+        """
+        impl_count = len(self._runners)
+        impl_word = "implementation" if impl_count == 1 else "implementations"
+
+        self._console.print(Panel(
+            f"Dialect: [bold]{self._dialect.pretty_name}[/bold]  "
+            f"Running: [bold]{impl_count}[/bold] {impl_word}\n\n"
+            "[dim]Enter a JSON schema, then one instance to validate.\n"
+            "Type [bold]q[/bold] to quit.[/dim]",
+            title="bowtie tui",
+        ))
+
+        while True:
+            try:
+                raw_schema = self._prompt("Schema")
+            except (KeyboardInterrupt, EOFError):
+                break
+            if raw_schema.strip().lower() in _QUIT:
+                break
+            try:
+                schema = _parse_json(raw_schema)
+            except ValueError as e:
+                self._console.print(
+                    f"[red]Invalid JSON for schema: {e}[/red]",
+                    )
+                continue
+
+            if not _is_schema_like(schema):
+                self._console.print(
+                    "[red]Schemas must be a JSON object or boolean "
+                    f"(got {type(schema).__name__}).[/red]",
+                )
+                continue
+
+            try:
+                raw_instance = self._prompt("Instance")
+            except (KeyboardInterrupt, EOFError):
+                break
+            if raw_instance.strip().lower() in _QUIT:
+                break
+            try:
+                instance = _parse_json(raw_instance)
+            except ValueError as e:
+                self._console.print(
+                    f"[red]Invalid JSON for instance: {e}[/red]",
+                    )
+                continue
+
+            results = await self.run_once(schema=schema, instance=instance)
+            self.show_results(results=results)
+
+
+def _parse_json(raw: str) -> Any:
+    """
+    Parse a JSON string, raising ValueError with a clean message on failure.
+    """
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(str(e)) from e
+
+
+def _is_schema_like(value: Any) -> bool:
+    return isinstance(value, (dict, bool))

--- a/bowtie/_tui.py
+++ b/bowtie/_tui.py
@@ -69,13 +69,14 @@ class TuiSession:
 
         output: list[tuple[str, str, bool | None]] = []
         for (impl_id, version, _), seq_result in zip(
-                self._runners, raw_results,
-            ):
+            self._runners,
+            raw_results,
+        ):
             test_result = seq_result.result_for(_SINGLE)
             if test_result.errored or test_result.skipped:
                 valid = None
             else:
-                valid = bool(test_result.valid) # type: ignore[reportUnknownMemberType]
+                valid = bool(test_result.valid)  # type: ignore[reportUnknownMemberType]
             output.append((impl_id, version, valid))
         return output
 

--- a/bowtie/_tui.py
+++ b/bowtie/_tui.py
@@ -35,12 +35,12 @@ class TuiSession:
     """
 
     def __init__(
-            self,
-            runners: list[tuple[str, str, DialectRunner]],
-            dialect: Dialect,
-            console: Console,
-            prompt: Callable[[str], str],
-            ) -> None:
+        self,
+        runners: list[tuple[str, str, DialectRunner]],
+        dialect: Dialect,
+        console: Console,
+        prompt: Callable[[str], str],
+    ) -> None:
         self._runners = runners
         self._dialect = dialect
         self._console = console
@@ -48,9 +48,9 @@ class TuiSession:
         self._seq = 0
 
     async def run_once(
-            self,
-            schema: Any,
-            instance: Any,
+        self,
+        schema: Any,
+        instance: Any,
     ) -> list[tuple[str, str, bool | None]]:
         """
         Validate one instance against one schema across all runners.
@@ -63,10 +63,7 @@ class TuiSession:
         )
         seq_case = SeqCase(seq=self._seq, case=case)
 
-        tasks = [
-            seq_case.run(runner=runner)
-            for _, _, runner in self._runners
-        ]
+        tasks = [seq_case.run(runner=runner) for _, _, runner in self._runners]
 
         raw_results = await asyncio.gather(*tasks)
 
@@ -80,8 +77,8 @@ class TuiSession:
         return output
 
     def show_results(
-            self,
-            results: list[tuple[str, str, bool | None]],
+        self,
+        results: list[tuple[str, str, bool | None]],
     ) -> None:
         table = Table(show_header=True, header_style="bold")
         table.add_column("Implementation")
@@ -107,13 +104,15 @@ class TuiSession:
         impl_count = len(self._runners)
         impl_word = "implementation" if impl_count == 1 else "implementations"
 
-        self._console.print(Panel(
-            f"Dialect: [bold]{self._dialect.pretty_name}[/bold]  "
-            f"Running: [bold]{impl_count}[/bold] {impl_word}\n\n"
-            "[dim]Enter a JSON schema, then one instance to validate.\n"
-            "Type [bold]q[/bold] to quit.[/dim]",
-            title="bowtie tui",
-        ))
+        self._console.print(
+            Panel(
+                f"Dialect: [bold]{self._dialect.pretty_name}[/bold]  "
+                f"Running: [bold]{impl_count}[/bold] {impl_word}\n\n"
+                "[dim]Enter a JSON schema, then one instance to validate.\n"
+                "Type [bold]q[/bold] to quit.[/dim]",
+                title="bowtie tui",
+            )
+        )
 
         while True:
             try:
@@ -127,7 +126,7 @@ class TuiSession:
             except ValueError as e:
                 self._console.print(
                     f"[red]Invalid JSON for schema: {e}[/red]",
-                    )
+                )
                 continue
 
             if not _is_schema_like(schema):
@@ -148,7 +147,7 @@ class TuiSession:
             except ValueError as e:
                 self._console.print(
                     f"[red]Invalid JSON for instance: {e}[/red]",
-                    )
+                )
                 continue
 
             results = await self.run_once(schema=schema, instance=instance)

--- a/bowtie/_tui.py
+++ b/bowtie/_tui.py
@@ -67,7 +67,7 @@ class TuiSession:
 
         raw_results = await asyncio.gather(*tasks)
 
-        output = []
+        output: list[tuple[str, str, bool | None]] = []
         for (impl_id, version, _), seq_result in zip(
                 self._runners, raw_results,
             ):
@@ -75,7 +75,7 @@ class TuiSession:
             if test_result.errored or test_result.skipped:
                 valid = None
             else:
-                valid = test_result.valid # type: ignore[reportUnknownMemberType]
+                valid = bool(test_result.valid) # type: ignore[reportUnknownMemberType]
             output.append((impl_id, version, valid))
         return output
 

--- a/bowtie/_tui.py
+++ b/bowtie/_tui.py
@@ -68,11 +68,14 @@ class TuiSession:
         raw_results = await asyncio.gather(*tasks)
 
         output = []
-        for (impl_id, version, _), result in zip(self._runners, raw_results):
-            try:
-                valid: bool | None = result.result.results[_SINGLE].valid
-            except (AttributeError, IndexError):
+        for (impl_id, version, _), seq_result in zip(
+                self._runners, raw_results,
+            ):
+            test_result = seq_result.result_for(_SINGLE)
+            if test_result.errored or test_result.skipped:
                 valid = None
+            else:
+                valid = test_result.valid # type: ignore[reportUnknownMemberType]
             output.append((impl_id, version, valid))
         return output
 

--- a/bowtie/tests/test_tui.py
+++ b/bowtie/tests/test_tui.py
@@ -1,0 +1,98 @@
+import io
+
+from rich.console import Console
+import pytest
+import pytest_asyncio
+
+from bowtie import _report
+from bowtie._connectables import Connectable
+from bowtie._direct_connectable import Direct
+from bowtie._tui import TuiSession, _is_schema_like, _parse_json
+
+
+def _silent_console() -> Console:
+    return Console(file=io.StringIO(), highlight=False)
+
+def _test_prompt(inputs: list[str]):
+    it = iter(inputs)
+
+    def prompt(msg: str) -> str:
+        try:
+            return next(it)
+        except StopIteration:
+            raise EOFError from None
+
+    return prompt
+
+def test_parse_json_invalid_raises_value_error():
+    with pytest.raises(ValueError, match="Expecting property name"):
+        _parse_json("{not valid json")
+
+def test_is_schema_like_rejects_string():
+    assert _is_schema_like("hello") is False
+
+@pytest.fixture
+def dialect():
+    from bowtie._core import Dialect
+    return Dialect.by_short_name()["draft2020-12"]
+
+@pytest_asyncio.fixture
+async def session(dialect):
+    """
+    A TuiSession backed by python-jsonschema DialectRunner.
+    No Docker. No terminal
+    """
+    silent = _report.Reporter(write=lambda **_: None)
+    registry = Direct.from_id("python-jsonschema").registry()
+    connectable = Connectable.from_str("python-jsonschema")
+
+    async with connectable.connect(reporter=silent, registry=registry) as impl:
+        runner = await impl.start_speaking(dialect)
+        yield TuiSession(
+            runners=[(impl.id, impl.info.version or "?", runner)],
+            dialect=dialect,
+            console=_silent_console(),
+            prompt=lambda _: (_ for _ in ()).throw(EOFError()),
+        )
+
+@pytest.mark.asyncio
+async def test_run_once_valid_instance(session):
+    results = await session.run_once(
+        schema={"type": "integer"},
+        instance=42,
+    )
+    assert len(results) == 1
+    impl_id, _version, valid = results[0]
+    assert valid is True
+    assert "jsonschema" in impl_id
+
+@pytest.mark.asyncio
+async def test_run_once_invalid_instance(session):
+    results = await session.run_once(
+        schema={"type": "integer"},
+        instance="not an integer",
+    )
+    assert len(results) == 1
+    _, _, valid = results[0]
+    assert valid is False
+
+@pytest.mark.asyncio
+async def test_repl_exits_on_q(session):
+    session._prompt = _test_prompt(["q"])
+    await session.repl()
+
+@pytest.mark.asyncio
+async def test_repl_non_schema_json_continues(session):
+    session._prompt = _test_prompt(['"just a string"', "q"])
+    await session.repl()
+
+@pytest.mark.asyncio
+async def test_repl_validates_and_continues(session):
+    session._prompt = _test_prompt([
+        '{"type": "integer"}',
+        "42",
+        '{"type": "integer"}',
+        '"hello"',
+        "q",
+    ])
+    await session.repl()

--- a/bowtie/tests/test_tui.py
+++ b/bowtie/tests/test_tui.py
@@ -106,6 +106,6 @@ async def test_repl_validates_and_continues(session):
             '{"type": "integer"}',
             '"hello"',
             "q",
-        ]
+        ],
     )
     await session.repl()

--- a/bowtie/tests/test_tui.py
+++ b/bowtie/tests/test_tui.py
@@ -13,6 +13,7 @@ from bowtie._tui import TuiSession, _is_schema_like, _parse_json
 def _silent_console() -> Console:
     return Console(file=io.StringIO(), highlight=False)
 
+
 def _test_prompt(inputs: list[str]):
     it = iter(inputs)
 
@@ -24,17 +25,22 @@ def _test_prompt(inputs: list[str]):
 
     return prompt
 
+
 def test_parse_json_invalid_raises_value_error():
     with pytest.raises(ValueError, match="Expecting property name"):
         _parse_json("{not valid json")
 
+
 def test_is_schema_like_rejects_string():
     assert _is_schema_like("hello") is False
+
 
 @pytest.fixture
 def dialect():
     from bowtie._core import Dialect
+
     return Dialect.by_short_name()["draft2020-12"]
+
 
 @pytest_asyncio.fixture
 async def session(dialect):
@@ -55,6 +61,7 @@ async def session(dialect):
             prompt=lambda _: (_ for _ in ()).throw(EOFError()),
         )
 
+
 @pytest.mark.asyncio
 async def test_run_once_valid_instance(session):
     results = await session.run_once(
@@ -66,6 +73,7 @@ async def test_run_once_valid_instance(session):
     assert valid is True
     assert "jsonschema" in impl_id
 
+
 @pytest.mark.asyncio
 async def test_run_once_invalid_instance(session):
     results = await session.run_once(
@@ -76,23 +84,28 @@ async def test_run_once_invalid_instance(session):
     _, _, valid = results[0]
     assert valid is False
 
+
 @pytest.mark.asyncio
 async def test_repl_exits_on_q(session):
     session._prompt = _test_prompt(["q"])
     await session.repl()
+
 
 @pytest.mark.asyncio
 async def test_repl_non_schema_json_continues(session):
     session._prompt = _test_prompt(['"just a string"', "q"])
     await session.repl()
 
+
 @pytest.mark.asyncio
 async def test_repl_validates_and_continues(session):
-    session._prompt = _test_prompt([
-        '{"type": "integer"}',
-        "42",
-        '{"type": "integer"}',
-        '"hello"',
-        "q",
-    ])
+    session._prompt = _test_prompt(
+        [
+            '{"type": "integer"}',
+            "42",
+            '{"type": "integer"}',
+            '"hello"',
+            "q",
+        ]
+    )
     await session.repl()


### PR DESCRIPTION
- Adds `bowtie tui`, a REPL-style TUI for interactively evaluating JSON schemas against instances across running implementations.

- This is the minimal first version: one schema, one instance per round, results in a rich table. 

- Multi-instance input, report export, and streaming results are left for follow-up issues.

- Only `python-jsonschema` is available as a direct connectable; Docker implementations work but are untested in this PR.

Part of #883 