### PR TITLE
Improve frontend typography, accessibility, navigation, and URL state

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * Accessibility gate. Each key view is scanned with axe (WCAG 2.0/2.1 A + AA)
+ * in both colour schemes; any violation fails the build. Pages render from the
+ * live report data the dev server proxies, so we wait for real content first.
+ */
+interface Scenario {
+  name: string;
+  path: string;
+  ready: string;
+  /** optional interaction to reach a sub-view (e.g. open a case) before scanning */
+  open?: (page: Page) => Promise<void>;
+}
+
+const scenarios: Scenario[] = [
+  { name: "compliance report", path: "/#/", ready: ".shell .matrix .row" },
+  {
+    name: "case detail",
+    path: "/#/",
+    ready: ".shell .case-row",
+    open: async (page) => {
+      await page.locator(".case-row").first().click();
+      await page.waitForSelector(".dis .ogroup", { timeout: 20000 });
+    },
+  },
+  {
+    name: "implementation",
+    path: "/#/implementations/python-jsonschema",
+    ready: "table.compliance tbody tr",
+  },
+  { name: "implementations index", path: "/#/implementations", ready: ".impl-card" },
+  { name: "benchmarks", path: "/#/benchmarks", ready: ".bchart .brow" },
+  { name: "upload", path: "/#/local-report", ready: ".dropzone" },
+  { name: "not found", path: "/#/does-not-exist", ready: "h1" },
+];
+
+async function scan(page: Page) {
+  const { violations } = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  const summary = violations.map((v) => `${v.id} (${v.nodes.length})`).join(", ");
+  expect(violations, summary).toEqual([]);
+}
+
+for (const scheme of ["light", "dark"] as const) {
+  test.describe(`a11y (${scheme})`, () => {
+    test.use({ colorScheme: scheme });
+    for (const s of scenarios) {
+      test(s.name, async ({ page }) => {
+        await page.goto(s.path);
+        await page.waitForSelector(s.ready, { timeout: 45000 });
+        if (s.open) await s.open(page);
+        await page.waitForTimeout(500);
+        await scan(page);
+      });
+    }
+  });
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,11 +36,14 @@
     "watch-test": "vitest watch"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.3.0",
+    "@fontsource-variable/geist-mono": "^5.3.0",
     "dayjs": "^1.11.21",
     "title-case": "^4.3.2",
     "urijs": "^1.19.11"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
     "@sveltejs/vite-plugin-svelte": "^7.2.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,6 +12,12 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/geist':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource-variable/geist-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
@@ -22,6 +28,9 @@ importers:
         specifier: ^1.19.11
         version: 1.19.11
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0(jiti@2.7.0))
@@ -96,6 +105,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -193,6 +207,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@fontsource-variable/geist-mono@5.3.0':
+    resolution: {integrity: sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==}
+
+  '@fontsource-variable/geist@5.3.0':
+    resolution: {integrity: sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -507,6 +527,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1413,6 +1437,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.1
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -1492,6 +1521,10 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.1': {}
+
+  '@fontsource-variable/geist-mono@5.3.0': {}
+
+  '@fontsource-variable/geist@5.3.0': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -1791,6 +1824,8 @@ snapshots:
   aria-query@5.3.1: {}
 
   assertion-error@2.0.1: {}
+
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 

--- a/frontend/src/components/Breadcrumbs.svelte
+++ b/frontend/src/components/Breadcrumbs.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { router, matchRoute } from "../stores/router.svelte";
+  import { SECTIONS, type Section } from "../lib/nav";
+  import { report } from "../stores/report.svelte";
+
+  const route = $derived(matchRoute(router.path));
+
+  interface Crumb {
+    label: string;
+    href?: string;
+    /** the compliance root: clicking it deselects the case (store state) rather than navigating */
+    clears?: boolean;
+  }
+
+  // The leaf is the drill-down context (an implementation, or a selected case);
+  // top-level pages have none, so no breadcrumb is shown — the top nav suffices.
+  function leafLabel(): string | null {
+    if (route.name === "implementation") return route.params.id ?? null;
+    if (route.name === "dialect" && report.selectedSeq !== null) {
+      return (
+        report.data?.cases.get(report.selectedSeq)?.description ??
+        `case ${report.selectedSeq}`
+      );
+    }
+    return null;
+  }
+
+  const trail = $derived.by<Crumb[]>(() => {
+    const leaf = leafLabel();
+    if (!leaf) return [];
+
+    const chain: Section[] = [];
+    let cur: Section | undefined = SECTIONS[route.name];
+    while (cur) {
+      chain.unshift(cur);
+      cur = cur.parent ? SECTIONS[cur.parent] : undefined;
+    }
+    return [
+      ...chain.map((s) => ({ label: s.label, href: s.href, clears: s.name === "dialect" })),
+      { label: leaf },
+    ];
+  });
+
+  function clearSelection(e: MouseEvent) {
+    e.preventDefault();
+    report.selectedSeq = null;
+  }
+</script>
+
+{#if trail.length}
+  <nav class="crumbs" aria-label="Breadcrumb">
+    {#each trail as c, i (i)}
+      {#if i > 0}<span class="sep">/</span>{/if}
+      {#if i === trail.length - 1}
+        <span aria-current="page">{c.label}</span>
+      {:else if c.clears}
+        <a href={c.href} onclick={clearSelection}>{c.label}</a>
+      {:else}
+        <a href={c.href}>{c.label}</a>
+      {/if}
+    {/each}
+  </nav>
+{/if}

--- a/frontend/src/components/CaseDetail.svelte
+++ b/frontend/src/components/CaseDetail.svelte
@@ -2,11 +2,11 @@
   import { report } from "../stores/report.svelte";
   import { mapLanguage } from "../data/mapLanguage";
   import JsonPanel from "./JsonPanel.svelte";
+  import Breadcrumbs from "./Breadcrumbs.svelte";
   import {
     resultFor,
     stateToWorst,
     testCounts,
-    caseGroup,
     type Worst,
   } from "../lib/reportModel";
 
@@ -15,7 +15,6 @@
   const c = $derived(data.cases.get(seq)!);
   const t = $derived(Math.min(report.selectedTest, c.tests.length - 1));
   const implIds = $derived(report.scopedImplIds);
-  const group = $derived(caseGroup(c));
 
   const nDisagree = $derived(report.nDisagree(seq));
 
@@ -55,10 +54,7 @@
   }
 </script>
 
-<div class="crumbs">
-  <a href="#/" onclick={(e) => { e.preventDefault(); report.selectedSeq = null; }}>Report</a>
-  {#if group}<span class="sep">/</span><span class="mono" style="color:var(--accent)">{group}</span>{/if}
-</div>
+<Breadcrumbs />
 
 <h1 class="page">{c.description}</h1>
 

--- a/frontend/src/components/DialectPicker.svelte
+++ b/frontend/src/components/DialectPicker.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import Dialect from "../data/Dialect";
+  import { router } from "../stores/router.svelte";
+
+  let { current, base }: { current: string; base: string } = $props();
+
+  const dialects = Dialect.newestToOldest();
+
+  function onChange(e: Event) {
+    router.navigate(`${base}/${(e.target as HTMLSelectElement).value}`);
+  }
+</script>
+
+<label class="dialect-picker">
+  <span class="label">Dialect</span>
+  <div class="dp-select">
+    <select value={current} onchange={onChange} aria-label="Choose dialect">
+      {#each dialects as d (d.shortName)}
+        <option value={d.shortName}>{d.prettyName}</option>
+      {/each}
+    </select>
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+  </div>
+</label>
+
+<style>
+  .dialect-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .dp-select {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .dp-select select {
+    appearance: none;
+    width: 100%;
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--text);
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    padding: 7px 30px 7px 11px;
+    cursor: pointer;
+  }
+  .dp-select select:focus-visible {
+    border-color: var(--accent);
+  }
+  .dp-select svg {
+    position: absolute;
+    right: 10px;
+    color: var(--text-faint);
+    pointer-events: none;
+  }
+</style>

--- a/frontend/src/components/FailureItem.svelte
+++ b/frontend/src/components/FailureItem.svelte
@@ -55,9 +55,9 @@
     text-transform: uppercase;
     letter-spacing: 0.03em;
   }
-  .badge.fail { background: color-mix(in srgb, var(--fail) 16%, transparent); color: var(--fail); }
-  .badge.err { background: color-mix(in srgb, var(--error) 18%, transparent); color: var(--error); }
-  .badge.skip { background: color-mix(in srgb, var(--skip) 16%, transparent); color: var(--skip); }
+  .badge.fail { background: color-mix(in srgb, var(--fail) 10%, transparent); color: var(--fail); }
+  .badge.err { background: color-mix(in srgb, var(--error) 10%, transparent); color: var(--error); }
+  .badge.skip { background: color-mix(in srgb, var(--skip) 10%, transparent); color: var(--skip); }
   .f-text {
     display: flex;
     flex-direction: column;

--- a/frontend/src/components/ImplementationFailures.svelte
+++ b/frontend/src/components/ImplementationFailures.svelte
@@ -61,7 +61,7 @@
   </header>
   <div class="body">
     {#if !active}
-      <div class="empty-note">{implName} isn't included in any dialect report.</div>
+      <div class="empty-note">{implName} isn’t included in any dialect report.</div>
     {:else if failures.length === 0}
       <div class="empty-note">{implName} passes every test on {active.prettyName}.</div>
     {:else}

--- a/frontend/src/components/JsonPanel.svelte
+++ b/frontend/src/components/JsonPanel.svelte
@@ -19,5 +19,8 @@
       <CopyButton text={json} label="Copy {label.toLowerCase()}" />
     </span>
   </header>
-  <pre class="code">{#each tokenizeJson(value) as tok, i (i)}{#if tok.cls}<span class={tok.cls}>{tok.text}</span>{:else}{tok.text}{/if}{/each}</pre>
+  <!-- a scrollable code block must be keyboard-focusable so it can be scrolled
+       (axe scrollable-region-focusable); Svelte's heuristic doesn't allow for that -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <pre class="code" tabindex="0" role="group" aria-label="{label} JSON">{#each tokenizeJson(value) as tok, i (i)}{#if tok.cls}<span class={tok.cls}>{tok.text}</span>{:else}{tok.text}{/if}{/each}</pre>
 </div>

--- a/frontend/src/components/Overview.svelte
+++ b/frontend/src/components/Overview.svelte
@@ -74,7 +74,6 @@
     );
 </script>
 
-<div class="crumbs"><span>Report</span></div>
 <h1 class="page">{data.runMetadata.dialect.prettyName} compliance</h1>
 <p class="h-lead">
   Bowtie is a tool for understanding and comparing implementations of the
@@ -154,7 +153,7 @@
     <summary>
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" /><path d="M12 16v-4M12 8h.01" /></svg>
       {others.length}
-      {others.length === 1 ? "implementation doesn't" : "more implementations don't"}
+      {others.length === 1 ? "implementation doesn’t" : "more implementations don't"}
       support {data.runMetadata.dialect.prettyName} under the current language filter
     </summary>
     <ul>

--- a/frontend/src/components/Rail.svelte
+++ b/frontend/src/components/Rail.svelte
@@ -2,6 +2,12 @@
   import { report } from "../stores/report.svelte";
   import { mapLanguage } from "../data/mapLanguage";
   import type { Worst } from "../lib/reportModel";
+  import DialectPicker from "./DialectPicker.svelte";
+
+  let { dialectBase }: { dialectBase?: string } = $props();
+
+  const inScope = (language: string) =>
+    report.langs.size === 0 || report.langs.has(language);
 
   const statusDefs: {
     key: Worst | "pass";
@@ -46,6 +52,12 @@
 </script>
 
 <aside class="rail">
+  {#if dialectBase && report.data}
+    <div class="rail-group">
+      <DialectPicker current={report.data.runMetadata.dialect.shortName} base={dialectBase} />
+    </div>
+  {/if}
+
   <div class="rail-group">
     <span class="label">Search cases</span>
     <div class="search">
@@ -101,8 +113,8 @@
          includes; filtering itself lives on the language chips above. -->
     <ul class="impl-list">
       {#each [...(report.data?.runMetadata.implementations ?? [])] as [id, impl] (id)}
-        <li class="impl-item {report.langs.has(impl.language) ? '' : 'off'}">
-          <span class="nm">{impl.name}</span>
+        <li class="impl-item {inScope(impl.language) ? '' : 'off'}">
+          <a class="nm" href="#/implementations/{id}">{impl.name}</a>
           <span class="lg">{mapLanguage(impl.language)}</span>
         </li>
       {/each}

--- a/frontend/src/components/ReportShell.svelte
+++ b/frontend/src/components/ReportShell.svelte
@@ -5,6 +5,10 @@
   import CaseList from "./CaseList.svelte";
   import CaseDetail from "./CaseDetail.svelte";
 
+  // Only the live dialect report offers a dialect switcher; a local upload has
+  // no dialect to navigate to.
+  let { dialectBase }: { dialectBase?: string } = $props();
+
   // Arrow-key navigation through the currently-visible case list.
   function onKeydown(e: KeyboardEvent) {
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -27,7 +31,7 @@
 <svelte:window onkeydown={onKeydown} />
 
 <div class="shell">
-  <Rail />
+  <Rail {dialectBase} />
   <main class="center">
     {#key report.selectedSeq}
       <div class="center-inner fade">

--- a/frontend/src/components/TopBar.svelte
+++ b/frontend/src/components/TopBar.svelte
@@ -1,21 +1,11 @@
 <script lang="ts">
-  import Dialect from "../data/Dialect";
   import { theme } from "../stores/theme.svelte";
-  import { router, matchRoute } from "../stores/router.svelte";
+  import { router, matchRoute, type Route } from "../stores/router.svelte";
   import { report } from "../stores/report.svelte";
+  import { NAV } from "../lib/nav";
 
   const route = $derived(matchRoute(router.path));
-  const dialects = Dialect.newestToOldest();
-
-  const currentDraft = $derived(
-    route.params.draftName ?? Dialect.latest().shortName,
-  );
-
-  function onDialectChange(e: Event) {
-    const shortName = (e.target as HTMLSelectElement).value;
-    const base = route.name === "benchmarks" ? "/benchmarks" : "/dialects";
-    router.navigate(`${base}/${shortName}`);
-  }
+  const isActive = (m: Route["name"][]) => m.includes(route.name);
 </script>
 
 <header class="topbar">
@@ -23,15 +13,16 @@
     <span class="mark">&gt;·&lt;</span> Bowtie
   </a>
 
-  {#if route.name === "dialect" || route.name === "benchmarks"}
-    <label class="dialect-pill">
-      <select value={currentDraft} onchange={onDialectChange} aria-label="Choose dialect">
-        {#each dialects as d (d.shortName)}
-          <option value={d.shortName}>{d.prettyName}</option>
-        {/each}
-      </select>
-    </label>
-  {/if}
+  <nav class="topnav" aria-label="Primary">
+    {#each NAV as item (item.label)}
+      <a
+        class="navlink"
+        class:active={isActive(item.match)}
+        href={item.href}
+        aria-current={isActive(item.match) ? "page" : undefined}
+      >{item.label}</a>
+    {/each}
+  </nav>
 
   <div class="spacer"></div>
 
@@ -52,16 +43,6 @@
       </svg>
     {/if}
   </button>
-
-  {#if route.name === "benchmarks"}
-    <a class="ghost" href="#/">Reports</a>
-  {:else}
-    <a class="ghost" href="#/benchmarks">Benchmarks</a>
-  {/if}
-
-  <a class="ghost" href="#/implementations">Implementations</a>
-
-  <a class="ghost" href="#/local-report">Upload</a>
 
   <a class="ghost" href="https://docs.bowtie.report/" target="_blank" rel="noopener noreferrer">
     Docs

--- a/frontend/src/lib/nav.ts
+++ b/frontend/src/lib/nav.ts
@@ -1,0 +1,43 @@
+import type { Route } from "../stores/router.svelte";
+
+export interface Section {
+  name: Route["name"];
+  label: string;
+  href: string;
+  /** route names for which this section is the active top-nav item */
+  match: Route["name"][];
+  /** parent section, for breadcrumb trails on drill-down pages */
+  parent?: Route["name"];
+  /** whether it appears in the primary top nav */
+  inNav: boolean;
+}
+
+/**
+ * Single source of truth for navigation: the top nav renders {@link NAV}, and
+ * breadcrumbs walk `parent` links here. Renaming/re-parenting a section is a
+ * one-line change — nothing is duplicated in page components.
+ */
+export const SECTIONS: Record<Route["name"], Section> = {
+  dialect: {
+    name: "dialect", label: "Compliance", href: "#/", match: ["dialect"], inNav: true,
+  },
+  benchmarks: {
+    name: "benchmarks", label: "Benchmarks", href: "#/benchmarks", match: ["benchmarks"], inNav: true,
+  },
+  implementations: {
+    name: "implementations", label: "Implementations", href: "#/implementations",
+    match: ["implementations", "implementation"], inNav: true,
+  },
+  implementation: {
+    name: "implementation", label: "Implementation", href: "#/implementations",
+    match: [], parent: "implementations", inNav: false,
+  },
+  local: {
+    name: "local", label: "Upload", href: "#/local-report", match: ["local"], inNav: true,
+  },
+  notfound: {
+    name: "notfound", label: "Not found", href: "#/", match: [], inNav: false,
+  },
+};
+
+export const NAV: Section[] = Object.values(SECTIONS).filter((s) => s.inNav);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,7 @@
 import { mount } from "svelte";
 
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
 import "./styles/tokens.css";
 import "./styles/global.css";
 import App from "./App.svelte";

--- a/frontend/src/routes/Benchmarks.svelte
+++ b/frontend/src/routes/Benchmarks.svelte
@@ -13,6 +13,7 @@
   import BenchmarkChart from "../components/BenchmarkChart.svelte";
   import BenchmarkGroup from "../components/BenchmarkGroup.svelte";
   import Spinner from "../components/Spinner.svelte";
+  import DialectPicker from "../components/DialectPicker.svelte";
 
   let { draftName }: { draftName?: string } = $props();
 
@@ -35,8 +36,7 @@
       const report = await dialect.fetchBenchmarkReport();
       if (token !== loadToken) return;
       data = report;
-      langs = benchmarkLanguages(report.metadata.implementations);
-      types = benchmarkTypes(report.results);
+      // langs/types stay empty = "all" (first click narrows, further clicks add)
     } catch (e) {
       if (token === loadToken)
         error = e instanceof Error ? e.message : String(e);
@@ -54,16 +54,21 @@
   );
   const allTypes = $derived(data ? benchmarkTypes(data.results) : []);
 
+  // empty selection = all (first click narrows, further clicks add)
   const scopedIds = $derived(
     data
       ? [...data.metadata.implementations]
-          .filter(([, i]) => langs.includes(i.language))
+          .filter(([, i]) => langs.length === 0 || langs.includes(i.language))
           .map(([id]) => id)
       : [],
   );
 
   const filteredGroups = $derived(
-    data ? data.results.filter((g) => types.includes(g.benchmarkType)) : [],
+    data
+      ? data.results.filter(
+          (g) => types.length === 0 || types.includes(g.benchmarkType),
+        )
+      : [],
   );
 
   const ranking = $derived(
@@ -90,13 +95,15 @@
 {:else if error}
   <div class="doc"><div class="doc-inner">
     <h1 class="page">Benchmarks</h1>
-    <div class="empty-note">Couldn't load benchmarks.<br />{error}</div>
+    <div class="empty-note">Couldn’t load benchmarks.<br />{error}</div>
   </div></div>
 {:else if data}
   <div class="doc">
     <div class="doc-inner">
-      <div class="crumbs"><a href="#/">Report</a><span class="sep">/</span><span>Benchmarks</span></div>
-      <h1 class="page">{data.metadata.dialect.prettyName} benchmarks</h1>
+      <div class="page-head">
+        <h1 class="page">{data.metadata.dialect.prettyName} benchmarks</h1>
+        <DialectPicker current={data.metadata.dialect.shortName} base="/benchmarks" />
+      </div>
 
       <div class="card">
         <header>Run info</header>
@@ -150,7 +157,7 @@
         </div>
       </div>
 
-      {#each allTypes.filter((t) => types.includes(t) && groupsByType[t]) as type (type)}
+      {#each allTypes.filter((t) => (types.length === 0 || types.includes(t)) && groupsByType[t]) as type (type)}
         <h2 class="bench-type-head">{titleCase(type)}</h2>
         {#each groupsByType[type] as group, gi (gi)}
           <BenchmarkGroup {group} {scopedIds} implementations={data.metadata.implementations} />

--- a/frontend/src/routes/DialectReport.svelte
+++ b/frontend/src/routes/DialectReport.svelte
@@ -52,7 +52,7 @@
 {#if loading}
   <Spinner />
 {:else if error}
-  <div class="empty-note">Couldn't load this report.<br />{error}</div>
+  <div class="empty-note">Couldn’t load this report.<br />{error}</div>
 {:else}
-  <ReportShell />
+  <ReportShell dialectBase="/dialects" />
 {/if}

--- a/frontend/src/routes/ImplementationReport.svelte
+++ b/frontend/src/routes/ImplementationReport.svelte
@@ -10,6 +10,7 @@
   import VersionsTrend from "../components/VersionsTrend.svelte";
   import BadgeEmbed from "../components/BadgeEmbed.svelte";
   import ImplementationFailures from "../components/ImplementationFailures.svelte";
+  import Breadcrumbs from "../components/Breadcrumbs.svelte";
   import Spinner from "../components/Spinner.svelte";
 
   let { id, badges = false }: { id: string; badges?: boolean } = $props();
@@ -75,7 +76,7 @@
 {:else if error}
   <div class="doc">
     <div class="doc-inner">
-      <h1 class="page">Couldn't load this implementation</h1>
+      <h1 class="page">Couldn’t load this implementation</h1>
       <div class="empty-note">{error}<br /><a href="#/">Back to the report</a></div>
     </div>
   </div>
@@ -91,10 +92,7 @@
 {:else}
   <div class="doc">
     <div class="doc-inner">
-      <div class="crumbs">
-        <a href="#/">Report</a><span class="sep">/</span>
-        <span class="mono" style="color:var(--accent)">{impl.id}</span>
-      </div>
+      <Breadcrumbs />
       <div class="impl-head">
         <div>
           <h1 class="page">{impl.name}</h1>

--- a/frontend/src/routes/Implementations.svelte
+++ b/frontend/src/routes/Implementations.svelte
@@ -37,7 +37,7 @@
 {:else if error}
   <div class="doc"><div class="doc-inner">
     <h1 class="page">Implementations</h1>
-    <div class="empty-note">Couldn't load implementations.<br />{error}</div>
+    <div class="empty-note">Couldn’t load implementations.<br />{error}</div>
   </div></div>
 {:else}
   <div class="doc">

--- a/frontend/src/routes/LocalReport.svelte
+++ b/frontend/src/routes/LocalReport.svelte
@@ -53,7 +53,7 @@
     <div class="doc-inner">
       <h1 class="page">Upload a report</h1>
       <p class="h-lead">
-        Explore a report you generated locally with Bowtie's CLI — it's parsed
+        Explore a report you generated locally with Bowtie’s CLI — it’s parsed
         in your browser and never leaves your machine.
       </p>
 
@@ -89,7 +89,7 @@
         </svg>
         {#if invalid}
           <p style="color:var(--fail);font-weight:560;margin:0">
-            That doesn't look like a Bowtie report.
+            That doesn’t look like a Bowtie report.
           </p>
         {:else}
           <p style="margin:0">Drag &amp; drop a JSON report here, or click to choose a file.</p>

--- a/frontend/src/routes/NotFound.svelte
+++ b/frontend/src/routes/NotFound.svelte
@@ -3,6 +3,6 @@
 <div class="doc">
   <div class="doc-inner">
     <h1 class="page">Page not found</h1>
-    <p class="h-lead">That page doesn't exist. <a href="#/">Back to the report</a>.</p>
+    <p class="h-lead">That page doesn’t exist. <a href="#/">Back to the report</a>.</p>
   </div>
 </div>

--- a/frontend/src/stores/report.svelte.ts
+++ b/frontend/src/stores/report.svelte.ts
@@ -9,16 +9,17 @@ import {
 
 /**
  * Holds the currently-loaded dialect report plus all cross-pane UI state
- * (filters + selection). Kept as a single reactive store so the rail, case
- * list, and detail stay in sync. Selection/filters are in-memory for now;
- * URL-syncing (`?case=`, `?language=`) is a follow-up.
+ * (filters + selection), kept as a single reactive store so the rail, case
+ * list, and detail stay in sync. Filters + selection round-trip through the URL
+ * via {@link toQuery}/{@link applyQuery}.
  */
 class ReportStore {
   data = $state<ReportData | null>(null);
   allImpls = $state<Map<string, Implementation>>(new Map());
   worst = $state<Map<number, Map<string, Worst>>>(new Map());
 
-  // filters
+  // filters. An empty `langs` set means "all languages" (no filter); the first
+  // click on a language narrows to just it, further clicks add/remove.
   langs = $state<Set<string>>(new Set());
   statuses = $state<Set<Worst>>(new Set<Worst>(["fail", "err", "skip"]));
   search = $state("");
@@ -33,11 +34,7 @@ class ReportStore {
     this.data = data;
     this.allImpls = allImpls;
     this.worst = computeWorst(data);
-    const langs = new Set<string>();
-    for (const impl of data.runMetadata.implementations.values()) {
-      langs.add(impl.language);
-    }
-    this.langs = langs;
+    this.langs = new Set(); // empty = all languages
     this.statuses = new Set<Worst>(["fail", "err", "skip"]);
     this.search = "";
     this.showPassing = false;
@@ -62,8 +59,9 @@ class ReportStore {
 
   get scopedImplIds(): string[] {
     if (!this.data) return [];
+    const all = this.langs.size === 0;
     return [...this.d.runMetadata.implementations]
-      .filter(([, i]) => this.langs.has(i.language))
+      .filter(([, i]) => all || this.langs.has(i.language))
       .map(([id]) => id);
   }
 
@@ -77,7 +75,7 @@ class ReportStore {
     return [...this.allImpls.values()]
       .filter(
         (i) =>
-          this.langs.has(i.language) &&
+          (this.langs.size === 0 || this.langs.has(i.language)) &&
           !this.d.implementationsResults.has(i.id),
       )
       .sort((a, b) => a.name.localeCompare(b.name));
@@ -161,17 +159,25 @@ class ReportStore {
     this.openDiag = null;
   }
 
+  private static readonly DEFAULT_STATUS = ["err", "fail", "skip"];
+
   /**
-   * Serialize the shareable slice of state (language filter + selected
-   * case/test) to a query string. Ephemeral UI (status toggles, search text)
-   * is intentionally left out of the URL.
+   * Serialize the filter + selection state to a query string so a view is
+   * shareable and survives reload. Defaults (all languages, the default status
+   * set, no search) are omitted to keep URLs tidy.
    */
   toQuery(): string {
     const p = new URLSearchParams();
-    const all = this.languages;
-    if (this.langs.size && this.langs.size < all.length) {
-      for (const l of all) if (this.langs.has(l)) p.append("language", l);
+    if (this.langs.size) {
+      for (const l of this.languages) if (this.langs.has(l)) p.append("language", l);
     }
+    const cur = [...this.statuses].sort();
+    if (cur.join(",") !== ReportStore.DEFAULT_STATUS.join(",")) {
+      if (cur.length === 0) p.set("status", "none");
+      else for (const s of cur) p.append("status", s);
+    }
+    if (this.showPassing) p.set("passing", "1");
+    if (this.search) p.set("q", this.search);
     if (this.selectedSeq !== null) {
       p.set("case", String(this.selectedSeq));
       if (this.selectedTest) p.set("test", String(this.selectedTest));
@@ -181,10 +187,21 @@ class ReportStore {
 
   /** Restore filters/selection from a URL query (deep links, reloads). */
   applyQuery(params: URLSearchParams) {
-    const langs = params
-      .getAll("language")
-      .filter((l) => this.languages.includes(l));
-    if (langs.length) this.langs = new Set(langs);
+    this.langs = new Set(
+      params.getAll("language").filter((l) => this.languages.includes(l)),
+    );
+
+    const valid: Worst[] = ["fail", "err", "skip"];
+    if (params.get("status") === "none") {
+      this.statuses = new Set();
+    } else {
+      const statuses = params
+        .getAll("status")
+        .filter((s): s is Worst => valid.includes(s as Worst));
+      if (statuses.length) this.statuses = new Set(statuses);
+    }
+    this.showPassing = params.get("passing") === "1";
+    this.search = params.get("q") ?? "";
 
     const caseParam = params.get("case");
     if (caseParam !== null) {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -11,6 +11,10 @@ body {
 }
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
+/* Links inside running text must be distinguishable without relying on colour
+   (WCAG 1.4.1 / axe link-in-text-block) — so underline in-text/prose links.
+   Standalone UI links (nav, cards, crumbs, table cells) are exempt. */
+p a, .h-lead a, .empty-note a, .other-impls a { text-decoration: underline; text-underline-offset: 0.15em; }
 button { font-family: inherit; color: inherit; }
 .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .label { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.13em; text-transform: uppercase; color: var(--text-faint); font-weight: 500; }
@@ -30,8 +34,10 @@ button { font-family: inherit; color: inherit; }
 .topbar::-webkit-scrollbar { display: none; }
 .brand { display: flex; align-items: center; gap: 10px; font-weight: 640; letter-spacing: -0.02em; font-size: 15px; color: var(--text); text-decoration: none; }
 .brand .mark { font-family: var(--font-mono); color: var(--accent); font-size: 17px; font-weight: 700; letter-spacing: -0.04em; }
-.dialect-pill { display: inline-flex; align-items: center; gap: 7px; font-family: var(--font-mono); font-size: 12px; padding: 5px 11px; border: 1px solid var(--border-strong); border-radius: 7px; background: var(--surface); cursor: pointer; color: var(--text); }
-.dialect-pill select { border: 0; background: transparent; color: inherit; font: inherit; cursor: pointer; outline: none; }
+.topnav { display: flex; align-items: center; gap: 2px; }
+.navlink { padding: 6px 11px; border-radius: 7px; font-size: 13.5px; color: var(--text-muted); text-decoration: none; white-space: nowrap; }
+.navlink:hover { background: var(--surface-2); color: var(--text); text-decoration: none; }
+.navlink.active { color: var(--accent); font-weight: 540; }
 .topbar .spacer { flex: 1; }
 .topbar .ghost { display: inline-flex; align-items: center; gap: 7px; height: 32px; padding: 0 11px; border-radius: 7px; border: 1px solid transparent; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 13px; text-decoration: none; }
 .topbar .ghost:hover { background: var(--surface-2); color: var(--text); text-decoration: none; }
@@ -56,7 +62,8 @@ button { font-family: inherit; color: inherit; }
 .chip.status .dot { display: inline-block; width: 7px; height: 7px; border-radius: 2px; margin-right: 5px; vertical-align: middle; }
 .impl-list { list-style: none; display: flex; flex-direction: column; gap: 1px; max-height: 260px; overflow-y: auto; margin: 0 -6px; padding: 0 6px; }
 .impl-item { display: flex; align-items: center; gap: 8px; padding: 4px 6px; border-radius: 6px; }
-.impl-item .nm { font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.impl-item .nm { font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: inherit; text-decoration: none; }
+.impl-item .nm:hover { color: var(--accent); text-decoration: underline; }
 .impl-item .lg { font-family: var(--font-mono); font-size: 10px; color: var(--text-faint); margin-left: auto; flex: none; }
 .impl-item.off { opacity: 0.34; }
 .impl-count { font-family: var(--font-mono); font-size: 10px; color: var(--text-faint); padding-left: 2px; }
@@ -75,7 +82,9 @@ button { font-family: inherit; color: inherit; }
 .runstrip .cell .v { font-family: var(--font-mono); font-size: 15px; margin-top: 4px; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
 .runstrip .cell .v.small { font-size: 12px; }
 
-.h-lead { font-size: 13px; color: var(--text-muted); margin: 0 0 20px; max-width: 62ch; }
+.h-lead { font-size: 15px; line-height: 1.6; color: var(--text-muted); margin: 0 0 20px; max-width: 66ch; }
+.page-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 18px; flex-wrap: wrap; }
+.page-head .page { margin-bottom: 0; }
 h1.page { font-size: 26px; letter-spacing: -0.025em; font-weight: 660; margin: 4px 0 6px; text-wrap: balance; line-height: 1.2; }
 
 .matrix { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; background: var(--surface); }
@@ -119,7 +128,7 @@ pre.code .j-key { color: var(--j-key); } pre.code .j-str { color: var(--j-str); 
 .tline .exp { font-family: var(--font-mono); font-size: 10px; color: var(--text-faint); margin-left: 8px; }
 .tline .tally { margin-left: auto; display: flex; gap: 12px; font-family: var(--font-mono); font-size: 11.5px; font-variant-numeric: tabular-nums; flex: none; }
 .tally .t-ok { color: var(--pass); } .tally .t-fail { color: var(--fail); } .tally .t-err { color: var(--error); } .tally .t-skip { color: var(--skip); }
-.tally .mut { opacity: 0.3; }
+.tally .mut { color: var(--text-faint); }
 
 .dis { border: 1px solid var(--border); border-radius: 11px; background: var(--surface); overflow: hidden; }
 .dis .dhead { padding: 12px 14px; border-bottom: 1px solid var(--border); background: var(--surface-2); display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
@@ -131,9 +140,9 @@ pre.code .j-key { color: var(--j-key); } pre.code .j-str { color: var(--j-str); 
 .ogroup:first-child { border-top: 0; }
 .oh { padding: 11px 14px 4px; display: flex; align-items: center; gap: 9px; }
 .oh .badge { font-family: var(--font-mono); font-size: 10px; padding: 2px 8px; border-radius: 5px; letter-spacing: 0.03em; text-transform: uppercase; }
-.badge.fail { background: color-mix(in srgb, var(--fail) 16%, transparent); color: var(--fail); }
-.badge.err { background: color-mix(in srgb, var(--error) 18%, transparent); color: var(--error); }
-.badge.skip { background: color-mix(in srgb, var(--skip) 16%, transparent); color: var(--skip); }
+.badge.fail { background: color-mix(in srgb, var(--fail) 10%, transparent); color: var(--fail); }
+.badge.err { background: color-mix(in srgb, var(--error) 10%, transparent); color: var(--error); }
+.badge.skip { background: color-mix(in srgb, var(--skip) 10%, transparent); color: var(--skip); }
 .chips-impl { display: flex; flex-wrap: wrap; gap: 6px; padding: 8px 14px 13px; }
 .ichip { font-family: var(--font-mono); font-size: 11px; padding: 3px 9px; border-radius: 6px; border: 1px solid var(--border-strong); background: var(--surface); cursor: pointer; color: var(--text-muted); display: inline-flex; align-items: baseline; gap: 6px; }
 .ichip:hover { border-color: var(--text-faint); color: var(--text); }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,38 +1,38 @@
 :root {
-  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
-  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, "Cascadia Code", monospace;
+  --font-sans: "Geist Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono: "Geist Mono Variable", ui-monospace, "SF Mono", Menlo, "Cascadia Code", monospace;
 
-  /* light (default) */
+  /* light (default) — all text/background pairs meet WCAG AA (>=4.5:1) */
   --bg: #faf8fb;
   --surface: #ffffff;
   --surface-2: #f4f1f7;
   --border: #e9e4ef;
   --border-strong: #d7d0e1;
   --text: #1b1720;
-  --text-muted: #6a6377;
-  --text-faint: #9a93a6;
-  --accent: #e2116a;
-  --accent-hover: #c60d5c;
+  --text-muted: #615a6e;
+  --text-faint: #716a7d;
+  --accent: #c60d5c;
+  --accent-hover: #a80d50;
   --accent-ink: #ffffff;
-  --pass: #12a05c;
-  --fail: #e23150;
-  --error: #bd6c12;
-  --skip: #7d7690;
-  --sel-bg: rgba(226, 17, 106, 0.07);
+  --pass: #0a7d44;
+  --fail: #cc1338;
+  --error: #9c5410;
+  --skip: #655e73;
+  --sel-bg: rgba(198, 13, 92, 0.06);
   --shadow: 0 1px 2px rgba(20, 12, 24, 0.06), 0 8px 24px rgba(20, 12, 24, 0.05);
-  --j-key: #b3226e;
-  --j-str: #1a7f4b;
-  --j-num: #b96a12;
+  --j-key: #a11560;
+  --j-str: #157540;
+  --j-num: #9a560c;
   --j-bool: #6b43c9;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #131017; --surface: #1a171f; --surface-2: #221e28; --border: #2b2732;
-    --border-strong: #3b3644; --text: #f0edf4; --text-muted: #a09aab; --text-faint: #6d6679;
+    --border-strong: #3b3644; --text: #f0edf4; --text-muted: #a8a2b3; --text-faint: #8c8597;
     --accent: #ff3d84; --accent-hover: #ff5c99; --accent-ink: #16020c;
-    --pass: #35c281; --fail: #ff5470; --error: #f7a63b; --skip: #8a83a0;
-    --sel-bg: rgba(255, 61, 132, 0.10);
+    --pass: #35c281; --fail: #ff5470; --error: #f7a63b; --skip: #948da4;
+    --sel-bg: rgba(255, 61, 132, 0.06);
     --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.35);
     --j-key: #ff85b5; --j-str: #6fd39b; --j-num: #f7a63b; --j-bool: #c79bff;
   }
@@ -40,20 +40,20 @@
 
 :root[data-theme="light"] {
   --bg: #faf8fb; --surface: #ffffff; --surface-2: #f4f1f7; --border: #e9e4ef;
-  --border-strong: #d7d0e1; --text: #1b1720; --text-muted: #6a6377; --text-faint: #9a93a6;
-  --accent: #e2116a; --accent-hover: #c60d5c; --accent-ink: #ffffff;
-  --pass: #12a05c; --fail: #e23150; --error: #bd6c12; --skip: #7d7690;
-  --sel-bg: rgba(226, 17, 106, 0.07);
+  --border-strong: #d7d0e1; --text: #1b1720; --text-muted: #615a6e; --text-faint: #716a7d;
+  --accent: #c60d5c; --accent-hover: #a80d50; --accent-ink: #ffffff;
+  --pass: #0a7d44; --fail: #cc1338; --error: #9c5410; --skip: #655e73;
+  --sel-bg: rgba(198, 13, 92, 0.06);
   --shadow: 0 1px 2px rgba(20, 12, 24, 0.06), 0 8px 24px rgba(20, 12, 24, 0.05);
-  --j-key: #b3226e; --j-str: #1a7f4b; --j-num: #b96a12; --j-bool: #6b43c9;
+  --j-key: #a11560; --j-str: #157540; --j-num: #9a560c; --j-bool: #6b43c9;
 }
 
 :root[data-theme="dark"] {
   --bg: #131017; --surface: #1a171f; --surface-2: #221e28; --border: #2b2732;
-  --border-strong: #3b3644; --text: #f0edf4; --text-muted: #a09aab; --text-faint: #6d6679;
+  --border-strong: #3b3644; --text: #f0edf4; --text-muted: #a8a2b3; --text-faint: #8c8597;
   --accent: #ff3d84; --accent-hover: #ff5c99; --accent-ink: #16020c;
-  --pass: #35c281; --fail: #ff5470; --error: #f7a63b; --skip: #8a83a0;
-  --sel-bg: rgba(255, 61, 132, 0.10);
+  --pass: #35c281; --fail: #ff5470; --error: #f7a63b; --skip: #948da4;
+  --sel-bg: rgba(255, 61, 132, 0.06);
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.35);
   --j-key: #ff85b5; --j-str: #6fd39b; --j-num: #f7a63b; --j-bool: #c79bff;
 }


### PR DESCRIPTION
Follow-up polish on the Svelte frontend, batching several UX and quality improvements.

## Typography
- Self-host **Geist Sans + Geist Mono** via `@fontsource-variable` (subset, variable weight).
- Constrain running-text width, underline in-text links (no longer colour-only), and fix the About paragraph wrapping awkwardly at narrow widths.

## Accessibility
- Retuned the colour tokens so **every text/background pair meets WCAG AA** (light + dark).
- Made scrollable code blocks keyboard-focusable.
- Added an **axe (WCAG 2.0/2.1 A + AA) e2e gate** over every view (compliance report, case detail, implementation, implementations index, benchmarks, upload, 404) in both colour schemes. It runs in CI through the existing `ui(tests)` session — no workflow change needed.

## Navigation
- Centralised the site's sections in a single `nav.ts` config (previously hand-written per page).
- Compliance / Benchmarks / Implementations / Upload now show on **every** page; "Reports" is renamed **"Compliance"**; the nav is no longer stranded on the right.
- Breadcrumbs are derived from the route + report store instead of hand-written in each view.
- Moved the dialect selector out of the top bar into a labelled in-body picker on the compliance and benchmark pages.

## Filters & state
- **URL-sync** status / passing / search alongside language and selection, so any filtered/selected view is shareable and survives reload.
- **Language filter UX**: an empty selection means "all" (first click narrows to one language, further clicks add more). This also fixes the benchmarks page, which was rendering empty by default.
- In-scope implementations now link through to their implementation pages.

## Verification
- `svelte-check` 0 errors, `eslint` clean, `vite build` clean.
- Playwright e2e: **15/15 pass**, including the axe scans in both colour schemes.
- The 4 `parse*Data` unit tests that shell out to the `bowtie` CLI fail only locally (the CLI isn't installed in this worktree); they pass in CI's `ui(tests)` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)