### PR TITLE
Add support for annotations in the Java networknt implementation harness

### DIFF
--- a/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -124,14 +124,12 @@ public class BowtieJsonSchemaValidator {
     output.println(objectMapper.writeValueAsString(dialectResponse));
   }
 
-  private void
-  addAnnotation(Map<String, Map<String, Map<String, Object>>> annotations,
-                String instanceLoc, String schemaLoc, String keyword,
-                Object value) {
-    Map<String, Map<String, Object>> byKeyword = annotations.computeIfAbsent(
-        instanceLoc, k -> new LinkedHashMap<>()); // NOPMD
-    Map<String, Object> bySchema =
-        byKeyword.computeIfAbsent(keyword, k -> new LinkedHashMap<>()); // NOPMD
+  @SuppressWarnings("PMD.UseConcurrentHashMap")
+  private void addAnnotation(
+      Map<String, Map<String, Map<String, Object>>> annotations, String instanceLoc, 
+      String schemaLoc, String keyword, Object value) {
+    Map<String, Map<String, Object>> byKeyword = annotations.computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>()); // NOPMD
+    Map<String, Object> bySchema = byKeyword.computeIfAbsent(keyword, k -> new LinkedHashMap<>()); // NOPMD
     bySchema.put(schemaLoc, value);
   }
 
@@ -174,6 +172,7 @@ public class BowtieJsonSchemaValidator {
     }
   }
 
