### PR TITLE
jsu: report the harness's own version, not the backend's too

### DIFF
--- a/implementations/c-jsu/bowtie_jsu_compile.py
+++ b/implementations/c-jsu/bowtie_jsu_compile.py
@@ -142,7 +142,8 @@ class Runner:
             *options,
         ]
         # TODO do not necessarily use subprocess?
-        self.jsu_version = get_version(["jsu-compile", "--version"])
+        # Only jsu's own version, not the "X (jmc backend Y)" string.
+        self.jsu_version = get_version(["jsu-compile", "--version"]).split()[0]
 
         TMP.mkdir(exist_ok=True)
 

--- a/implementations/java-jsu/bowtie_jsu_compile.py
+++ b/implementations/java-jsu/bowtie_jsu_compile.py
@@ -142,7 +142,8 @@ class Runner:
             *options,
         ]
         # TODO do not necessarily use subprocess?
-        self.jsu_version = get_version(["jsu-compile", "--version"])
+        # Only jsu's own version, not the "X (jmc backend Y)" string.
+        self.jsu_version = get_version(["jsu-compile", "--version"]).split()[0]
 
         TMP.mkdir(exist_ok=True)
 

--- a/implementations/js-jsu/bowtie_jsu_compile.py
+++ b/implementations/js-jsu/bowtie_jsu_compile.py
@@ -142,7 +142,8 @@ class Runner:
             *options,
         ]
         # TODO do not necessarily use subprocess?
-        self.jsu_version = get_version(["jsu-compile", "--version"])
+        # Only jsu's own version, not the "X (jmc backend Y)" string.
+        self.jsu_version = get_version(["jsu-compile", "--version"]).split()[0]
 
         TMP.mkdir(exist_ok=True)
 

--- a/implementations/perl-jsu/bowtie_jsu_compile.py
+++ b/implementations/perl-jsu/bowtie_jsu_compile.py
@@ -142,7 +142,8 @@ class Runner:
             *options,
         ]
         # TODO do not necessarily use subprocess?
-        self.jsu_version = get_version(["jsu-compile", "--version"])
+        # Only jsu's own version, not the "X (jmc backend Y)" string.
+        self.jsu_version = get_version(["jsu-compile", "--version"]).split()[0]
 
         TMP.mkdir(exist_ok=True)
 

--- a/implementations/python-jsu/bowtie_jsu_compile.py
+++ b/implementations/python-jsu/bowtie_jsu_compile.py
@@ -142,7 +142,8 @@ class Runner:
             *options,
         ]
         # TODO do not necessarily use subprocess?
-        self.jsu_version = get_version(["jsu-compile", "--version"])
+        # Only jsu's own version, not the "X (jmc backend Y)" string.
+        self.jsu_version = get_version(["jsu-compile", "--version"]).split()[0]
 
         TMP.mkdir(exist_ok=True)
 


### PR DESCRIPTION
`bowtie_jsu_compile.py` (which all five `*-jsu` harnesses run) set the implementation `version` to the full output of `jsu-compile --version` — `"0.9.13 (jmc backend 2.0.52)"`. That reports two versions where one belongs (the jmc backend is a dependency), and — because of the spaces/parens — it isn't a valid container or git tag, so an **extracted** jsu harness can't tag or publish its image (it's what blocked python-jsu & perl-jsu).

Report just the leading token — json-schema-utils' own version (`0.9.13`).

The already-extracted `python-jsu` / `perl-jsu` repos get the same one-line fix directly so they can publish.