### PR TITLE
Add 5 missing JSU implementations to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -615,3 +615,41 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+
+  #
+  # JSU (JSON Schema Utils) implementations
+  #
+  - package-ecosystem: "docker"
+    directory: "/implementations/c-jsu"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/implementations/python-jsu"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/implementations/js-jsu"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/implementations/java-jsu"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/implementations/perl-jsu"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Probably this is necessary so that the implementations are run?

Are there other necessary changes to the CI?