### PR TITLE
Report iris's language as c++, not cpp

### DIFF
--- a/implementations/cpp-iris/bowtie_iris.cpp
+++ b/implementations/cpp-iris/bowtie_iris.cpp
@@ -164,7 +164,7 @@ void on_start(const iris::JsonValue &cmd) {
   (void)cmd;
   write_line(
       R"({"version":1,"implementation":{)"
-      R"("language":"cpp",)"
+      R"("language":"c++",)"
       R"("name":"iris",)"
       R"("version":"0.1.0",)"
       R"("homepage":"https://github.com/Cobra007-star-source/IRIS",)"


### PR DESCRIPTION
`cpp-iris` advertised `"language":"cpp"` in its start metadata, while the other three C++ harnesses — blaze, jsoncons, and valijson — all report `"c++"`. That inconsistency splits C++ into two separate languages ("C++" and "Cpp") in the report UI's language grouping and filter.

One line in `implementations/cpp-iris/bowtie_iris.cpp` brings it in line with the others; no frontend change is needed (the UI groups by the reported language string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)