### PR TITLE
Pin click below 8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dynamic = ["version"]
 dependencies = [
   "aiodocker",
   "attrs>=22.2.0",
+  # click 8.4 made ParamType generic, but rich-click's type stubs still
+  # reference it without a type argument, breaking strict type checking.
+  "click<8.4",
   "diagnostic",
   "github3.py",
   "httpx",

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiodocker" },
     { name = "attrs" },
+    { name = "click" },
     { name = "diagnostic" },
     { name = "github3-py" },
     { name = "httpx" },
@@ -251,6 +252,7 @@ typing = [
 requires-dist = [
     { name = "aiodocker" },
     { name = "attrs", specifier = ">=22.2.0" },
+    { name = "click", specifier = "<8.4" },
     { name = "diagnostic" },
     { name = "github3-py" },
     { name = "httpx" },
@@ -407,14 +409,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
click 8.4 made `ParamType` generic, but rich-click's type stubs still reference it without a type argument, which breaks `nox -s typing` under pyright's strict mode — 45+ `reportUnknownMemberType` errors across the `@click.option` / `@click.argument` / `version_option` decorators in `_cli.py`, plus `reportMissingTypeArgument` on our own `ParamType` subclasses.

Pin click below 8.4 until rich-click's stubs are updated for the now-generic `ParamType`. The constraint is self-documenting: when rich-click ships fixed stubs, dependabot will try to bump click, CI will flag it, and the pin can be lifted.

Only changes: `pyproject.toml` (the pin) and `uv.lock` (click 8.4.1 → 8.3.3). rich-click stays at 1.9.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)