### PR TITLE
Add a Scala 3 harness for jam01/json-schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -278,6 +278,7 @@ updates:
     cooldown:
       default-days: 7
 
+  # ignore: scala-json-schema - Dependabot doesn't support Scala.
   # ignore: scala-mjs-validator - Dependabot doesn't support Scala.
   # ignore: scala-rc-circe-json-validator - Dependabot doesn't support Scala.
   # ignore: unison-typed-json - Dependabot doesn't support Unsion.
@@ -563,6 +564,13 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/implementations/java-json-schema-react"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/implementations/scala-json-schema"
     schedule:
       interval: "daily"
     cooldown:

--- a/implementations/scala-json-schema/Dockerfile
+++ b/implementations/scala-json-schema/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /opt/harness
 COPY Harness.scala /opt/harness
 COPY build.sbt /opt/harness
 COPY project /opt/harness/project
+COPY src /opt/harness/src
 RUN sbt assembly
 
 FROM bellsoft/liberica-openjdk-alpine:26

--- a/implementations/scala-json-schema/Dockerfile
+++ b/implementations/scala-json-schema/Dockerfile
@@ -1,0 +1,11 @@
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.4_1.7.2_2.13.10 AS builder
+
+WORKDIR /opt/harness
+COPY Harness.scala /opt/harness
+COPY build.sbt /opt/harness
+COPY project /opt/harness/project
+RUN sbt assembly
+
+FROM bellsoft/liberica-openjdk-alpine:26
+COPY --from=builder /opt/harness/target/scala-*/bowtieJsonSchema.jar /opt/app/bowtieJsonSchema.jar
+CMD ["java", "-jar", "/opt/app/bowtieJsonSchema.jar"]

--- a/implementations/scala-json-schema/Harness.scala
+++ b/implementations/scala-json-schema/Harness.scala
@@ -3,10 +3,21 @@ import io.circe.parser.parse
 import io.circe.syntax.EncoderOps
 import io.circe.{Json, Decoder}
 import java.io.InputStream
+import java.nio.charset.StandardCharsets
 import java.util.Scanner
 import java.util.jar.Manifest
-import io.github.jam01.json_schema.{Config, Dialect, MutableRegistry, Schema, Uri}
+import io.github.jam01.json_schema.{Config, Dialect, MutableRegistry, Registry, Schema, Uri}
 import io.github.jam01.json_schema as js
