### PR TITLE
use "javascript" instead of "js" to help bowtie language classification

### DIFF
--- a/implementations/c-jsu/bowtie_jsu_compile.py
+++ b/implementations/c-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js":  # requires node_modules
+            case "js"|"javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/c-jsu/bowtie_jsu_compile.py
+++ b/implementations/c-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js"|"javascript":  # requires node_modules
+            case "js" | "javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/java-jsu/bowtie_jsu_compile.py
+++ b/implementations/java-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js":  # requires node_modules
+            case "js"|"javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/java-jsu/bowtie_jsu_compile.py
+++ b/implementations/java-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js"|"javascript":  # requires node_modules
+            case "js" | "javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/js-jsu/Dockerfile
+++ b/implementations/js-jsu/Dockerfile
@@ -26,4 +26,4 @@ RUN echo '{"name": "bowtie-js-jsu", "type": "module"}' | jq > package.json
 RUN npm install /usr/lib/python3.*/site-packages/json_model/runtime/js --install-links
 
 COPY bowtie_jsu_compile.py .
-CMD ["python3", "./bowtie_jsu_compile.py", "JS"]
+CMD ["python3", "./bowtie_jsu_compile.py", "JavaScript"]

--- a/implementations/js-jsu/bowtie_jsu_compile.py
+++ b/implementations/js-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js":  # requires node_modules
+            case "js"|"javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/js-jsu/bowtie_jsu_compile.py
+++ b/implementations/js-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js"|"javascript":  # requires node_modules
+            case "js" | "javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/perl-jsu/bowtie_jsu_compile.py
+++ b/implementations/perl-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js":  # requires node_modules
+            case "js"|"javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/perl-jsu/bowtie_jsu_compile.py
+++ b/implementations/perl-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js"|"javascript":  # requires node_modules
+            case "js" | "javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/python-jsu/bowtie_jsu_compile.py
+++ b/implementations/python-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js":  # requires node_modules
+            case "js"|"javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]

--- a/implementations/python-jsu/bowtie_jsu_compile.py
+++ b/implementations/python-jsu/bowtie_jsu_compile.py
@@ -104,7 +104,7 @@ class Runner:
                 self.output = TMP / "schema.out"
                 self.runner = [str(self.output)]
                 vers_cmd = ["cc", "--version"]
-            case "js"|"javascript":  # requires node_modules
+            case "js" | "javascript":  # requires node_modules
                 self.output = TMP / "schema.js"
                 self.runner = ["node", str(self.output)]
                 vers_cmd = ["node", "--version"]


### PR DESCRIPTION
Otherwise bowtie classify the js-jsu implementation as "js" instead of "javascript" for others.