### PR TITLE
Stop making a GitHub API call per repository when building

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -106,9 +106,12 @@ class BowtieDataIncluder(BuildHookInterface):
     def _collect_harnesses(gh_token) -> list[str]:
         gh = login(token=gh_token) if gh_token else GitHub()
         org = gh.organization("bowtie-json-schema")
-        repositories = org.repositories()
 
+        # Topics already come back with the organization's repository listing,
+        # so read them from there rather than a separate `.topics()` call per
+        # repository -- the org has dozens of repositories, and one API call
+        # each rapidly exhausts the GitHub rate limit during builds.
         def is_harness(repo) -> bool:
-            return "bowtie-harness" in repo.topics().names
+            return "bowtie-harness" in (repo.as_dict().get("topics") or [])
 
-        return [repo.name for repo in repositories if is_harness(repo)]
+        return [repo.name for repo in org.repositories() if is_harness(repo)]


### PR DESCRIPTION
### Problem

CI keeps hitting `GITHUB_TOKEN` rate-limit errors. The cause is `hatch_build.py`, which runs every time Bowtie is built from source (i.e. once per nox session, and `ci.yml` fans out a matrix job per session):

```python
repositories = org.repositories()
def is_harness(repo):
    return "bowtie-harness" in repo.topics().names   # <-- one API call PER repository
return [repo.name for repo in repositories if is_harness(repo)]
```

`repo.topics()` is a separate REST call for **each** repository. The org has 55 repositories, so that's ~56 calls **per build** × ~20 nox sessions ≈ well over the 1000-requests/hour `GITHUB_TOKEN` limit for a single CI run.

### Fix

A repository's `topics` are already included in the organization's repository listing response, so read them from there and filter locally. Harness discovery drops from ~56 requests to **one** listing request per build.

Verified against the live API and with a real `uv build`: same result — **51 implementations bundled** (48 topic-tagged harness repos ∪ the 3 still-local implementations), including `rust-jsonschema` (from GitHub) and `python-jsonschema` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)