### PR TITLE
Fix new pyright 1.1.409 typing errors

### DIFF
--- a/bowtie/_connectables.py
+++ b/bowtie/_connectables.py
@@ -18,7 +18,7 @@ from bowtie._direct_connectable import Direct
 from bowtie.exceptions import CannotConnect
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncGenerator
     from contextlib import AbstractAsyncContextManager
 
     from bowtie._core import Connection
@@ -140,7 +140,7 @@ class Connectable:
         return self._connector.kind
 
     @asynccontextmanager
-    async def connect(self, **kwargs: Any) -> AsyncIterator[Implementation]:
+    async def connect(self, **kwargs: Any) -> AsyncGenerator[Implementation]:
         async with (
             self._connector.connect() as connection,
             Implementation.start(

--- a/bowtie/_containers.py
+++ b/bowtie/_containers.py
@@ -26,7 +26,7 @@ from bowtie.exceptions import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncGenerator, Awaitable, Callable
     from typing import Any
 
     import aiodocker.containers
@@ -226,7 +226,7 @@ class ConnectableImage:
     kind = "image"
 
     @asynccontextmanager
-    async def connect(self) -> AsyncIterator[Connection]:
+    async def connect(self) -> AsyncGenerator[Connection]:
         async with AsyncExitStack() as stack:
             docker = await stack.enter_async_context(Docker())
             create = start_container_maybe_pull
@@ -367,7 +367,7 @@ class ConnectableContainer:
     kind = "container"
 
     @asynccontextmanager
-    async def connect(self) -> AsyncIterator[Connection]:
+    async def connect(self) -> AsyncGenerator[Connection]:
         async with Docker() as docker:
             try:
                 container = await docker.containers.get(self._id)  # type: ignore[reportUnknownMemberType]

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -37,6 +37,7 @@ from bowtie.exceptions import (
 
 if TYPE_CHECKING:
     from collections.abc import (
+        AsyncGenerator,
         AsyncIterator,
         Callable,
         Iterable,
@@ -515,7 +516,7 @@ class Implementation:
         id: ConnectableId,
         reporter: Reporter,
         **kwargs: Any,
-    ) -> AsyncIterator[Self]:
+    ) -> AsyncGenerator[Self]:
         _harness = HarnessClient(**kwargs)
 
         try:
@@ -558,9 +559,10 @@ class Implementation:
         )
         for page in pages:
             try:
+                data = cast("Mapping[str, Any]", page.as_dict() or {})
                 tags = cast(
                     "Iterable[str]",
-                    page.as_dict()["metadata"]["container"]["tags"],
+                    data["metadata"]["container"]["tags"],
                 )
             except KeyError:
                 continue


### PR DESCRIPTION
Unblocks #2592.

- `AsyncIterator[T]` annotations on `@asynccontextmanager` functions are now flagged as deprecated by pyright; switch the four affected sites to `AsyncGenerator[T]`.
- `page.as_dict()` is typed as possibly `None`; cast through `or {}` so the subscript chain is safe.

Verified clean under both pyright 1.1.408 (current pin) and 1.1.409.