### PR TITLE
Migrate to attest action as the old one is a wrapper for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
       contents: write # to create GitHub releases
       id-token: write # to authenticate with PyPI via OIDC
       attestations: write # to generate build provenance attestations
+      artifact-metadata: write # to generate build provenance attestations
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -213,7 +214,7 @@ jobs:
 
       - name: Generate attestation for wheels
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1
         with:
           subject-path: "dist/*.whl"
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -131,6 +131,7 @@ jobs:
       contents: read # needed for actions/checkout
       attestations: write # needed for build provenance attestation
       packages: write # needed for pushing to ghcr.io
+      artifact-metadata: write # needed for build provenance attestation
 
     strategy:
       fail-fast: false
@@ -240,7 +241,7 @@ jobs:
           )
 
       - name: Generate attestation for images
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
Migrate from https://github.com/actions/attest-build-provenance because it is a wrapper over https://github.com/actions/attest.

Additional permissions added as recommended by the action description.