### PR TITLE
lua-schema: refactor with lsb_release

### DIFF
--- a/implementations/lua-schema/Dockerfile
+++ b/implementations/lua-schema/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.24
 WORKDIR /harness
 
 RUN apk add --no-cache \
+    lsb-release-minimal \
     lua5.4 \
     lua5.4-lpeg \
     lua5.4-rex-pcre2 \

--- a/implementations/lua-schema/bowtie_schema.lua
+++ b/implementations/lua-schema/bowtie_schema.lua
@@ -97,8 +97,8 @@ local cmds = {
           'http://json-schema.org/draft-06/schema#',
           'http://json-schema.org/draft-04/schema#',
         },
-        os = exec 'uname',
-        os_version = exec 'uname -r',
+        os = exec 'lsb_release -is',
+        os_version = exec 'lsb_release -rs',
         language_version = _VERSION:match '^%S+%s+(%S+)',
       },
     }

--- a/implementations/lua-schema/bowtie_schema.lua
+++ b/implementations/lua-schema/bowtie_schema.lua
@@ -84,7 +84,6 @@ local cmds = {
     return {
       version = 1,
       implementation = {
-        language = 'lua',
         name = schema._NAME,
         version = schema._VERSION,
         homepage = 'https://fperrad.frama.io/lua-schema',
@@ -97,9 +96,10 @@ local cmds = {
           'http://json-schema.org/draft-06/schema#',
           'http://json-schema.org/draft-04/schema#',
         },
+        language = 'lua',
+        language_version = _VERSION:match '^%S+%s+(%S+)',
         os = exec 'lsb_release -is',
         os_version = exec 'lsb_release -rs',
-        language_version = _VERSION:match '^%S+%s+(%S+)',
       },
     }
   end,


### PR DESCRIPTION
the given info becomes "Ran on Alpine 3.24.0" instead of "Ran on Linux 7.0.0-22-generic"

I think that the Alpine version is more useful than the kernel version.