### PR TITLE
harness-ci: install Bowtie from PyPI instead of self-referencing bowtie's action

### DIFF
--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -109,8 +109,16 @@ jobs:
         # not `github.sha` (the ref the workflow was dispatched on).
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          python-version: "3.14"
+          enable-cache: false
+
       - name: Install Bowtie
-        uses: bowtie-json-schema/bowtie@b83e81f74693a2032638eeeb8b62613498a9919a # main
+        # Installed from PyPI rather than via bowtie's own action.
+        # A self-reference here would make bowtie's Dependabot bump the pin on every commit, each bump becoming the next target -- a loop.
+        run: uv tool install bowtie-json-schema
 
       - name: Compute implementation (image) name
         id: impl

--- a/bin/extract-harness
+++ b/bin/extract-harness
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Extract a Bowtie test harness out of implementations/<name>/ into a standalone
+# repository (github.com/bowtie-json-schema/<name>), preserving its git history.
+#
+# The extracted repository keeps the harness's own commit history at its root
+# (via git-filter-repo) and gains the standard CI scaffolding (workflows,
+# Dependabot, zizmor, pre-commit, LICENSE) copied from the test-harness-template
+# repository. The published image stays at ghcr.io/bowtie-json-schema/<name>, so
+# `bowtie run -i <name>` keeps working once the image is rebuilt from the new repo.
+#
+# By default this only PREPARES the new repository locally and prints the
+# remaining (outward-facing / judgement) steps. Pass --push to actually create
+# and push the GitHub repository.
+#
+# Usage:
+#   bin/extract-harness <name> [--push] [--workdir DIR]
+#
+# Requirements: git, git-filter-repo, gh (authenticated), jq.
+
+set -euo pipefail
+
+ORG=bowtie-json-schema
+TEMPLATE_REPO="$ORG/test-harness-template"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+step() { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+note() { printf '    %s\n' "$*"; }
+
+NAME=""
+PUSH=false
+WORKDIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --push) PUSH=true ;;
+    --workdir) shift; WORKDIR="${1:-}" ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) die "unknown option: $1" ;;
+    *) [ -z "$NAME" ] || die "unexpected argument: $1"; NAME="$1" ;;
+  esac
+  shift
+done
+
+[ -n "$NAME" ] || die "usage: bin/extract-harness <name> [--push] [--workdir DIR]"
+
+# Run from the root of a bowtie checkout.
+BOWTIE_DIR=$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)
+HARNESS_DIR="$BOWTIE_DIR/implementations/$NAME"
+[ -d "$HARNESS_DIR" ] || die "no such harness: implementations/$NAME"
+[ -f "$HARNESS_DIR/Dockerfile" ] || die "implementations/$NAME has no Dockerfile"
+
+for tool in git git-filter-repo gh jq; do
+  command -v "$tool" >/dev/null 2>&1 || die "missing required tool: $tool"
+done
+
+if [ -z "$WORKDIR" ]; then
+  WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/extract-$NAME.XXXXXX")
+fi
+OUT="$WORKDIR/$NAME"
+[ -e "$OUT" ] && die "$OUT already exists; pass a clean --workdir"
+
+step "Extracting implementations/$NAME/ with history into $OUT"
+# Filter a fresh clone in place (git-filter-repo's recommended mode); the bowtie
+# clone itself is never touched. --subdirectory-filter moves the harness's files
+# up to the repository root and keeps only the commits that touched them.
+git clone --quiet --single-branch --branch main "file://$BOWTIE_DIR" "$OUT"
+( cd "$OUT" && PYTHONWARNINGS=ignore git-filter-repo --subdirectory-filter "implementations/$NAME/" --force --quiet )
+# Drop bowtie's own tags (release tags etc.) that the clone carried along; the
+# new repo starts tagless and accrues its own harness-release-* tags later.
+git -C "$OUT" tag -l | xargs -r git -C "$OUT" tag -d >/dev/null
+note "$(git -C "$OUT" rev-list --count HEAD) commit(s) of harness history preserved"
+
+step "Fetching CI scaffolding from $TEMPLATE_REPO"
+TEMPLATE_DIR="$WORKDIR/template"
+gh repo clone "$TEMPLATE_REPO" "$TEMPLATE_DIR" -- --depth 1 --quiet
+
+# Copy the scaffolding the harness needs, but never clobber a file the harness
+# already ships (its real Dockerfile, sources, manifests, .gitignore, ...).
+copy_if_absent() {
+  local rel="$1"
+  if [ -e "$OUT/$rel" ]; then
+    note "keeping harness's own $rel"
+  else
+    mkdir -p "$OUT/$(dirname "$rel")"
+    cp "$TEMPLATE_DIR/$rel" "$OUT/$rel"
+    note "added $rel"
+  fi
+}
+
+step "Adding scaffolding"
+mkdir -p "$OUT/.github/workflows"
+cp "$TEMPLATE_DIR"/.github/workflows/*.yml "$OUT/.github/workflows/"
+note "added .github/workflows/ (build, build-all, dependabot-build)"
+copy_if_absent .github/dependabot.yml
+copy_if_absent zizmor.yml
+copy_if_absent .pre-commit-config.yaml
+copy_if_absent .gitignore
+copy_if_absent LICENSE
+# The template's placeholder Dockerfile/README are never wanted here; the
+# harness ships its own Dockerfile and we generate a minimal README below.
+
+if [ ! -e "$OUT/README.md" ]; then
+  cat > "$OUT/README.md" <<EOF
+# $NAME
+
+A [Bowtie](https://github.com/bowtie-json-schema/bowtie) test harness.
+
+Its image is published to \`ghcr.io/$ORG/$NAME\` and run via \`bowtie run -i $NAME\`.
+EOF
+  note "generated README.md"
+fi
+
+# Known special cases, mirroring the central images.yml: Go and .NET build
+# multi-arch natively (no QEMU), and python-fastjsonschema can't pass smoke yet.
+case "$NAME" in
+  go-*|dotnet-*)
+    sed -i.bak 's/^\( *\)# qemu: false.*/\1qemu: false/' "$OUT/.github/workflows/build.yml"
+    note "set qemu: false (native multi-arch build)"
+    ;;
+esac
+if [ "$NAME" = "python-fastjsonschema" ]; then
+  sed -i.bak 's/^\( *\)# smoke-continue-on-error: true.*/\1smoke-continue-on-error: true/' "$OUT/.github/workflows/build.yml"
+  note "set smoke-continue-on-error: true"
+fi
+rm -f "$OUT/.github/workflows/build.yml.bak"
+
+step "Committing scaffolding"
+git -C "$OUT" add -A
+git -C "$OUT" commit -q -m "Add Bowtie CI scaffolding from $TEMPLATE_REPO"
+
+if ! $PUSH; then
+  step "Prepared $OUT (not pushed)"
+  note "Inspect it, then re-run with --push, or push it yourself."
+else
+  step "Creating and pushing $ORG/$NAME"
+  git -C "$OUT" branch -M main
+  gh repo create "$ORG/$NAME" --public --source "$OUT" --remote origin --push
+  # Standard harness-repo settings: discoverable by Bowtie (topic), and the
+  # Dependabot flow needs auto-merge; delete merged branches; no wiki/projects.
+  gh repo edit "$ORG/$NAME" \
+    --add-topic bowtie-harness \
+    --enable-auto-merge \
+    --delete-branch-on-merge \
+    --enable-wiki=false \
+    --enable-projects=false
+  note "pushed, tagged bowtie-harness, and configured repo defaults"
+fi
+
+cat <<EOF
+
+$(printf '\033[1;32mNext steps (manual / judgement):\033[0m')
+  1. Review .github/dependabot.yml -- add this harness's package-ecosystem
+     (see its current entries in bowtie's .github/dependabot.yml).
+  2. Review .pre-commit-config.yaml -- add its language's formatter/linter
+     (see bowtie's .pre-commit-config.yaml).
+  3. Grant the ghcr.io/$ORG/$NAME package write access to the new repo
+     (Package settings -> Manage Actions access), or publishing will fail. This
+     is only needed because the package already exists (from images.yml).
+  4. If the Dockerfile uses ARG IMPLEMENTATION_VERSION (previously fed by
+     images.yml), decide how the version is pinned now: builds default to
+     "latest". Rebuilding a historical version via build-all only works if the
+     version is captured in the repo at each harness-release-* tag.
+  5. Confirm CI is green and \`bowtie run -i $NAME\` still works.
+  6. In bowtie, open a PR removing implementations/$NAME/, its dependabot.yml
+     entries, and its .pre-commit-config.yaml hooks.
+EOF


### PR DESCRIPTION
`harness-ci.yml` lives in bowtie but installed Bowtie via `uses: bowtie-json-schema/bowtie@<sha>` — a reference to this repo. Our own Dependabot kept bumping that self-reference, and because each bump is a **commit to bowtie**, it immediately became the next bump target — a loop that never converges (it had already walked `1ad060eb → b83e81f` on its own).

Fix: install Bowtie inline (`setup-uv` + `uv tool install bowtie-json-schema`), always the latest released version from PyPI. No self-reference, so nothing to loop on — and nothing frozen forever either (ignoring the dependency would've done that).

Harness repos are unaffected: they reference bowtie, but a bump there doesn't create a commit here, so they just converge — and should keep tracking bowtie.