+
+// The library resolves `$ref` purely against the supplied Registry - it doesn't bundle
+// the official meta-schema documents itself, so a schema that `$ref`s its own dialect's
+// meta-schema (e.g. the test suite's "remote ref, containing refs itself" case) needs
+// them supplied. Falls back to the officially bundled 2020-12 meta-schemas whenever a
+// URI isn't found in the per-case registry.
+final class FallbackRegistry(primary: Registry, fallback: Registry) extends Registry {
+  override def contains(schemaUri: Uri): Boolean = primary.contains(schemaUri) || fallback.contains(schemaUri)
+  override def get(schemaUri: Uri): Option[Schema] = primary.get(schemaUri).orElse(fallback.get(schemaUri))
+}
 
 class Harness {
   def operate(line: String) = {
@@ -77,7 +88,8 @@ class Harness {
 
       val schema: Schema = js.from(ujson.Readable, ujson.Readable.fromString(testCase.schema.noSpaces),
         registry = registry)
-      val validator = js.validator(schema, Config(dialect = Dialect.FullSpec, ffast = false), registry)
+      val effectiveRegistry = new FallbackRegistry(registry, Harness.metaschemas)
+      val validator = js.validator(schema, Config(dialect = Dialect.FullSpec, ffast = false), effectiveRegistry)
 
       val resultArray = testCase.tests.map { test =>
         val outcome = ujson.read(test.instance.noSpaces).transform(validator)
@@ -131,6 +143,27 @@ case class Test(description: String, comment: Option[String], instance: Json, va
 
 object Harness {
   var started: Boolean = false
+
+  // The official JSON Schema 2020-12 meta-schemas, bundled as resources and pre-registered
+  // once so `$ref`s to them (e.g. a schema validating against its own dialect) resolve.
+  val metaschemas: MutableRegistry = {
+    val reg = new MutableRegistry
+    Seq(
+      "schema.json" -> "https://json-schema.org/draft/2020-12/schema",
+      "meta_core.json" -> "https://json-schema.org/draft/2020-12/meta/core",
+      "meta_applicator.json" -> "https://json-schema.org/draft/2020-12/meta/applicator",
+      "meta_unevaluated.json" -> "https://json-schema.org/draft/2020-12/meta/unevaluated",
+      "meta_validation.json" -> "https://json-schema.org/draft/2020-12/meta/validation",
+      "meta_meta-data.json" -> "https://json-schema.org/draft/2020-12/meta/meta-data",
+      "meta_format-annotation.json" -> "https://json-schema.org/draft/2020-12/meta/format-annotation",
+      "meta_content.json" -> "https://json-schema.org/draft/2020-12/meta/content",
+    ).foreach { case (resource, uri) =>
+      val is = getClass.getResourceAsStream(s"/metaschemas/$resource")
+      val text = new String(is.readAllBytes(), StandardCharsets.UTF_8)
+      js.from(ujson.Readable, ujson.Readable.fromString(text), docbase = Uri(uri), registry = reg)
+    }
+    reg
+  }
 
   def main(args: Array[String]): Unit = {
     val input = new Scanner(System.in)

--- a/implementations/scala-json-schema/Harness.scala
+++ b/implementations/scala-json-schema/Harness.scala
@@ -1,0 +1,141 @@
+import io.circe.generic.auto._
+import io.circe.parser.parse
+import io.circe.syntax.EncoderOps
+import io.circe.{Json, Decoder}
+import java.io.InputStream
+import java.util.Scanner
+import java.util.jar.Manifest
+import io.github.jam01.json_schema.{Config, Dialect, MutableRegistry, Schema, Uri}
+import io.github.jam01.json_schema as js
+
+class Harness {
+  def operate(line: String) = {
+    val node: Json = parse(line) match {
+      case Right(json)          => json
+      case Left(parsingFailure) => throw parsingFailure
+    }
+
+    val cmd: String = (node \\ "cmd").headOption match {
+      case Some(value) => value.asString.getOrElse("")
+      case None        => throw new RuntimeException("Failed to get cmd")
+    }
+    cmd match {
+      case "start"   => println(start(node))
+      case "dialect" => println(dialect(node))
+      case "run"     => println(run(node))
+      case "stop"    => System.exit(0)
+      case default   => throw new IllegalArgumentException(s"Unknown command: $default")
+    }
+  }
+
+  def start(node: Json): String = {
+    Harness.started = true
+    val startRequest: StartRequest = decodeTo[StartRequest](node)
+    if (startRequest.version != 1) {
+      throw new IllegalArgumentException(s"Unsupported IHOP version: ${startRequest.version}")
+    }
+
+    val is: InputStream = getClass.getResourceAsStream("META-INF/MANIFEST.MF")
+    val attributes = new Manifest(is).getMainAttributes
+
+    val implementation: Implementation = Implementation(
+      "scala",
+      attributes.getValue("Implementation-Name"),
+      attributes.getValue("Implementation-Version"),
+      List("https://json-schema.org/draft/2020-12/schema"),
+      "https://github.com/jam01/json-schema",
+      "https://github.com/jam01/json-schema/issues",
+      "https://github.com/jam01/json-schema",
+      System.getProperty("os.name"),
+      System.getProperty("os.version"),
+      Runtime.version().toString,
+      List()
+    )
+    StartResponse(startRequest.version, implementation).asJson.noSpaces
+  }
+
+  def dialect(node: Json): String = {
+    if (!Harness.started) {
+      throw new IllegalArgumentException("Not started!")
+    }
+    DialectResponse(true).asJson.noSpaces
+  }
+
+  def run(node: Json): String = {
+    if (!Harness.started) {
+      throw new IllegalArgumentException("Not started!")
+    }
+
+    val runRequest: RunRequest = decodeTo[RunRequest](node)
+    val testCase = runRequest.testCase
+    try {
+      val registry = new MutableRegistry
+      testCase.registry.getOrElse(Map.empty).foreach { case (uri, schemaJson) =>
+        js.from(ujson.Readable, ujson.Readable.fromString(schemaJson.noSpaces),
+          docbase = Uri(uri), registry = registry)
+      }
+
+      val schema: Schema = js.from(ujson.Readable, ujson.Readable.fromString(testCase.schema.noSpaces),
+        registry = registry)
+      val validator = js.validator(schema, Config(dialect = Dialect.FullSpec, ffast = false), registry)
+
+      val resultArray = testCase.tests.map { test =>
+        val outcome = ujson.read(test.instance.noSpaces).transform(validator)
+        Json.obj("valid" -> outcome.vvalid.asJson)
+      }
+      RunResponse(runRequest.seq, resultArray.toVector).asJson.noSpaces
+    } catch {
+      case e: Exception =>
+        val error: ErrorContext = ErrorContext(e.getMessage, e.getStackTrace.mkString("\n"))
+        RunErroredResponse(runRequest.seq, context = error).asJson.noSpaces
+    }
+  }
+
+  def decodeTo[Request: Decoder](json: Json): Request = {
+    json.as[Request] match {
+      case Right(value)          => value
+      case Left(decodingFailure) => throw decodingFailure
+    }
+  }
+}
+
+case class Implementation(language: String, name: String, version: String,
+                          dialects: List[String], homepage: String, issues: String,
+                          source: String, os: String, os_version: String,
+                          language_version: String, links: List[Link])
+
+case class Link(url: String, description: String)
+
+case class StartRequest(version: Int)
+
+case class StartResponse(version: Int, implementation: Implementation)
+
+case class DialectRequest(dialect: String)
+
+case class DialectResponse(ok: Boolean)
+
+case class RunRequest(seq: Json, testCase: TestCase)
+implicit val decodeRunRequest: Decoder[RunRequest] = Decoder.forProduct2("seq", "case")(RunRequest.apply)
+
+case class RunResponse(seq: Json, results: Vector[Json])
+
+case class RunSkippedResponse(seq: Json, skipped: Boolean = true, message: Option[String] = None)
+
+case class RunErroredResponse(seq: Json, errored: Boolean = true, context: ErrorContext)
+
+case class ErrorContext(message: String, traceback: String)
+
+case class TestCase(description: String, comment: Option[String], schema: Json, registry: Option[Map[String, Json]], tests: List[Test])
+
+case class Test(description: String, comment: Option[String], instance: Json, valid: Option[Boolean])
+
+object Harness {
+  var started: Boolean = false
+
+  def main(args: Array[String]): Unit = {
+    val input = new Scanner(System.in)
+    while (true) {
+      new Harness().operate(input.nextLine())
+    }
+  }
+}

--- a/implementations/scala-json-schema/build.sbt
+++ b/implementations/scala-json-schema/build.sbt
@@ -1,0 +1,32 @@
+name := "scala-json-schema"
+
+ThisBuild / version := "1.0"
+ThisBuild / scalaVersion := "3.3.3"
+
+javacOptions ++= Seq("-source", "17", "-target", "17")
+
+resolvers += Resolver.mavenCentral
+
+val circeVersion = "0.14.6"
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core",
+  "io.circe" %% "circe-generic",
+  "io.circe" %% "circe-parser"
+).map(_ % circeVersion)
+
+val jsonSchemaVersion = "0.2.0"
+libraryDependencies += "io.github.jam01" %% "json-schema" % jsonSchemaVersion
+
+// Not a transitive dependency of json-schema (see its README) - pinned to the exact
+// upickle-core version that json-schema_3:0.2.0's POM depends on.
+libraryDependencies += "com.lihaoyi" %% "ujson" % "3.3.1"
+
+assembly / assemblyJarName := "bowtieJsonSchema.jar"
+assembly / packageOptions := Seq(
+  Package.ManifestAttributes(
+    "Main-Class" -> "Harness",
+    "Implementation-Group" -> "io.github.jam01",
+    "Implementation-Name" -> "json-schema",
+    "Implementation-Version" -> jsonSchemaVersion,
+  )
+)

--- a/implementations/scala-json-schema/project/build.properties
+++ b/implementations/scala-json-schema/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.6

--- a/implementations/scala-json-schema/project/plugins.sbt
+++ b/implementations/scala-json-schema/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/meta_applicator.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/meta_applicator.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/applicator",
+    "$dynamicAnchor": "meta",
+
+    "title": "Applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "prefixItems": { "$ref": "#/$defs/schemaArray" },
+        "items": { "$dynamicRef": "#meta" },
+        "contains": { "$dynamicRef": "#meta" },
+        "additionalProperties": { "$dynamicRef": "#meta" },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependentSchemas": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "default": {}
+        },
+        "propertyNames": { "$dynamicRef": "#meta" },
+        "if": { "$dynamicRef": "#meta" },
+        "then": { "$dynamicRef": "#meta" },
+        "else": { "$dynamicRef": "#meta" },
+        "allOf": { "$ref": "#/$defs/schemaArray" },
+        "anyOf": { "$ref": "#/$defs/schemaArray" },
+        "oneOf": { "$ref": "#/$defs/schemaArray" },
+        "not": { "$dynamicRef": "#meta" }
+    },
+    "$defs": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$dynamicRef": "#meta" }
+        }
+    }
+}

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/meta_content.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/meta_content.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/content",
+    "$dynamicAnchor": "meta",
+
+    "title": "Content vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "contentEncoding": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentSchema": { "$dynamicRef": "#meta" }
+    }
+}

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/meta_core.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/meta_core.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/core",
+    "$dynamicAnchor": "meta",
+
+    "title": "Core vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "$ref": "#/$defs/uriReferenceString",
+            "$comment": "Non-empty fragments not allowed.",
+            "pattern": "^[^#]*#?$"
+        },
+        "$schema": { "$ref": "#/$defs/uriString" },
+        "$ref": { "$ref": "#/$defs/uriReferenceString" },
+        "$anchor": { "$ref": "#/$defs/anchorString" },
+        "$dynamicRef": { "$ref": "#/$defs/uriReferenceString" },
+        "$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
+        "$vocabulary": {
+            "type": "object",
+            "propertyNames": { "$ref": "#/$defs/uriString" },
+            "additionalProperties": {
+                "type": "boolean"
+            }
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "$defs": {
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" }
+        }
+    },
+    "$defs": {
+        "anchorString": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+        },
+        "uriString": {
+            "type": "string",
+            "format": "uri"
+        },
+        "uriReferenceString": {
+            "type": "string",
+            "format": "uri-reference"
+        }
+    }
+}

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/meta_format-annotation.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/meta_format-annotation.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/format-annotation",
+    "$dynamicAnchor": "meta",
+
+    "title": "Format vocabulary meta-schema for annotation results",
+    "type": ["object", "boolean"],
+    "properties": {
+        "format": { "type": "string" }
+    }
+}

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/meta_meta-data.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/meta_meta-data.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/meta-data",
+    "$dynamicAnchor": "meta",
+
+    "title": "Meta-data vocabulary meta-schema",
+
+    "type": ["object", "boolean"],
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "deprecated": {
+            "type": "boolean",
+            "default": false
+        },
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        }
+    }
+}

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/meta_unevaluated.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/meta_unevaluated.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/unevaluated",
+    "$dynamicAnchor": "meta",
+
+    "title": "Unevaluated applicator vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "unevaluatedItems": { "$dynamicRef": "#meta" },
+        "unevaluatedProperties": { "$dynamicRef": "#meta" }
+    }
+}

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/meta_validation.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/meta_validation.json
@@ -1,0 +1,95 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/meta/validation",
+    "$dynamicAnchor": "meta",
+
+    "title": "Validation vocabulary meta-schema",
+    "type": ["object", "boolean"],
+    "properties": {
+        "type": {
+            "anyOf": [
+                { "$ref": "#/$defs/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minContains": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 1
+        },
+        "maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/$defs/stringArray" },
+        "dependentRequired": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/stringArray"
+            }
+        }
+    },
+    "$defs": {
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "$ref": "#/$defs/nonNegativeInteger",
+            "default": 0
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    }
+}

