### PR TITLE
Handle rules newly enforced by the latest ruff

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -626,8 +626,10 @@ class _Report(click.File):
                 code="truncated-report",
                 message="The Bowtie report looks corrupt.",
                 causes=[
-                    f"{input.name} is missing its footer, which usually means "
-                    "it has been somehow truncated.",
+                    (
+                        f"{input.name} is missing its footer, which usually "
+                        "means it has been somehow truncated."
+                    ),
                 ],
                 hint_stmt=(
                     "Try running the command you used to produce the report, "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ ignore = [
   "B905",  # No need for explicit strict, this is simply zip's default behavior
   "C408",  # Calling dict is fine when it saves quoting the keys
   "C901",  # Not really something to focus on
+  "CPY001",  # We don't put copyright notices at the top of files
   "D105",  # It's fine to not have docstrings for magic methods.
   "D107",  # __init__ especially doesn't need a docstring
   "D200",  # This rule makes diffs uglier when expanding docstrings
@@ -191,6 +192,7 @@ ignore = [
   "PLR0912",  # These metrics are fine to be aware of but not to enforce
   "PLR0913",
   "PLR0915",
+  "PLR0917",
   "PLW2901",  # Shadowing for loop variables is occasionally fine.
   "PT006",  # pytest parametrize takes strings as well
   "PT028",  # gets very confused by functions named test* which are not tests


### PR DESCRIPTION
`noxfile.py`'s `style` session installs ruff **unpinned**, so a new ruff release started flagging rules under `select = ["ALL"]` that weren't enforced before — turning `Run CI (style)` red on `main` and every open PR (e.g. #2974), even for changes that touch no Python.

The 63 new errors were:
- **58 × CPY001** (missing copyright notice) → added to `ignore`; we don't use copyright headers.
- **4 × PLR0917** (too many positional arguments) → added to `ignore`, alongside the `PLR0912/0913/0915` metrics we already choose not to enforce.
- **1 × ISC004** (`bowtie/_cli.py:629`) → an intentional two-line message string; parenthesized it so this (genuinely useful, missing-comma-catching) rule stays enabled.

After this lands, other open PRs just need a rebase / re-run to go green.