### PR TITLE
Distributed harness reporting: per-hour suite pin + `harness-report.yml`

### DIFF
--- a/.github/workflows/harness-report.yml
+++ b/.github/workflows/harness-report.yml
@@ -1,0 +1,54 @@
+# Reusable workflow: a harness runs the official JSON Schema Test Suite against
+# its own published image and publishes the per-dialect reports as assets on a
+# rolling `report` release in its own repository.
+#
+# Bowtie's central report workflow then just collects each harness's latest
+# report and combines them -- it no longer runs every implementation's suite
+# itself.
+#
+# `bowtie site collect` pins the suite to a deterministic per-hour commit (the
+# newest commit at or before the start of the current hour), so every harness
+# independently runs the very same suite and the reports can be combined --
+# with no test-suite URLs, dialect lists or commit wrangling in the workflow.
+name: Harness Report
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+jobs:
+  report:
+    name: Run the suite and publish the report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to publish the report release
+      packages: read # to pull the harness's own image
+
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          python-version: "3.14"
+          enable-cache: false
+
+      - name: Install Bowtie
+        run: uv tool install bowtie-json-schema
+
+      - name: Run the suite against the published image
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_REPOSITORY: ${{ github.repository }}
+        run: bowtie site collect -i "${GH_REPOSITORY##*/}" --output reports
+
+      - name: Publish the report release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes="Latest Bowtie compliance report for this harness."
+          if gh release view report >/dev/null 2>&1; then
+            gh release edit report --notes "$notes"
+          else
+            gh release create report --title "Latest report" --notes "$notes"
+          fi
+          gh release upload report reports/*.json --clobber

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -2723,9 +2723,7 @@ def collect(
         run_metadata: dict[str, Any] = {}
     else:
         try:
-            root, run_metadata = _suite.download(
-                ref=suite_source or _suite.DEFAULT_REF,
-            )
+            root, run_metadata = _suite.download(ref=suite_source)
         except _suite.SuiteNotAvailable as error:
             STDERR.print(error.diagnostic())
             context.exit(EX.CONFIG)

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -5,6 +5,7 @@ Peculiarities related to how the official JSON Schema Test Suite is structured.
 from __future__ import annotations
 
 from contextlib import suppress
+from datetime import UTC, datetime
 from fnmatch import fnmatch
 from functools import cache
 from io import BytesIO
@@ -266,17 +267,53 @@ def _commit_metadata(repo: Any, ref: str) -> dict[str, Any]:
     return {"Commit": commit_info}
 
 
-def download(ref: str = DEFAULT_REF) -> tuple[_P, dict[str, Any]]:
+def hour_start() -> datetime:
     """
-    Download the whole official test suite once, at the given ref.
+    The start of the current hour, in UTC.
 
-    Returns its root directory (which contains ``tests/`` and ``remotes/``)
-    alongside run metadata recording the exact commit retrieved.
+    Pinning the suite to this makes the choice deterministic within any
+    given hour, so independent runs in the same hour collect against -- and
+    can therefore be combined at -- the same commit, with no coordination
+    needed between them.
+    """
+    return datetime.now(tz=UTC).replace(
+        minute=0,
+        second=0,
+        microsecond=0,
+    )
+
+
+def _commit_at_hour_start(repo: Any) -> str:
+    """
+    The newest commit on the suite's main branch at or before this hour.
+    """
+    commits = repo.commits(sha=DEFAULT_REF, until=hour_start(), number=1)
+    commit = next(iter(commits), None)
+    if commit is None:
+        return DEFAULT_REF
+    return commit.sha
+
+
+def download(ref: str | None = None) -> tuple[_P, dict[str, Any]]:
+    """
+    Download the whole official test suite once.
+
+    With no ``ref``, the suite is pinned to the newest commit on its main
+    branch at or before the start of the current hour -- a deterministic
+    choice, so that independent runs within the same hour all collect
+    against (and can therefore be combined at) the same commit. Pass an
+    explicit ref (a branch, tag or commit) to override.
+
+    Returns the suite's root directory (which contains ``tests/`` and
+    ``remotes/``) alongside run metadata recording the exact commit.
     Every dialect collected from this one root is therefore guaranteed to
     share a single consistent commit, even if the suite moves meanwhile.
     """
     segments = cast("list[str]", TEST_SUITE_URL.path_segments)
     repo = github().repository(segments[0], segments[1])  # type: ignore[reportUnknownMemberType]
+
+    if ref is None:
+        ref = _commit_at_hour_start(repo)
 
     data = BytesIO()
     data.name = ""

--- a/bowtie/tests/test_github.py
+++ b/bowtie/tests/test_github.py
@@ -2,9 +2,11 @@
 Tests for extracting information out of GitHub URLs.
 """
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
-from bowtie._suite import path_and_ref_from_gh_path
+from bowtie._suite import hour_start, path_and_ref_from_gh_path
 
 
 @pytest.mark.parametrize(
@@ -41,3 +43,14 @@ from bowtie._suite import path_and_ref_from_gh_path
 )
 def test_path_and_ref(path, expected):
     assert path_and_ref_from_gh_path(path.split("/")) == expected
+
+
+def test_hour_start():
+    now = datetime.now(tz=UTC)
+    start = hour_start()
+
+    assert (start.minute, start.second, start.microsecond) == (0, 0, 0)
+    assert start.tzinfo == UTC
+    # The most recent hour boundary: at or before now, less than an hour ago.
+    assert start <= now
+    assert now - start < timedelta(hours=1)


### PR DESCRIPTION
The first half of distributing report generation: each harness runs the suite against its own image and publishes the result, instead of Bowtie running every implementation centrally. Two pieces here — the reusable producer, and the one bowtie change that lets independent runs be combinable.

### Per-hour suite pin

`bowtie site collect` with no `--suite` now pins the suite to **the newest commit on its main branch at or before the start of the current hour**, instead of "latest main". It's a pure function of the hour, so harnesses running independently within the same hour all collect against — and can therefore be combined at — the same commit, with no coordination and no central pin to maintain. An explicit `--suite <ref>` still overrides it (for local checkouts or pinning).

This is what keeps the workflow leak-free: the harness never has to resolve a suite commit, list dialects, or build suite URLs — bowtie owns all of it. (It also makes the central `report.yml` run deterministic.)

The only genuinely testable part — computing the hour boundary — is a pure `hour_start()` function with a real test (no mocks); the thin `repo.commits(until=…)` glue stays untested like the rest of `download`.

### `harness-report.yml`

The reusable workflow a harness runs on a (staggered) schedule:

```yaml
- run: uv tool install bowtie-json-schema
- run: bowtie site collect -i "${GH_REPOSITORY##*/}" --output reports   # the whole suite step
- run: gh release upload report reports/*.json --clobber                # publish
```

It publishes the per-dialect reports as assets on a rolling `report` release in the harness's own repo. zizmor (pedantic) is clean.

### Status / next

This adds the **producer** and the bowtie capability it needs. It doesn't activate until (a) a Bowtie release ships `site collect` + this pin to PyPI, then (b) a thin caller is rolled out to each harness + the template, and finally (c) `report.yml` is switched to *collect* each harness's `report` release instead of running the suite itself. Those are the follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)