### PR TITLE
Adapt jsonschex 0.7.0 to use :loader option 

### DIFF
--- a/implementations/elixir-jsonschex/lib/bowtie_jsonschex.ex
+++ b/implementations/elixir-jsonschex/lib/bowtie_jsonschex.ex
@@ -123,9 +123,7 @@ defmodule BowtieJSONSchex do
   defp build_schema(raw_schema, registry, state) do
     loader = build_loader(registry)
 
-    opts =
-      [external_loader: loader]
-      |> maybe_put_default_dialect(state)
+    opts = maybe_put_default_dialect([loader: loader], state)
 
     case JSONSchex.compile(raw_schema, opts) do
       {:ok, schema} -> schema

--- a/implementations/elixir-jsonschex/mix.exs
+++ b/implementations/elixir-jsonschex/mix.exs
@@ -26,7 +26,7 @@ defmodule BowtieJSONSchex.MixProject do
 
   defp deps do
     [
-      {:jsonschex, "~> 0.5"},
+      {:jsonschex, "~> 0.7"},
       {:idna, "~> 7.1"},
       {:decimal, "~> 3.0"}
     ]


### PR DESCRIPTION
There is a breaking change that rename the remote/reference loading option from `:external_loader` to `:loader`, so this PR fixed this adaption issue of jsonschex `0.7.0`, please review, thanks.