### PR TITLE
Give harness-report.yml's gh commands a repo to act on

### DIFF
--- a/.github/workflows/harness-report.yml
+++ b/.github/workflows/harness-report.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Publish the report release
         env:
           GH_TOKEN: ${{ github.token }}
+          # The repo isn't checked out, so tell gh which repository to act on.
+          GH_REPO: ${{ github.repository }}
         run: |
           notes="Latest Bowtie compliance report for this harness."
           if gh release view report >/dev/null 2>&1; then


### PR DESCRIPTION
The report job doesn't check out the repository, so `gh release …` had no git context and failed with `fatal: not a git repository` (caught on a pilot run — `bowtie site collect` itself worked and produced reports; only publishing failed). Setting `GH_REPO: ${{ github.repository }}` tells gh which repository to publish the rolling `report` release to. zizmor (pedantic) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)