### PR TITLE
Collect each implementation's published report instead of running it

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -14,8 +14,10 @@ on:
         type: boolean
   workflow_dispatch:
   schedule:
-    # Every 6 hours, at 15 past the hour
-    - cron: "15 */6 * * *"
+    # Every 6 hours, at 50 past the hour -- after the harnesses publish their
+    # own reports near the start of the same hour, so we collect fresh reports
+    # pinned to the same per-hour suite commit.
+    - cron: "50 */6 * * *"
 
 permissions:
   contents: read
@@ -70,14 +72,26 @@ jobs:
         with:
           version: ${{ inputs.bowtie-version }}
 
-      - name: Collect Reports
-        # Bowtie runs the whole suite for every dialect the implementation
-        # supports in a single command, so the workflow needs no per-dialect
-        # loop and no test-suite URLs.
+      - name: Collect this implementation's report
+        # Prefer the harness's own published report (produced by its
+        # harness-report.yml against the same per-hour suite commit).
+        # Fall back to running the suite centrally for implementations that
+        # don't publish one -- the in-repo direct connectables, and any
+        # harness that hasn't reported yet.
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           MATRIX_IMPLEMENTATION: ${{ matrix.implementation }}
-        run: bowtie site collect -i "${MATRIX_IMPLEMENTATION}" --output reports
+        run: |
+          if gh release download report \
+               --repo "bowtie-json-schema/${MATRIX_IMPLEMENTATION}" \
+               --dir reports --clobber 2>/dev/null; then
+            echo "Using ${MATRIX_IMPLEMENTATION}'s published report."
+          else
+            echo "No published report for ${MATRIX_IMPLEMENTATION}; running the suite."
+            rm -rf reports
+            bowtie site collect -i "${MATRIX_IMPLEMENTATION}" --output reports
+          fi
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
       # number of container images.


### PR DESCRIPTION
The consumption half of distributed reporting: `report.yml`'s `collect` job now **prefers each harness's own published `report` release** and only runs `bowtie site collect` centrally as a fallback.

```sh
if gh release download report --repo "bowtie-json-schema/$IMPL" --dir reports; then
  : # use the harness's own report (pinned to the same per-hour suite commit)
else
  bowtie site collect -i "$IMPL" --output reports   # fall back to running it
fi
```

The fallback keeps it correct **before and during** rollout: implementations that don't publish a report yet — the in-repo direct connectables (python-jsonschema, …), and any harness whose report workflow isn't live — are still collected centrally, exactly as today. As each harness's `harness-report.yml` goes live, the central pipeline silently stops re-running that suite. No further change here is needed.

The per-hour suite pin is what makes this combinable: every harness and the central fallback resolve the same commit within an hour, so the downloaded and centrally-run reports share test cases and `site combine` merges them. The schedule moves to `:50` so the central run happens after harnesses publish near the start of the hour.

**Coordination caveat** (worth hardening later): if a harness's report is stale (its run lagged past `:50`, or failed this cycle), its commit won't match and `site combine` will reject that dialect (`InconsistentCases`). The generous 30-minute gap covers normal runs; a follow-up could have `site combine` tolerate/skip commit outliers.

zizmor (pedantic) clean. Prep PR — safe to merge now (pure fallback until harnesses publish), but most useful once the caller rollout lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)