### PR TITLE
Move case filters to the right pane; celebrate fully-compliant implementations

### DIFF
--- a/frontend/src/components/CaseList.svelte
+++ b/frontend/src/components/CaseList.svelte
@@ -1,10 +1,31 @@
 <script lang="ts">
   import { report } from "../stores/report.svelte";
-  import { caseGroup } from "../lib/reportModel";
+  import { caseGroup, type Worst } from "../lib/reportModel";
 
   const failing = $derived(report.failingSeqs);
   const passing = $derived(report.passingSeqs);
   const shown = $derived(failing.length + (report.showPassing ? passing.length : 0));
+
+  const statusDefs: {
+    key: Worst | "pass";
+    label: string;
+    color: string;
+    hint: string;
+  }[] = [
+    { key: "fail", label: "failed", color: "var(--fail)", hint: "The implementation ran but gave the wrong answer." },
+    { key: "err", label: "errored", color: "var(--error)", hint: "The implementation crashed trying to answer." },
+    { key: "skip", label: "skipped", color: "var(--skip)", hint: "The implementation skipped the test, usually a known bug." },
+    { key: "pass", label: "passing", color: "var(--pass)", hint: "The implementation gave the correct answer." },
+  ];
+
+  function statusPressed(key: Worst | "pass"): boolean {
+    return key === "pass" ? report.showPassing : report.statuses.has(key);
+  }
+
+  function toggleStatus(key: Worst | "pass") {
+    if (key === "pass") report.showPassing = !report.showPassing;
+    else report.toggleStatus(key);
+  }
 
   function seg(n: number, total: number, cls: string) {
     if (!n) return null;
@@ -28,6 +49,31 @@
     <div class="row1">
       <h2>Test cases</h2>
       <span class="n">{shown} shown</span>
+    </div>
+    <div class="master-filters">
+      <div class="search">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" />
+        </svg>
+        <input
+          type="text"
+          placeholder="description, keyword…"
+          aria-label="Search test cases"
+          bind:value={report.search}
+        />
+      </div>
+      <div class="chips">
+        {#each statusDefs as s (s.key)}
+          <button
+            class="chip status"
+            aria-pressed={statusPressed(s.key)}
+            title={s.hint}
+            onclick={() => toggleStatus(s.key)}
+          >
+            <span class="dot" style="background:{s.color}"></span>{s.label}
+          </button>
+        {/each}
+      </div>
     </div>
   </div>
 

--- a/frontend/src/components/ImplementationFailures.svelte
+++ b/frontend/src/components/ImplementationFailures.svelte
@@ -43,37 +43,49 @@
   const failures = $derived(active ? failuresFor(reports.get(active)!, implId) : []);
 </script>
 
-<div class="card">
-  <header class="ff-head">
-    <span>Failures</span>
-    {#if dialects.length > 1 && active}
-      <select
-        class="ff-select mono"
-        value={active.shortName}
-        onchange={(e) => (chosen = (e.target as HTMLSelectElement).value)}
-        aria-label="Dialect for failures"
-      >
-        {#each dialects as d (d.shortName)}
-          <option value={d.shortName}>{d.prettyName}</option>
-        {/each}
-      </select>
-    {/if}
-  </header>
-  <div class="body">
-    {#if !active}
-      <div class="empty-note">{implName} isn’t included in any dialect report.</div>
-    {:else if failures.length === 0}
-      <div class="empty-note">{implName} passes every test on {active.prettyName}.</div>
-    {:else}
-      <p class="ff-count">
-        <b>{failures.length}</b> unsuccessful {failures.length === 1 ? "test" : "tests"} on {active.prettyName}
-      </p>
-      {#each failures as f, i (i)}
-        <FailureItem failure={f} />
-      {/each}
-    {/if}
+{#if active && failures.length === 0}
+  <div class="card pass-card">
+    <div class="pass-body">
+      <svg class="pass-ic" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" /><path d="m8.5 12 2.5 2.5 4.5-5" />
+      </svg>
+      <div class="pass-text">
+        <strong>Fully compliant</strong>
+        <span>{implName} passes every test on {active.prettyName}.</span>
+      </div>
+    </div>
   </div>
-</div>
+{:else}
+  <div class="card">
+    <header class="ff-head">
+      <span>Failures</span>
+      {#if dialects.length > 1 && active}
+        <select
+          class="ff-select mono"
+          value={active.shortName}
+          onchange={(e) => (chosen = (e.target as HTMLSelectElement).value)}
+          aria-label="Dialect for failures"
+        >
+          {#each dialects as d (d.shortName)}
+            <option value={d.shortName}>{d.prettyName}</option>
+          {/each}
+        </select>
+      {/if}
+    </header>
+    <div class="body">
+      {#if !active}
+        <div class="empty-note">{implName} isn’t included in any dialect report.</div>
+      {:else}
+        <p class="ff-count">
+          <b>{failures.length}</b> unsuccessful {failures.length === 1 ? "test" : "tests"} on {active.prettyName}
+        </p>
+        {#each failures as f, i (i)}
+          <FailureItem failure={f} />
+        {/each}
+      {/if}
+    </div>
+  </div>
+{/if}
 
 <style>
   .ff-head {
@@ -98,5 +110,33 @@
   .ff-count b {
     color: var(--text);
     font-variant-numeric: tabular-nums;
+  }
+  .pass-card {
+    border-color: color-mix(in srgb, var(--pass) 38%, var(--border));
+    background: color-mix(in srgb, var(--pass) 7%, var(--surface));
+  }
+  .pass-body {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 18px;
+  }
+  .pass-ic {
+    color: var(--pass);
+    flex: none;
+  }
+  .pass-text {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .pass-text strong {
+    color: var(--pass);
+    font-size: var(--fs-md);
+    letter-spacing: -0.01em;
+  }
+  .pass-text span {
+    color: var(--text-muted);
+    font-size: var(--fs-sm);
   }
 </style>

--- a/frontend/src/components/Rail.svelte
+++ b/frontend/src/components/Rail.svelte
@@ -1,54 +1,12 @@
 <script lang="ts">
   import { report } from "../stores/report.svelte";
   import { mapLanguage } from "../data/mapLanguage";
-  import type { Worst } from "../lib/reportModel";
   import DialectPicker from "./DialectPicker.svelte";
 
   let { dialectBase }: { dialectBase?: string } = $props();
 
   const inScope = (language: string) =>
     report.langs.size === 0 || report.langs.has(language);
-
-  const statusDefs: {
-    key: Worst | "pass";
-    label: string;
-    color: string;
-    hint: string;
-  }[] = [
-    {
-      key: "fail",
-      label: "failed",
-      color: "var(--fail)",
-      hint: "The implementation ran but gave the wrong answer.",
-    },
-    {
-      key: "err",
-      label: "errored",
-      color: "var(--error)",
-      hint: "The implementation crashed trying to answer.",
-    },
-    {
-      key: "skip",
-      label: "skipped",
-      color: "var(--skip)",
-      hint: "The implementation skipped the test, usually a known bug.",
-    },
-    {
-      key: "pass",
-      label: "passing",
-      color: "var(--pass)",
-      hint: "The implementation gave the correct answer.",
-    },
-  ];
-
-  function statusPressed(key: Worst | "pass"): boolean {
-    return key === "pass" ? report.showPassing : report.statuses.has(key);
-  }
-
-  function toggleStatus(key: Worst | "pass") {
-    if (key === "pass") report.showPassing = !report.showPassing;
-    else report.toggleStatus(key);
-  }
 </script>
 
 <aside class="rail">
@@ -57,37 +15,6 @@
       <DialectPicker current={report.data.runMetadata.dialect.shortName} base={dialectBase} />
     </div>
   {/if}
-
-  <div class="rail-group">
-    <span class="label">Search cases</span>
-    <div class="search">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="11" cy="11" r="7" /><path d="m21 21-4-4" />
-      </svg>
-      <input
-        type="text"
-        placeholder="description, keyword…"
-        aria-label="Search test cases"
-        bind:value={report.search}
-      />
-    </div>
-  </div>
-
-  <div class="rail-group">
-    <span class="label">Status</span>
-    <div class="chips">
-      {#each statusDefs as s (s.key)}
-        <button
-          class="chip status"
-          aria-pressed={statusPressed(s.key)}
-          title={s.hint}
-          onclick={() => toggleStatus(s.key)}
-        >
-          <span class="dot" style="background:{s.color}"></span>{s.label}
-        </button>
-      {/each}
-    </div>
-  </div>
 
   <div class="rail-group">
     <span class="label">Language</span>

--- a/frontend/src/routes/ImplementationReport.svelte
+++ b/frontend/src/routes/ImplementationReport.svelte
@@ -175,11 +175,16 @@
             </thead>
             <tbody>
               {#each compliance as [dialect, totals] (dialect.uri)}
-                <tr>
+                {@const bad = badTotal(totals)}
+                <tr class:compliant={bad === 0}>
                   <th scope="row" class="dialect">{dialect.prettyName}</th>
-                  <td class="num" class:bad={totals.failedTests}>{totals.failedTests ?? 0}</td>
-                  <td class="num" class:bad={totals.skippedTests}>{totals.skippedTests ?? 0}</td>
-                  <td class="num" class:bad={totals.erroredTests}>{totals.erroredTests ?? 0}</td>
+                  {#if bad === 0}
+                    <td class="pass-cell" colspan="3"><span class="ok-check">✓</span> passes every test</td>
+                  {:else}
+                    <td class="num" class:bad={totals.failedTests}>{totals.failedTests ?? 0}</td>
+                    <td class="num" class:bad={totals.skippedTests}>{totals.skippedTests ?? 0}</td>
+                    <td class="num" class:bad={totals.erroredTests}>{totals.erroredTests ?? 0}</td>
+                  {/if}
                   <td>
                     <a href="#{dialect.routePath}">
                       <img class="badge" alt="{dialect.prettyName} compliance" src={impl.complianceBadgeFor(dialect).href()} />
@@ -238,6 +243,14 @@
   table.compliance .num.bad {
     color: var(--text);
     font-weight: 600;
+  }
+  table.compliance .pass-cell {
+    color: var(--pass);
+    font-size: var(--fs-sm);
+  }
+  table.compliance .ok-check {
+    font-weight: 700;
+    margin-right: 3px;
   }
   .badge {
     max-width: 100%;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -43,7 +43,7 @@ button { font-family: inherit; color: inherit; }
 .topbar .ghost:hover { background: var(--surface-2); color: var(--text); text-decoration: none; }
 .ver { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--text-faint); }
 
-.shell { flex: 1; min-height: 0; display: grid; grid-template-columns: 248px minmax(0, 1fr) 392px; }
+.shell { flex: 1; min-height: 0; display: grid; grid-template-columns: 280px minmax(0, 1fr) 392px; }
 .shell > * { min-height: 0; overflow-y: auto; }
 
 /* ---------- left rail ---------- */
@@ -159,6 +159,7 @@ pre.code .j-key { color: var(--j-key); } pre.code .j-str { color: var(--j-str); 
 .master-head .row1 { display: flex; align-items: center; justify-content: space-between; }
 .master-head h2 { font-size: var(--fs-base); margin: 0; letter-spacing: -0.01em; }
 .master-head .n { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--text-muted); background: var(--surface-2); padding: 2px 8px; border-radius: 20px; }
+.master-filters { display: flex; flex-direction: column; gap: 10px; margin-top: 12px; }
 .section-label { padding: 14px 16px 6px; }
 .case-row { display: block; width: 100%; text-align: left; border: 0; background: transparent; cursor: pointer; padding: 11px 16px; border-bottom: 1px solid var(--border); border-left: 2px solid transparent; }
 .case-row:hover { background: var(--surface-2); }


### PR DESCRIPTION
Two frontend follow-ups (both build on the type scale from #3004).

## Left rail → right pane
**Search** and **Status** only filter the right-pane test-case list, yet lived in the left rail — action-at-a-distance. Verified in the store: neither touches the center matrix (which keys off language only). Moved both into the case list's sticky header, next to what they filter. The left rail now holds only what scopes the whole report (dialect, language, in-scope list) and is widened **248→280px** so the implementation list is less cramped.

## Celebrate fully-compliant implementations
The *good* case was presented as an afterthought:
- a muted "passes every test" note inside a **"Failures"** card → now a green **"Fully compliant"** card (replacing the Failures card entirely) when an implementation passes every test;
- a compliance table of all-zeros that read as *empty* → fully-passing rows now render green **"✓ passes every test"** instead of `0 0 0`.

On "the compliance box seems empty on all implementation pages": I probed the rendered pages — it's actually populated (python-jsonschema shows 6 rows with real numbers, corvus shows 5). The "empty" look was specifically the all-zeros compliant case, which the green treatment above fixes. If you ever see a genuinely empty table for an implementation that *has* failures, that's a stale cached build (hard-refresh) or an implementation currently missing from the live reports.

## Verification
svelte-check 0/0 · eslint clean · vite build clean · Playwright **15/15** (a11y both schemes). Pass card, green compliance rows, and filter placement all confirmed via DOM probe (`.pass-card`, 5 `.pass-cell`, Search/Status in `.master-filters`, 0 in `.rail`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)