### PR TITLE
Parenthesize an implicit string concatenation (ruff 0.16.0 ISC004)

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -2809,8 +2809,10 @@ async def _collect(
             code="no-reports",
             message="No reports were produced.",
             causes=[
-                "None of the implementation's supported dialects were "
-                "found in the test suite.",
+                (
+                    "None of the implementation's supported dialects were "
+                    "found in the test suite."
+                ),
             ],
             hint_stmt="Check `bowtie smoke -i <implementation>`.",
         )


### PR DESCRIPTION
`ci.yml`'s `style` session installs ruff **unpinned**, and ruff 0.16.0 (released after #3005 merged) reports `ISC004` for the implicitly concatenated strings in the `no-reports` error's `causes` list:

```
ISC004 Unparenthesized implicit string concatenation in collection
    --> bowtie/_cli.py:2812:17
```

This fails style on `main` itself, and therefore on every open PR (e.g. #3008). Wrapping the two string literals in parentheses resolves it. Verified with `ruff 0.16.0` (CI's version) — `All checks passed!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)