### PR TITLE
Bump `harness-ci.yml` pinned actions and the zizmor hook to latest

### DIFF
--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -98,7 +98,7 @@ jobs:
       artifact-metadata: write # needed for build provenance attestation
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
@@ -190,7 +190,7 @@ jobs:
 
       - name: Generate attestation for the image
         if: inputs.publish
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ steps.build_image.outputs.image }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--fix, lf]
       - id: trailing-whitespace
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.27.0
+    rev: v1.28.0
     hooks:
       - id: zizmor
         args: [--pedantic]


### PR DESCRIPTION
Freshness pass on the newly-added harness CI tooling.

- `actions/checkout` v7.0.0 → **v7.0.1**
- `actions/attest` v4.1 → **v4.2.0**
- zizmor pre-commit hook v1.27.0 → **v1.28.0**

`redhat-actions/buildah-build`, `podman-login` and `push-to-registry` are already pinned to the current tips of their `v2`/`v1` tags, so they're unchanged. The rest of the repo's actions are Dependabot-managed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)