### PR TITLE
Group react and react-dom into one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
     directory: "frontend"
     schedule:
       interval: "weekly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
     cooldown:
       default-days: 7
 


### PR DESCRIPTION
## Summary
- React requires `react` and `react-dom` to be the exact same version at runtime, so when dependabot opens independent PRs for each, the first one to merge (or even hit CI) breaks until its sibling catches up — exactly what happened on #2546.
- Group the React pair (plus their `@types/*` counterparts) so dependabot bundles them into a single PR going forward.

## Test plan
- [ ] Confirm next dependabot run produces a single grouped PR rather than separate ones when both `react` and `react-dom` have new releases.