### PR TITLE
os-release / lsb_release

### DIFF
--- a/implementations/c-jsu/bowtie_jsu_compile.py
+++ b/implementations/c-jsu/bowtie_jsu_compile.py
@@ -213,6 +213,8 @@ class Runner:
 
         assert req.get("version") == 1, "expecting protocol version 1"
 
+        os_release = platform.freedesktop_os_release()
+
         return {
             "version": 1,
             "implementation": {
@@ -220,8 +222,8 @@ class Runner:
                 "version": self.jsu_version,
                 "language": self.language,
                 "language_version": self.language_version,
-                "os": platform.system(),
-                "os_version": platform.release(),
+                "os": os_release["ID"],
+                "os_version": os_release["VERSION_ID"],
                 "dialects": sorted(VERSIONS.keys()),
                 "homepage": "https://github.com/zx80/json-schema-utils/",
                 "documentation": "https://github.com/zx80/json-schema-utils/",

--- a/implementations/java-jsu/bowtie_jsu_compile.py
+++ b/implementations/java-jsu/bowtie_jsu_compile.py
@@ -213,6 +213,8 @@ class Runner:
 
         assert req.get("version") == 1, "expecting protocol version 1"
 
+        os_release = platform.freedesktop_os_release()
+
         return {
             "version": 1,
             "implementation": {
@@ -220,8 +222,8 @@ class Runner:
                 "version": self.jsu_version,
                 "language": self.language,
                 "language_version": self.language_version,
-                "os": platform.system(),
-                "os_version": platform.release(),
+                "os": os_release["ID"],
+                "os_version": os_release["VERSION_ID"],
                 "dialects": sorted(VERSIONS.keys()),
                 "homepage": "https://github.com/zx80/json-schema-utils/",
                 "documentation": "https://github.com/zx80/json-schema-utils/",

--- a/implementations/js-jsu/bowtie_jsu_compile.py
+++ b/implementations/js-jsu/bowtie_jsu_compile.py
@@ -213,6 +213,8 @@ class Runner:
 
         assert req.get("version") == 1, "expecting protocol version 1"
 
+        os_release = platform.freedesktop_os_release()
+
         return {
             "version": 1,
             "implementation": {
@@ -220,8 +222,8 @@ class Runner:
                 "version": self.jsu_version,
                 "language": self.language,
                 "language_version": self.language_version,
-                "os": platform.system(),
-                "os_version": platform.release(),
+                "os": os_release["ID"],
+                "os_version": os_release["VERSION_ID"],
                 "dialects": sorted(VERSIONS.keys()),
                 "homepage": "https://github.com/zx80/json-schema-utils/",
                 "documentation": "https://github.com/zx80/json-schema-utils/",

--- a/implementations/perl-jsu/bowtie_jsu_compile.py
+++ b/implementations/perl-jsu/bowtie_jsu_compile.py
@@ -213,6 +213,8 @@ class Runner:
 
         assert req.get("version") == 1, "expecting protocol version 1"
 
+        os_release = platform.freedesktop_os_release()
+
         return {
             "version": 1,
             "implementation": {
@@ -220,8 +222,8 @@ class Runner:
                 "version": self.jsu_version,
                 "language": self.language,
                 "language_version": self.language_version,
-                "os": platform.system(),
-                "os_version": platform.release(),
+                "os": os_release["ID"],
+                "os_version": os_release["VERSION_ID"],
                 "dialects": sorted(VERSIONS.keys()),
                 "homepage": "https://github.com/zx80/json-schema-utils/",
                 "documentation": "https://github.com/zx80/json-schema-utils/",

--- a/implementations/php-justinrainbow-json-schema/Dockerfile
+++ b/implementations/php-justinrainbow-json-schema/Dockerfile
@@ -12,6 +12,7 @@ FROM php:8.5-cli-alpine3.22
 
 WORKDIR /usr/src/json-schema
 
+RUN apk add --no-cache lsb-release-minimal
 COPY ./src ./src
 COPY ./bootstrap.php .
 COPY composer.* .

--- a/implementations/php-justinrainbow-json-schema/src/TestHarness.php
+++ b/implementations/php-justinrainbow-json-schema/src/TestHarness.php
@@ -77,7 +77,6 @@ class TestHarness
         return [
             'version' => 1,
             'implementation' => [
-                'language' => 'php',
                 'name' => 'justinrainbow-json-schema',
                 'version' => InstalledVersions::getVersion('justinrainbow/json-schema'),
                 'homepage' => 'https://github.com/jsonrainbow/json-schema',
@@ -90,9 +89,10 @@ class TestHarness
                     'http://json-schema.org/draft-04/schema#',
                     'http://json-schema.org/draft-03/schema#',
                 ],
-                'os' => PHP_OS,
-                'os_version' => php_uname('r'),
+                'language' => 'php',
                 'language_version' => PHP_VERSION,
+                'os' => rtrim(shell_exec('lsb_release -is')),
+                'os_version' => rtrim(shell_exec('lsb_release -rs')),
             ],
         ];
     }

--- a/implementations/php-opis-json-schema/Dockerfile
+++ b/implementations/php-opis-json-schema/Dockerfile
@@ -11,6 +11,7 @@ FROM php:8.5.0RC2-fpm-alpine
 
 WORKDIR /usr/src/myapp
 
+RUN apk add --no-cache lsb-release-minimal
 COPY bowtieJsonSchema.php .
 COPY --from=builder /usr/src/myapp/vendor /usr/src/myapp/vendor
 

--- a/implementations/php-opis-json-schema/bowtieJsonSchema.php
+++ b/implementations/php-opis-json-schema/bowtieJsonSchema.php
@@ -30,7 +30,6 @@ function start($request)
     return [
         'version' => 1,
         'implementation' => [
-            'language' => 'php',
             'name' => 'opis-json-schema',
             'version' => $jsonschema_version,
             'homepage' => 'https://opis.io/json-schema',
@@ -43,9 +42,10 @@ function start($request)
                 'http://json-schema.org/draft-07/schema#',
                 'http://json-schema.org/draft-06/schema#',
             ],
-            'os' => PHP_OS,
-            'os_version' => php_uname('r'),
+            'language' => 'php',
             'language_version' => PHP_VERSION,
+            'os' => rtrim(shell_exec('lsb_release -is')),
+            'os_version' => rtrim(shell_exec('lsb_release -rs')),
         ],
     ];
 }

--- a/implementations/python-fastjsonschema/bowtie_fastjsonschema.py
+++ b/implementations/python-fastjsonschema/bowtie_fastjsonschema.py
@@ -26,10 +26,10 @@ class Runner:
     def cmd_start(self, version):
         assert version == 1
         self._started = True
+        os_release = platform.freedesktop_os_release()
         return dict(
             version=1,
             implementation=dict(
-                language="python",
                 name="fastjsonschema",
                 version=metadata.version("fastjsonschema"),
                 homepage="https://horejsek.github.io/python-fastjsonschema/",
@@ -45,9 +45,10 @@ class Runner:
                     "http://json-schema.org/draft-06/schema#",
                     "http://json-schema.org/draft-04/schema#",
                 ],
-                os=platform.system(),
-                os_version=platform.release(),
+                language="python",
                 language_version=platform.python_version(),
+                os=os_release["ID"],
+                os_version=os_release["VERSION_ID"],
             ),
         )
 

--- a/implementations/python-jschon/bowtie_jschon.py
+++ b/implementations/python-jschon/bowtie_jschon.py
@@ -53,10 +53,10 @@ class Runner:
     def cmd_start(self, version):
         assert version == 1
         self._started = True
+        os_release = platform.freedesktop_os_release()
         return dict(
             version=1,
             implementation=dict(
-                language="python",
                 name="jschon",
                 version=metadata.version("jschon"),
                 homepage="https://jschon.readthedocs.io/",
@@ -67,9 +67,10 @@ class Runner:
                     "https://json-schema.org/draft/2020-12/schema",
                     "https://json-schema.org/draft/2019-09/schema",
                 ],
-                os=platform.system(),
-                os_version=platform.release(),
+                language="python",
                 language_version=platform.python_version(),
+                os=os_release["ID"],
+                os_version=os_release["VERSION_ID"],
             ),
         )
 

--- a/implementations/python-jsonschema/bowtie_jsonschema.py
+++ b/implementations/python-jsonschema/bowtie_jsonschema.py
@@ -44,10 +44,10 @@ class Runner:
     def cmd_start(self, version):
         assert version == 1
         self._started = True
+        os_release = platform.freedesktop_os_release()
         return dict(
             version=1,
             implementation=dict(
-                language="python",
                 name="jsonschema",
                 version=jsonschema_version,
                 homepage="https://python-jsonschema.readthedocs.io/",
@@ -64,9 +64,10 @@ class Runner:
                     "http://json-schema.org/draft-04/schema#",
                     "http://json-schema.org/draft-03/schema#",
                 ],
-                os=platform.system(),
-                os_version=platform.release(),
+                language="python",
                 language_version=platform.python_version(),
+                os=os_release["ID"],
+                os_version=os_release["VERSION_ID"],
             ),
         )
 

--- a/implementations/python-jsu/bowtie_jsu_compile.py
+++ b/implementations/python-jsu/bowtie_jsu_compile.py
@@ -213,6 +213,8 @@ class Runner:
 
         assert req.get("version") == 1, "expecting protocol version 1"
 
+        os_release = platform.freedesktop_os_release()
+
         return {
             "version": 1,
             "implementation": {
@@ -220,8 +222,8 @@ class Runner:
                 "version": self.jsu_version,
                 "language": self.language,
                 "language_version": self.language_version,
-                "os": platform.system(),
-                "os_version": platform.release(),
+                "os": os_release["ID"],
+                "os_version": os_release["VERSION_ID"],
                 "dialects": sorted(VERSIONS.keys()),
                 "homepage": "https://github.com/zx80/json-schema-utils/",
                 "documentation": "https://github.com/zx80/json-schema-utils/",

--- a/implementations/python-jsu/bowtie_jsu_python.py
+++ b/implementations/python-jsu/bowtie_jsu_python.py
@@ -64,6 +64,8 @@ class Runner:
 
         assert req.get("version") == 1, "expecting protocol version 1"
 
+        os_release = platform.freedesktop_os_release()
+
         return {
             "version": 1,
             "implementation": {
@@ -76,8 +78,8 @@ class Runner:
                 "issues": "https://github.com/zx80/json-schema-utils/issues",
                 "source": "https://github.com/zx80/json-schema-utils.git",
                 "dialects": sorted(VERSIONS.keys()),
-                "os": platform.system(),
-                "os_version": platform.release(),
+                "os": os_release["ID"],
+                "os_version": os_release["VERSION_ID"],
             },
         }
 

--- a/implementations/ruby-json_schemer/Dockerfile
+++ b/implementations/ruby-json_schemer/Dockerfile
@@ -13,6 +13,7 @@ RUN bundle install
 
 FROM ruby:4-alpine
 WORKDIR /usr/src/app
+RUN apk add --no-cache lsb-release-minimal
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY . .
 CMD ["ruby", "bowtie_json_schemer.rb"]

--- a/implementations/ruby-json_schemer/bowtie_json_schemer.rb
+++ b/implementations/ruby-json_schemer/bowtie_json_schemer.rb
@@ -76,6 +76,7 @@ ARGF.each_line do |line| # rubocop:disable Metrics/BlockLength
   when 'start'
     version = request.fetch('version')
     raise UnsupportedVersion, version unless version == 1
+
     os = `lsb_release -is`
     os_version = `lsb_release -rs`
 

--- a/implementations/ruby-json_schemer/bowtie_json_schemer.rb
+++ b/implementations/ruby-json_schemer/bowtie_json_schemer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'etc'
 require 'json'
 require 'json_schemer'
 
@@ -77,6 +76,8 @@ ARGF.each_line do |line| # rubocop:disable Metrics/BlockLength
   when 'start'
     version = request.fetch('version')
     raise UnsupportedVersion, version unless version == 1
+    os = `lsb_release -is`
+    os_version = `lsb_release -rs`
 
     {
       version: version,
@@ -88,8 +89,8 @@ ARGF.each_line do |line| # rubocop:disable Metrics/BlockLength
         issues: 'https://github.com/davishmcclurg/json_schemer/issues',
         source: 'https://github.com/davishmcclurg/json_schemer',
         dialects: SUPPORTED_DIALECTS,
-        os: Etc.uname[:sysname],
-        os_version: Etc.uname[:release],
+        os: os.chomp!,
+        os_version: os_version.chomp!,
         language_version: RUBY_VERSION,
       },
     }


### PR DESCRIPTION
Python has a builtin support of `/etc/os-release`

PHP & Ruby need a external `lsb_release`