--- a/implementations/scala-json-schema/src/main/resources/metaschemas/schema.json
+++ b/implementations/scala-json-schema/src/main/resources/metaschemas/schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2020-12/vocab/core": true,
+        "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+        "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+        "https://json-schema.org/draft/2020-12/vocab/validation": true,
+        "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+        "https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+        "https://json-schema.org/draft/2020-12/vocab/content": true
+    },
+    "$dynamicAnchor": "meta",
+
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {"$ref": "meta/core"},
+        {"$ref": "meta/applicator"},
+        {"$ref": "meta/unevaluated"},
+        {"$ref": "meta/validation"},
+        {"$ref": "meta/meta-data"},
+        {"$ref": "meta/format-annotation"},
+        {"$ref": "meta/content"}
+    ],
+    "type": ["object", "boolean"],
+    "$comment": "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
+    "properties": {
+        "definitions": {
+            "$comment": "\"definitions\" has been replaced by \"$defs\".",
+            "type": "object",
+            "additionalProperties": { "$dynamicRef": "#meta" },
+            "deprecated": true,
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" has been split and replaced by \"dependentSchemas\" and \"dependentRequired\" in order to serve their differing semantics.",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$dynamicRef": "#meta" },
+                    { "$ref": "meta/validation#/$defs/stringArray" }
+                ]
+            },
+            "deprecated": true,
+            "default": {}
+        },
+        "$recursiveAnchor": {
+            "$comment": "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
+            "$ref": "meta/core#/$defs/anchorString",
+            "deprecated": true
+        },
+        "$recursiveRef": {
+            "$comment": "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
+            "$ref": "meta/core#/$defs/uriReferenceString",
+            "deprecated": true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `implementations/scala-json-schema/`, wiring up
[`io.github.jam01:json-schema`](https://github.com/jam01/json-schema) (published on Maven
Central as `json-schema_3:0.2.0`) as a new Bowtie implementation. It's a Scala 3 JSON Schema
2020-12 validator built on upickle's `Visitor` framework (JVM + Scala.js; this harness targets
the JVM artifact only). Follows the sbt + sbt-assembly pattern used by
`scala-rc-circe-json-validator`: circe handles the IHOP protocol envelope, and the library's own
`ujson`-based API (pinned to the exact `upickle-core` version the library depends on) handles
schema/instance parsing and validation.

- `dependabot.yml` updated: added the required `docker` ecosystem entry, and an `# ignore:`
  comment alongside the two existing Scala implementations (Dependabot doesn't support Scala).

## Test plan

- [x] `docker build` — harness compiles and the image builds cleanly.
- [x] `bowtie smoke -i <image>` — succeeds.
- [x] `bowtie validate -i <image>` — manual sanity check with valid/invalid instances, correct results.
- [x] `bowtie suite -i <image> <path>/tests/draft2020-12` — full official JSON Schema 2020-12 test
      suite (mandatory + optional `format`): **364 cases / 730 assertions, 0 failed, 0 errored, 0 skipped**.
- [x] `.pre-commit-hooks/check-dependabot` passes.