+  @SuppressWarnings("PMD.UseConcurrentHashMap")
   private TestResult runWithAnnotations(Schema jsonSchema, JsonNode test) {
     try {
       OutputUnit outputUnit = jsonSchema.validate(

--- a/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -12,6 +12,7 @@ import com.networknt.schema.resource.ResourceLoader;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -123,32 +124,36 @@ public class BowtieJsonSchemaValidator {
     output.println(objectMapper.writeValueAsString(dialectResponse));
   }
 
-  private void collectAnnotations(
-      OutputUnit unit,
-      Map<String, Map<String, Map<String, Object>>> annotations) {
-    if (unit == null)
-      return;
+  private void addAnnotation(
+      Map<String, Map<String, Map<String, Object>>> annotations, String instanceLoc, 
+      String schemaLoc, String keyword, Object value) {
+    Map<String, Map<String, Object>> byKeyword = annotations.computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>()); // NOPMD
+    Map<String, Object> bySchema = byKeyword.computeIfAbsent(keyword, k -> new LinkedHashMap<>()); // NOPMD
+    bySchema.put(schemaLoc, value);
+  }
 
-    String instanceLoc = unit.getInstanceLocation() != null
-                             ? unit.getInstanceLocation().toString()
-                             : "";
-    String schemaLoc = unit.getEvaluationPath() != null
-                           ? unit.getEvaluationPath().toString()
-                           : "";
+  private String normalizeSchemaLocation(OutputUnit unit) {
+    String schemaLoc = unit.getEvaluationPath() != null ? unit.getEvaluationPath().toString() : "";
     if (schemaLoc.isEmpty()) {
-      schemaLoc = "#";
+      return "#";
     } else if (schemaLoc.startsWith("/")) {
-      schemaLoc = "#" + schemaLoc;
+      return "#" + schemaLoc;
     }
+    return schemaLoc;
+  }
+
+  private void collectAnnotations(OutputUnit unit, Map<String, Map<String, Map<String, Object>>> annotations) {
+    if (unit == null) {
+      return;
+    }
+
+    String instanceLoc = unit.getInstanceLocation() != null ? unit.getInstanceLocation().toString() : "";
+    String schemaLoc = normalizeSchemaLocation(unit);
 
     Map<String, Object> unitAnnotations = unit.getAnnotations();
     if (unitAnnotations != null && !unitAnnotations.isEmpty()) {
       for (Map.Entry<String, Object> entry : unitAnnotations.entrySet()) {
-        String keyword = entry.getKey();
-        Object value = entry.getValue();
-        annotations.computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>())
-            .computeIfAbsent(keyword, k -> new LinkedHashMap<>())
-            .put(schemaLoc, value);
+        addAnnotation(annotations, instanceLoc, schemaLoc, entry.getKey(), entry.getValue());
       }
     }
 
@@ -157,6 +162,39 @@ public class BowtieJsonSchemaValidator {
         collectAnnotations(child, annotations);
       }
     }
+  }
+
+  private TestResult runWithAnnotations(Schema jsonSchema, JsonNode test) {
+    try {
+      OutputUnit outputUnit = jsonSchema.validate(
+          test.get("instance"),
+          OutputFormat.HIERARCHICAL,
+          executionContext -> {
+            executionContext.executionConfig(builder -> {
+              builder.annotationCollectionEnabled(true);
+              builder.annotationCollectionFilter(keyword -> true);
+            });
+          }
+      );
+
+      Map<String, Map<String, Map<String, Object>>> annotations = new LinkedHashMap<>(); // NOPMD
+      collectAnnotations(outputUnit, annotations);
+
+      if (annotations.isEmpty()) {
+        return new TestResult(outputUnit.isValid(), Collections.emptyMap());
+      }
+      return new TestResult(outputUnit.isValid(), annotations);
+    } catch (Exception e) {
+      List<Error> errors = jsonSchema.validate(test.get("instance"));
+      boolean isValid = errors == null || errors.isEmpty();
+      return new TestResult(isValid, Collections.emptyMap());
+    }
+  }
+
+  private TestResult runValidation(Schema jsonSchema, JsonNode test) {
+    List<Error> errors = jsonSchema.validate(test.get("instance"));
+    boolean isValid = errors == null || errors.isEmpty();
+    return new TestResult(isValid, Collections.emptyMap());
   }
 
   private void run(JsonNode node) {
@@ -188,30 +226,9 @@ public class BowtieJsonSchemaValidator {
       for (JsonNode test : tests) {
         Schema jsonSchema = schemaRegistry.getSchema(testCase.get("schema"));
         if (collectAnnotations) {
-          try {
-            OutputUnit outputUnit = jsonSchema.validate(
-                test.get("instance"), OutputFormat.HIERARCHICAL,
-                executionContext -> {
-                  executionContext.executionConfig(builder -> {
-                    builder.annotationCollectionEnabled(true);
-                    builder.annotationCollectionFilter(keyword -> true);
-                  });
-                });
-            boolean isValid = outputUnit.isValid();
-            Map<String, Map<String, Map<String, Object>>> annotations =
-                new LinkedHashMap<>();
-            collectAnnotations(outputUnit, annotations);
-            results.add(new TestResult(
-                isValid, annotations.isEmpty() ? null : annotations));
-          } catch (Exception e) {
-            List<Error> errors = jsonSchema.validate(test.get("instance"));
-            boolean isValid = errors == null || errors.isEmpty();
-            results.add(new TestResult(isValid, null));
-          }
+          results.add(runWithAnnotations(jsonSchema, test));
         } else {
-          List<Error> errors = jsonSchema.validate(test.get("instance"));
-          boolean isValid = errors == null || errors.isEmpty();
-          results.add(new TestResult(isValid, null));
+          results.add(runValidation(jsonSchema, test));
         }
       }
       String responseString = objectMapper.writeValueAsString(
@@ -299,6 +316,5 @@ record TestCase(String description, String comment, JsonNode schema,
 record Test(String description, String comment, JsonNode instance,
             JsonNode valid, JsonNode assertions) {}
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
-record TestResult(boolean valid,
-                  Map<String, Map<String, Map<String, Object>>> annotations) {}
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+record TestResult(boolean valid, Map<String, Map<String, Map<String, Object>>> annotations) {}

--- a/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -124,12 +124,17 @@ public class BowtieJsonSchemaValidator {
   }
 
   private void collectAnnotations(
-    OutputUnit unit,
-    Map<String, Map<String, Map<String, Object>>> annotations) {
-    if (unit == null) return;
+      OutputUnit unit,
+      Map<String, Map<String, Map<String, Object>>> annotations) {
+    if (unit == null)
+      return;
 
-    String instanceLoc = unit.getInstanceLocation() != null ? unit.getInstanceLocation().toString() : "";
-    String schemaLoc = unit.getEvaluationPath() != null ? unit.getEvaluationPath().toString() : "";
+    String instanceLoc = unit.getInstanceLocation() != null
+                             ? unit.getInstanceLocation().toString()
+                             : "";
+    String schemaLoc = unit.getEvaluationPath() != null
+                           ? unit.getEvaluationPath().toString()
+                           : "";
     if (schemaLoc.isEmpty()) {
       schemaLoc = "#";
     } else if (schemaLoc.startsWith("/")) {
@@ -141,8 +146,7 @@ public class BowtieJsonSchemaValidator {
       for (Map.Entry<String, Object> entry : unitAnnotations.entrySet()) {
         String keyword = entry.getKey();
         Object value = entry.getValue();
-        annotations
-            .computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>())
+        annotations.computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>())
             .computeIfAbsent(keyword, k -> new LinkedHashMap<>())
             .put(schemaLoc, value);
       }
@@ -161,7 +165,8 @@ public class BowtieJsonSchemaValidator {
     }
     JsonNode testCase = node.get("case");
     JsonNode tests = testCase.get("tests");
-    boolean collectAnnotations = node.has("collect_annotations") && node.get("collect_annotations").asBoolean();
+    boolean collectAnnotations = node.has("collect_annotations") &&
+                                 node.get("collect_annotations").asBoolean();
     try {
       SchemaRegistry schemaRegistry = SchemaRegistry.withDefaultDialect(
           versionFlag,
@@ -175,8 +180,7 @@ public class BowtieJsonSchemaValidator {
                  .resourceLoaders(resourceLoaders -> {
                    if (testCase.has("registry")) {
                      CustomResourceLoader resourceLoader =
-                         new CustomResourceLoader(
-                             testCase.get("registry"));
+                         new CustomResourceLoader(testCase.get("registry"));
                      resourceLoaders.add(resourceLoader);
                    }
                  }));
@@ -186,20 +190,19 @@ public class BowtieJsonSchemaValidator {
         if (collectAnnotations) {
           try {
             OutputUnit outputUnit = jsonSchema.validate(
-                test.get("instance"),
-                OutputFormat.HIERARCHICAL,
+                test.get("instance"), OutputFormat.HIERARCHICAL,
                 executionContext -> {
                   executionContext.executionConfig(builder -> {
                     builder.annotationCollectionEnabled(true);
                     builder.annotationCollectionFilter(keyword -> true);
                   });
-                }
-            );
+                });
             boolean isValid = outputUnit.isValid();
             Map<String, Map<String, Map<String, Object>>> annotations =
                 new LinkedHashMap<>();
             collectAnnotations(outputUnit, annotations);
-            results.add(new TestResult(isValid, annotations.isEmpty() ? null : annotations));
+            results.add(new TestResult(
+                isValid, annotations.isEmpty() ? null : annotations));
           } catch (Exception e) {
             List<Error> errors = jsonSchema.validate(test.get("instance"));
             boolean isValid = errors == null || errors.isEmpty();
@@ -293,9 +296,9 @@ record Link(String url, String description) {}
 record TestCase(String description, String comment, JsonNode schema,
                 JsonNode registry, List<Test> tests) {}
 
-record
-    Test(String description, String comment, JsonNode instance, JsonNode valid, JsonNode assertions) {
-}
+record Test(String description, String comment, JsonNode instance,
+            JsonNode valid, JsonNode assertions) {}
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-record TestResult(boolean valid, Map<String, Map<String, Map<String, Object>>> annotations) {}
+record TestResult(boolean valid,
+                  Map<String, Map<String, Map<String, Object>>> annotations) {}

--- a/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -1,13 +1,18 @@
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.networknt.schema.AbsoluteIri;
 import com.networknt.schema.Error;
+import com.networknt.schema.OutputFormat;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.SpecificationVersion;
+import com.networknt.schema.output.OutputUnit;
 import com.networknt.schema.resource.InputStreamSource;
 import com.networknt.schema.resource.ResourceLoader;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.Manifest;
@@ -118,11 +123,45 @@ public class BowtieJsonSchemaValidator {
     output.println(objectMapper.writeValueAsString(dialectResponse));
   }
 
+  private void collectAnnotations(
+    OutputUnit unit,
+    Map<String, Map<String, Map<String, Object>>> annotations) {
+    if (unit == null) return;
+
+    String instanceLoc = unit.getInstanceLocation() != null ? unit.getInstanceLocation().toString() : "";
+    String schemaLoc = unit.getEvaluationPath() != null ? unit.getEvaluationPath().toString() : "";
+    if (schemaLoc.isEmpty()) {
+      schemaLoc = "#";
+    } else if (schemaLoc.startsWith("/")) {
+      schemaLoc = "#" + schemaLoc;
+    }
+
+    Map<String, Object> unitAnnotations = unit.getAnnotations();
+    if (unitAnnotations != null && !unitAnnotations.isEmpty()) {
+      for (Map.Entry<String, Object> entry : unitAnnotations.entrySet()) {
+        String keyword = entry.getKey();
+        Object value = entry.getValue();
+        annotations
+            .computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>())
+            .computeIfAbsent(keyword, k -> new LinkedHashMap<>())
+            .put(schemaLoc, value);
+      }
+    }
+
+    if (unit.getDetails() != null) {
+      for (OutputUnit child : unit.getDetails()) {
+        collectAnnotations(child, annotations);
+      }
+    }
+  }
+
   private void run(JsonNode node) {
     if (!started) {
       throw new IllegalArgumentException("Not started!");
     }
-    RunRequest runRequest = objectMapper.treeToValue(node, RunRequest.class);
+    JsonNode testCase = node.get("case");
+    JsonNode tests = testCase.get("tests");
+    boolean collectAnnotations = node.has("collect_annotations") && node.get("collect_annotations").asBoolean();
     try {
       SchemaRegistry schemaRegistry = SchemaRegistry.withDefaultDialect(
           versionFlag,
@@ -134,33 +173,53 @@ public class BowtieJsonSchemaValidator {
                             .mapPrefix("https://json-schema.org", "classpath:")
                             .mapPrefix("http://json-schema.org", "classpath:"))
                  .resourceLoaders(resourceLoaders -> {
-                   if (runRequest.testCase().registry() != null) {
+                   if (testCase.has("registry")) {
                      CustomResourceLoader resourceLoader =
                          new CustomResourceLoader(
-                             runRequest.testCase().registry());
+                             testCase.get("registry"));
                      resourceLoaders.add(resourceLoader);
                    }
                  }));
-      List<TestResult> results =
-          runRequest.testCase()
-              .tests()
-              .stream()
-              .map(test -> {
-                Schema jsonSchema =
-                    schemaRegistry.getSchema(runRequest.testCase().schema());
-                List<Error> errors = jsonSchema.validate(test.instance());
-                boolean isValid = errors == null || errors.isEmpty();
-                return new TestResult(isValid);
-              })
-              .toList();
-      output.println(objectMapper.writeValueAsString(
-          new RunResponse(runRequest.seq(), results)));
+      List<TestResult> results = new ArrayList<>();
+      for (JsonNode test : tests) {
+        Schema jsonSchema = schemaRegistry.getSchema(testCase.get("schema"));
+        if (collectAnnotations) {
+          try {
+            OutputUnit outputUnit = jsonSchema.validate(
+                test.get("instance"),
+                OutputFormat.HIERARCHICAL,
+                executionContext -> {
+                  executionContext.executionConfig(builder -> {
+                    builder.annotationCollectionEnabled(true);
+                    builder.annotationCollectionFilter(keyword -> true);
+                  });
+                }
+            );
+            boolean isValid = outputUnit.isValid();
+            Map<String, Map<String, Map<String, Object>>> annotations =
+                new LinkedHashMap<>();
+            collectAnnotations(outputUnit, annotations);
+            results.add(new TestResult(isValid, annotations.isEmpty() ? null : annotations));
+          } catch (Exception e) {
+            List<Error> errors = jsonSchema.validate(test.get("instance"));
+            boolean isValid = errors == null || errors.isEmpty();
+            results.add(new TestResult(isValid, null));
+          }
+        } else {
+          List<Error> errors = jsonSchema.validate(test.get("instance"));
+          boolean isValid = errors == null || errors.isEmpty();
+          results.add(new TestResult(isValid, null));
+        }
+      }
+      String responseString = objectMapper.writeValueAsString(
+          new RunResponse(node.get("seq"), results));
+      output.println(responseString);
     } catch (Exception e) {
       StringWriter stringWriter = new StringWriter();
       PrintWriter printWriter = new PrintWriter(stringWriter);
       e.printStackTrace(printWriter);
       RunErroredResponse response = new RunErroredResponse(
-          runRequest.seq(), true,
+          node.get("seq"), true,
           new ErrorContext(e.getMessage(), stackTraceToString(e)));
       output.println(objectMapper.writeValueAsString(response));
     }
@@ -235,7 +294,8 @@ record TestCase(String description, String comment, JsonNode schema,
                 JsonNode registry, List<Test> tests) {}
 
 record
-    Test(String description, String comment, JsonNode instance, boolean valid) {
+    Test(String description, String comment, JsonNode instance, JsonNode valid, JsonNode assertions) {
 }
 
-record TestResult(boolean valid) {}
+@JsonInclude(JsonInclude.Include.NON_NULL)
+record TestResult(boolean valid, Map<String, Map<String, Map<String, Object>>> annotations) {}

--- a/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -124,16 +124,21 @@ public class BowtieJsonSchemaValidator {
     output.println(objectMapper.writeValueAsString(dialectResponse));
   }
 
-  private void addAnnotation(
-      Map<String, Map<String, Map<String, Object>>> annotations, String instanceLoc, 
-      String schemaLoc, String keyword, Object value) {
-    Map<String, Map<String, Object>> byKeyword = annotations.computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>()); // NOPMD
-    Map<String, Object> bySchema = byKeyword.computeIfAbsent(keyword, k -> new LinkedHashMap<>()); // NOPMD
+  private void
+  addAnnotation(Map<String, Map<String, Map<String, Object>>> annotations,
+                String instanceLoc, String schemaLoc, String keyword,
+                Object value) {
+    Map<String, Map<String, Object>> byKeyword = annotations.computeIfAbsent(
+        instanceLoc, k -> new LinkedHashMap<>()); // NOPMD
+    Map<String, Object> bySchema =
+        byKeyword.computeIfAbsent(keyword, k -> new LinkedHashMap<>()); // NOPMD
     bySchema.put(schemaLoc, value);
   }
 
   private String normalizeSchemaLocation(OutputUnit unit) {
-    String schemaLoc = unit.getEvaluationPath() != null ? unit.getEvaluationPath().toString() : "";
+    String schemaLoc = unit.getEvaluationPath() != null
+                           ? unit.getEvaluationPath().toString()
+                           : "";
     if (schemaLoc.isEmpty()) {
       return "#";
     } else if (schemaLoc.startsWith("/")) {
@@ -142,18 +147,23 @@ public class BowtieJsonSchemaValidator {
     return schemaLoc;
   }
 
-  private void collectAnnotations(OutputUnit unit, Map<String, Map<String, Map<String, Object>>> annotations) {
+  private void collectAnnotations(
+      OutputUnit unit,
+      Map<String, Map<String, Map<String, Object>>> annotations) {
     if (unit == null) {
       return;
     }
 
-    String instanceLoc = unit.getInstanceLocation() != null ? unit.getInstanceLocation().toString() : "";
+    String instanceLoc = unit.getInstanceLocation() != null
+                             ? unit.getInstanceLocation().toString()
+                             : "";
     String schemaLoc = normalizeSchemaLocation(unit);
 
     Map<String, Object> unitAnnotations = unit.getAnnotations();
     if (unitAnnotations != null && !unitAnnotations.isEmpty()) {
       for (Map.Entry<String, Object> entry : unitAnnotations.entrySet()) {
-        addAnnotation(annotations, instanceLoc, schemaLoc, entry.getKey(), entry.getValue());
+        addAnnotation(annotations, instanceLoc, schemaLoc, entry.getKey(),
+                      entry.getValue());
       }
     }
 
@@ -167,17 +177,15 @@ public class BowtieJsonSchemaValidator {
   private TestResult runWithAnnotations(Schema jsonSchema, JsonNode test) {
     try {
       OutputUnit outputUnit = jsonSchema.validate(
-          test.get("instance"),
-          OutputFormat.HIERARCHICAL,
-          executionContext -> {
+          test.get("instance"), OutputFormat.HIERARCHICAL, executionContext -> {
             executionContext.executionConfig(builder -> {
               builder.annotationCollectionEnabled(true);
               builder.annotationCollectionFilter(keyword -> true);
             });
-          }
-      );
+          });
 
-      Map<String, Map<String, Map<String, Object>>> annotations = new LinkedHashMap<>(); // NOPMD
+      Map<String, Map<String, Map<String, Object>>> annotations =
+          new LinkedHashMap<>(); // NOPMD
       collectAnnotations(outputUnit, annotations);
 
       if (annotations.isEmpty()) {
@@ -317,4 +325,5 @@ record Test(String description, String comment, JsonNode instance,
             JsonNode valid, JsonNode assertions) {}
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-record TestResult(boolean valid, Map<String, Map<String, Map<String, Object>>> annotations) {}
+record TestResult(boolean valid,
+                  Map<String, Map<String, Map<String, Object>>> annotations) {}

--- a/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
+++ b/implementations/java-networknt-json-schema-validator/BowtieJsonSchemaValidator.java
@@ -125,11 +125,14 @@ public class BowtieJsonSchemaValidator {
   }
 
   @SuppressWarnings("PMD.UseConcurrentHashMap")
-  private void addAnnotation(
-      Map<String, Map<String, Map<String, Object>>> annotations, String instanceLoc, 
-      String schemaLoc, String keyword, Object value) {
-    Map<String, Map<String, Object>> byKeyword = annotations.computeIfAbsent(instanceLoc, k -> new LinkedHashMap<>()); // NOPMD
-    Map<String, Object> bySchema = byKeyword.computeIfAbsent(keyword, k -> new LinkedHashMap<>()); // NOPMD
+  private void
+  addAnnotation(Map<String, Map<String, Map<String, Object>>> annotations,
+                String instanceLoc, String schemaLoc, String keyword,
+                Object value) {
+    Map<String, Map<String, Object>> byKeyword = annotations.computeIfAbsent(
+        instanceLoc, k -> new LinkedHashMap<>()); // NOPMD
+    Map<String, Object> bySchema =
+        byKeyword.computeIfAbsent(keyword, k -> new LinkedHashMap<>()); // NOPMD
     bySchema.put(schemaLoc, value);
   }
 


### PR DESCRIPTION
As per the discussion on slack, added annotation support for networknt implementation without breaking the existing bowtie commands.
Now when the run command includes ` "collect_annotations": true `, the harness switches from simple validation to annotation collection, while without the flag behavior is identical to the current upstream harness.

**Working**
- A new `collectAnnotations()` method recursively walks the OutputUnit tree returned by networknt and extracts annotations as a nested map: instanceLocation → keyword → schemaLocation → value
- The `TestResult` record now has an optional annotations field, annotated with `@JsonInclude(NON_EMPTY)` so it is completely omitted from the JSON output when not in annotation mode
- The `Test` record's valid field was changed from `boolean` to `JsonNode `to handle annotation test cases that may not have a valid field

**Testing**
``` bash
# Build
docker build -t networknt-test implementations/java-networknt-json-schema-validator/

# Validation mode (no flag — should show only valid field)
printf '{"cmd":"start","version":1}\n{"cmd":"dialect","dialect":"https://json-schema.org/draft/2020-12/schema"}\n{"cmd":"run","seq":1,"case":{"description":"type check","schema":{"type":"string"},"tests":[{"description":"valid","instance":"hello"},{"description":"invalid","instance":42}]}}\n{"cmd":"stop"}\n' | docker run --rm -i networknt-test

# Annotation mode (with flag — should show annotations)
printf '{"cmd":"start","version":1}\n{"cmd":"dialect","dialect":"https://json-schema.org/draft/2020-12/schema"}\n{"cmd":"run","seq":1,"collect_annotations":true,"case":{"description":"title test","schema":{"title":"My Schema","type":"string"},"tests":[{"description":"a string","instance":"hello"}]}}\n{"cmd":"stop"}\n' | docker run --rm -i networknt-test
```

**Output**
``` bash
# Validation mode
{"ok":true}
{"seq":1,"results":[{"valid":true},{"valid":false}]}

# Annotation mode
{"ok":true}
{"seq":1,"results":[{"valid":true,"annotations":{"":{"title":{"#":"My Schema"}}}}]}
```