### PR TITLE
lua-schema: fix with the latest alpine

### DIFF
--- a/implementations/lua-schema/Dockerfile
+++ b/implementations/lua-schema/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     lua5.4-rex-pcre2 \
     luarocks5.4 \
  && luarocks-5.4 install dkjson \
- && luarocks-5.4 install --dev lua-schema
+ && luarocks-5.4 install lua-schema
 COPY bowtie_schema.lua ./
 
 CMD ["lua5.4", "bowtie_schema.lua"]


### PR DESCRIPTION
the luarocks option --dev doesn't work with alpine 3.23 & 3.24

Error: No results matching query were found for Lua 5.4.