### PR TITLE
Move versioned report generation into `bowtie site collect --versioned`

### DIFF
--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -102,48 +102,31 @@ jobs:
           path: json-schema-test-suite
           persist-credentials: false
 
-      - name: Make a ${{ matrix.implementation }} directory to keep all its version reports
-        run: mkdir ${MATRIX_IMPLEMENTATION}
+      - name: Generate versioned reports for ${{ matrix.implementation }}
         env:
-          MATRIX_IMPLEMENTATION: ${{ matrix.implementation }}
-
-      - name: Generate New Versioned Reports for all Supported Dialects of ${{ matrix.implementation }}
-        id: generate-new-versioned-report
-        env:
-          GH_TOKEN: ${{ github.token }} # because we use gh CLI in the script (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows)
+          GH_TOKEN: ${{ github.token }} # for the gh CLI used to list version tags
           MATRIX_IMPLEMENTATION: ${{ matrix.implementation }}
         run: |
           impl=${MATRIX_IMPLEMENTATION}
-          MATRIX_VERSIONS_FILE="implementations/$impl/matrix-versions.json"
-          if [ ! -f $MATRIX_VERSIONS_FILE ]; then
-            echo "Dump versions for remote test harness $impl"
-            mkdir -p $(dirname "$MATRIX_VERSIONS_FILE")
-            tagged_versions=$(gh api \
+          # Historical versions come from a committed matrix-versions.json (the few
+          # in-repo harnesses) or from the extracted harness repo's `harness-release-*` tags.
+          if [ -f "implementations/$impl/matrix-versions.json" ]; then
+            versions=$(jq -r '.[]' "implementations/$impl/matrix-versions.json")
+          else
+            versions=$(gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/$GH_ORGANIZATION/$impl/git/matching-refs/tags/harness-release- | jq -c '[ .[].ref | ltrimstr("refs/tags/harness-release-") ]')
-            latest_version=$(bowtie info \
-                --implementation image:$impl \
-                --format json 2>/dev/null | jq -r '.version // empty' || true)
-            echo $tagged_versions | jq -c --arg latest "$latest_version" '. + [$latest]' > $MATRIX_VERSIONS_FILE
+              "/repos/$GH_ORGANIZATION/$impl/git/matching-refs/tags/harness-release-" \
+              | jq -r '.[].ref | ltrimstr("refs/tags/harness-release-")')
           fi
-          cp $MATRIX_VERSIONS_FILE $impl
-          for version in $(jq -r '.[]' $MATRIX_VERSIONS_FILE); do
-            # A version whose image is unavailable (a historical version that never built,
-            # or a `harness-release-*` tag with no matching image) is skipped rather than
-            # failing the whole implementation and dropping its entire trend.
-            if [ -z "$version" ] || ! bowtie info -i image:$impl:$version --format json > /dev/null 2>&1; then
-              echo "::warning::Skipping $impl:$version -- image unavailable"
-              continue
-            fi
-            SUPPORTED_DIALECTS=$(bowtie filter-dialects -i image:$impl:$version | xargs -I {} jq -r '.[] | select(.uri == "{}") | .shortName' data/dialects.json)
-            if [ -n "$SUPPORTED_DIALECTS" ]; then
-              mkdir "$impl/v$version"
-              for dialect in $SUPPORTED_DIALECTS; do
-                bowtie suite -i image:$impl:$version ./json-schema-test-suite/tests/$dialect > "$impl/v$version/$dialect.json"
-              done
-            fi
-          done
+          # The current published image plus each historical version. `bowtie` keys each
+          # report tree off the version the image reports, skips unavailable images, and
+          # writes the matrix-versions.json index, so one missing image never drops the trend.
+          images="-i image:$impl"
+          for version in $versions; do images="$images -i image:$impl:$version"; done
+          bowtie site collect --versioned $images \
+            --suite ./json-schema-test-suite \
+            --output "$impl"
 
       # This is useful to debug whether Bowtie accidentally fetched some huge
       # number of container images.

--- a/.github/workflows/versioned-report.yml
+++ b/.github/workflows/versioned-report.yml
@@ -104,26 +104,22 @@ jobs:
 
       - name: Generate versioned reports for ${{ matrix.implementation }}
         env:
-          GH_TOKEN: ${{ github.token }} # for the gh CLI used to list version tags
+          # Lets bowtie list an extracted harness's version tags un-throttled.
+          GITHUB_TOKEN: ${{ github.token }}
           MATRIX_IMPLEMENTATION: ${{ matrix.implementation }}
         run: |
           impl=${MATRIX_IMPLEMENTATION}
-          # Historical versions come from a committed matrix-versions.json (the few
-          # in-repo harnesses) or from the extracted harness repo's `harness-release-*` tags.
-          if [ -f "implementations/$impl/matrix-versions.json" ]; then
-            versions=$(jq -r '.[]' "implementations/$impl/matrix-versions.json")
-          else
-            versions=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/repos/$GH_ORGANIZATION/$impl/git/matching-refs/tags/harness-release-" \
-              | jq -r '.[].ref | ltrimstr("refs/tags/harness-release-")')
-          fi
-          # The current published image plus each historical version. `bowtie` keys each
-          # report tree off the version the image reports, skips unavailable images, and
-          # writes the matrix-versions.json index, so one missing image never drops the trend.
+          # bowtie discovers an extracted harness's versions from its
+          # harness-release-* tags on its own; the current image plus every
+          # discovered version is collected, each keyed by the version the image
+          # reports, unavailable ones skipped. The few in-repo harnesses instead
+          # pin their versions in a committed matrix-versions.json we pass through.
           images="-i image:$impl"
-          for version in $versions; do images="$images -i image:$impl:$version"; done
+          if [ -f "implementations/$impl/matrix-versions.json" ]; then
+            for version in $(jq -r '.[]' "implementations/$impl/matrix-versions.json"); do
+              images="$images -i image:$impl:$version"
+            done
+          fi
           bowtie site collect --versioned $images \
             --suite ./json-schema-test-suite \
             --output "$impl"
@@ -160,32 +156,40 @@ jobs:
 
   combine-all-versioned-reports:
     name: Combine Versioned Reports
+    # Publish whatever succeeded even if some implementations failed, rather than
+    # letting a single failure gate (and drop) every implementation's trend.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     needs: regenerate-versioned-reports
     steps:
-      - name: Download all uploaded artifacts
+      - name: Download this run's freshly generated reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          path: implementations
+          path: fresh
 
-      - name: Download latest versioned test reports
+      - name: Download the last published versioned reports
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           workflow: versioned-report.yml
           branch: main
           name: implementations
-          path: latest-implementations
-        if: ${{ inputs.implementation != null }}
+          path: implementations
+        continue-on-error: true # nothing is published yet on the very first run
 
-      - name: Prepare artifact for upload
+      - name: Overlay this run's reports onto the last published set
         run: |
-          rm -rf "latest-implementations/${INPUTS_IMPLEMENTATION}"
-          cp -r "implementations/${INPUTS_IMPLEMENTATION}" "latest-implementations/"
-        if: ${{ inputs.implementation != null }}
-        env:
-          INPUTS_IMPLEMENTATION: ${{ inputs.implementation }}
+          # Replace each implementation that was (re)generated this run, and keep
+          # the previously published trend for any that failed and produced no
+          # fresh reports -- so a transient failure never wipes an implementation.
+          shopt -s nullglob
+          mkdir -p implementations
+          for dir in fresh/*/; do
+            impl=$(basename "$dir")
+            rm -rf "implementations/$impl"
+            cp -r "$dir" "implementations/$impl"
+          done
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: implementations
-          path: ${{ inputs.implementation != null && 'latest-implementations' || 'implementations' }}
+          path: implementations

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -41,7 +41,15 @@ import rich_click as click
 import structlog
 import structlog.typing
 
-from bowtie import DOCS, HOMEPAGE, _benchmarks, _connectables, _report, _suite
+from bowtie import (
+    DOCS,
+    HOMEPAGE,
+    _benchmarks,
+    _connectables,
+    _containers,
+    _report,
+    _suite,
+)
 from bowtie._commands import SeqCase, TestResult, Unsuccessful
 from bowtie._core import (
     Dialect,
@@ -2688,10 +2696,23 @@ def collect(
             context.exit(EX.CONFIG)
 
     if versioned:
+        expanded: list[Connectable] = []
+        for connectable in connectables:
+            expanded.append(connectable)
+            terse = connectable.to_terse()
+            # A bare image (no `:version`) also contributes every version
+            # published for it, discovered from its harness-release-* tags.
+            if ":" not in terse:
+                expanded.extend(
+                    _connectables.Connectable.from_str(
+                        f"image:{terse}:{version}",
+                    )
+                    for version in _containers.versions_of(terse)
+                )
         context.exit(
             asyncio.run(
                 _collect_versions(
-                    connectables=connectables,
+                    connectables=expanded,
                     root=root,
                     run_metadata=run_metadata,
                     maybe_set_schema=maybe_set_schema,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -2617,6 +2617,19 @@ def site() -> None:
         "Defaults to the latest commit on the suite's default branch."
     ),
 )
+@click.option(
+    "--versioned",
+    "versioned",
+    is_flag=True,
+    help=(
+        "Collect a per-version trend rather than a single current report. "
+        "Each implementation passed with -i (typically several versions of "
+        "one, as image:<implementation>:<version>) is collected into a "
+        "v<version>/ subdirectory keyed by the version it reports, alongside "
+        "a matrix-versions.json index. Implementations whose image is "
+        "unavailable are skipped."
+    ),
+)
 @click.pass_context
 def collect(
     context: click.Context,
@@ -2625,23 +2638,29 @@ def collect(
     registry: ValidatorRegistry[Any],
     output: Path,
     suite_source: str | None,
+    versioned: bool,
 ) -> None:
     """
     Run the official test suite against a single implementation.
 
     Writes one Bowtie report per supported dialect into the output
     directory, ready to be combined into the data for Bowtie's website.
+
+    With --versioned, instead writes one such report tree per version under
+    v<version>/, for the implementation's compliance-over-time trend.
     """
-    if len(connectables) != 1:
+    if not versioned and len(connectables) != 1:
         error = DiagnosticError(
             code="one-implementation",
             message="`bowtie site collect` collects a single implementation.",
             causes=[f"{len(connectables)} implementations were provided."],
-            hint_stmt="Pass exactly one implementation with -i.",
+            hint_stmt=(
+                "Pass exactly one implementation with -i, "
+                "or --versioned to collect several versions of one."
+            ),
         )
         STDERR.print(error)
         context.exit(EX.USAGE)
-    (connectable,) = connectables
 
     try:
         output.mkdir(parents=True)
@@ -2668,6 +2687,21 @@ def collect(
             STDERR.print(error.diagnostic())
             context.exit(EX.CONFIG)
 
+    if versioned:
+        context.exit(
+            asyncio.run(
+                _collect_versions(
+                    connectables=connectables,
+                    root=root,
+                    run_metadata=run_metadata,
+                    maybe_set_schema=maybe_set_schema,
+                    registry=registry,
+                    output=output,
+                ),
+            ),
+        )
+
+    (connectable,) = connectables
     context.exit(
         asyncio.run(
             _collect(
@@ -2680,6 +2714,53 @@ def collect(
             ),
         ),
     )
+
+
+async def _collect_dialects(
+    implementation: Implementation,
+    connectable_id: ConnectableId,
+    available: frozenset[Dialect],
+    root: _suite._P,  # type: ignore[reportPrivateUsage]
+    maybe_set_schema: Callable[[Dialect], CaseTransform],
+    run_metadata: dict[str, Any],
+    output: Path,
+) -> int:
+    """
+    Write one report per supported dialect for a started implementation.
+
+    Returns the number of dialect reports written into `output` (whose parent
+    directory is created lazily, only once there is something to write).
+    """
+    wrote = 0
+    supported = sorted(implementation.info.dialects & available, reverse=True)
+    for dialect in supported:
+        cases = list(_suite.cases_for(root, dialect))
+        if not cases:
+            continue
+
+        try:
+            runner = await implementation.start_speaking(dialect)
+        except (DialectError, UnsupportedDialect) as error:
+            STDERR.print(error)
+            continue
+
+        report = await _run_cases(
+            runner=runner,
+            dialect=dialect,
+            cases=cases,
+            implementations={connectable_id: implementation.info},
+            maybe_set_schema=maybe_set_schema,
+            run_metadata=run_metadata,
+        )
+        if report is None:
+            continue
+
+        output.mkdir(parents=True, exist_ok=True)  # noqa: ASYNC240
+        output.joinpath(f"{dialect.short_name}.json").write_text(
+            "\n".join(report.serialized()),
+        )
+        wrote += 1
+    return wrote
 
 
 async def _collect(
@@ -2710,37 +2791,15 @@ async def _collect(
             STDERR.print(error)
             return EX.CONFIG
 
-        wrote = 0
-        supported = sorted(
-            implementation.info.dialects & available,
-            reverse=True,
+        wrote = await _collect_dialects(
+            implementation=implementation,
+            connectable_id=connectable_id,
+            available=available,
+            root=root,
+            maybe_set_schema=maybe_set_schema,
+            run_metadata=run_metadata,
+            output=output,
         )
-        for dialect in supported:
-            cases = list(_suite.cases_for(root, dialect))
-            if not cases:
-                continue
-
-            try:
-                runner = await implementation.start_speaking(dialect)
-            except (DialectError, UnsupportedDialect) as error:
-                STDERR.print(error)
-                continue
-
-            report = await _run_cases(
-                runner=runner,
-                dialect=dialect,
-                cases=cases,
-                implementations={connectable_id: implementation.info},
-                maybe_set_schema=maybe_set_schema,
-                run_metadata=run_metadata,
-            )
-            if report is None:
-                continue
-
-            output.joinpath(f"{dialect.short_name}.json").write_text(
-                "\n".join(report.serialized()),
-            )
-            wrote += 1
 
     if not wrote:
         error = DiagnosticError(
@@ -2759,6 +2818,81 @@ async def _collect(
 
     reports = _inflect_engine.plural("report", wrote)  # type: ignore[reportArgumentType]
     STDERR.print(f"Collected [green]{wrote}[/] {reports} into {output}.")
+    return 0
+
+
+async def _collect_versions(
+    connectables: Iterable[Connectable],
+    root: _suite._P,  # type: ignore[reportPrivateUsage]
+    run_metadata: dict[str, Any],
+    maybe_set_schema: Callable[[Dialect], CaseTransform],
+    registry: ValidatorRegistry[Any],
+    output: Path,
+) -> int:
+    """
+    Collect a per-version compliance trend for a single implementation.
+
+    Each connectable (typically ``image:<implementation>:<version>``) is
+    collected into ``output/v<version>/``, keyed by the version the image
+    itself reports. One whose image is unavailable (e.g. a historical version
+    that never built, or a tag with no published image) is skipped rather than
+    aborting the rest, so a single missing image never drops an
+    implementation's whole trend. Writes ``output/matrix-versions.json``
+    listing the versions that actually produced reports.
+    """
+    available = _suite.dialects_in(root)
+
+    collected: list[str] = []
+    seen: set[str] = set()
+    for connectable in connectables:
+        async with _start(
+            connectables=[connectable],
+            reporter=SILENT,
+            registry=registry,
+        ) as starting:
+            (started,) = starting
+            try:
+                connectable_id, implementation = await started
+            except STARTUP_ERRORS:
+                STDERR.print(
+                    f"[yellow]Skipping[/] {connectable.to_terse()} "
+                    "(image unavailable).",
+                )
+                continue
+
+            version = implementation.info.version
+            if not version:
+                STDERR.print(
+                    f"[yellow]Skipping[/] {connectable.to_terse()} "
+                    "(no reported version).",
+                )
+                continue
+
+            # The current image and a historical tag can report the same
+            # version; collect each distinct version only once.
+            if version in seen:
+                continue
+            seen.add(version)
+
+            wrote = await _collect_dialects(
+                implementation=implementation,
+                connectable_id=connectable_id,
+                available=available,
+                root=root,
+                maybe_set_schema=maybe_set_schema,
+                run_metadata=run_metadata,
+                output=output.joinpath(f"v{version}"),
+            )
+        if wrote:
+            collected.append(version)
+
+    output.mkdir(parents=True, exist_ok=True)  # noqa: ASYNC240
+    output.joinpath("matrix-versions.json").write_text(json.dumps(collected))
+
+    versions = _inflect_engine.plural("version", len(collected))  # type: ignore[reportArgumentType]
+    STDERR.print(
+        f"Collected [green]{len(collected)}[/] {versions} into {output}.",
+    )
     return 0
 
 

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -2633,9 +2633,9 @@ def site() -> None:
         "Collect a per-version trend rather than a single current report. "
         "Each implementation passed with -i (typically several versions of "
         "one, as ``image:<implementation>:<version>``) is collected into a "
-        "``v<version>/`` subdirectory keyed by the version it reports, "
-        "alongside a ``matrix-versions.json`` index. Implementations whose "
-        "image is unavailable are skipped."
+        "``v<version>/`` directory keyed by the version it reports, alongside "
+        "a ``matrix-versions.json`` index. Implementations whose image is "
+        "unavailable are skipped."
     ),
 )
 @click.pass_context

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -2632,10 +2632,10 @@ def site() -> None:
     help=(
         "Collect a per-version trend rather than a single current report. "
         "Each implementation passed with -i (typically several versions of "
-        "one, as image:<implementation>:<version>) is collected into a "
-        "v<version>/ subdirectory keyed by the version it reports, alongside "
-        "a matrix-versions.json index. Implementations whose image is "
-        "unavailable are skipped."
+        "one, as ``image:<implementation>:<version>``) is collected into a "
+        "``v<version>/`` subdirectory keyed by the version it reports, "
+        "alongside a ``matrix-versions.json`` index. Implementations whose "
+        "image is unavailable are skipped."
     ),
 )
 @click.pass_context
@@ -2740,7 +2740,7 @@ def collect(
 async def _collect_dialects(
     implementation: Implementation,
     connectable_id: ConnectableId,
-    available: frozenset[Dialect],
+    available: set[Dialect],
     root: _suite._P,  # type: ignore[reportPrivateUsage]
     maybe_set_schema: Callable[[Dialect], CaseTransform],
     run_metadata: dict[str, Any],

--- a/bowtie/_containers.py
+++ b/bowtie/_containers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from contextlib import AsyncExitStack, asynccontextmanager
 from os import environ
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 import json
 
 from attrs import field, frozen, mutable
@@ -60,14 +60,12 @@ def versions_of(name: str) -> list[str]:
     image, so version discovery is always best-effort and never fatal.
     """
     organization = IMAGE_REPOSITORY.rsplit("/", 1)[-1]
+    client: Any = github()
     try:
-        repo: Any = github().repository(  # type: ignore[reportUnknownMemberType]
-            organization,
-            name,
-        )
+        repo = client.repository(organization, name)
         if repo is None:
             return []
-        tags = cast("list[Any]", list(repo.tags()))
+        tags = list(repo.tags())
     except Exception:  # noqa: BLE001
         return []
     return [

--- a/bowtie/_containers.py
+++ b/bowtie/_containers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from contextlib import AsyncExitStack, asynccontextmanager
 from os import environ
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 import json
 
 from attrs import field, frozen, mutable
@@ -67,13 +67,14 @@ def versions_of(name: str) -> list[str]:
         )
         if repo is None:
             return []
-        return [
-            tag.name.removeprefix(_VERSION_TAG_PREFIX)
-            for tag in repo.tags()
-            if tag.name.startswith(_VERSION_TAG_PREFIX)
-        ]
+        tags = cast("list[Any]", list(repo.tags()))
     except Exception:  # noqa: BLE001
         return []
+    return [
+        tag.name.removeprefix(_VERSION_TAG_PREFIX)
+        for tag in tags
+        if tag.name.startswith(_VERSION_TAG_PREFIX)
+    ]
 
 
 _NO_ENGINE = (

--- a/bowtie/_containers.py
+++ b/bowtie/_containers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from contextlib import AsyncExitStack, asynccontextmanager
 from os import environ
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 import json
 
 from attrs import field, frozen, mutable
@@ -28,7 +28,7 @@ from imaged import (
 )
 import anyio
 
-from bowtie._core import InvalidResponse, Restarted
+from bowtie._core import InvalidResponse, Restarted, github
 from bowtie.exceptions import (
     CannotConnect,
     GotStderr,
@@ -43,6 +43,38 @@ if TYPE_CHECKING:
 
 
 IMAGE_REPOSITORY = "ghcr.io/bowtie-json-schema"
+
+#: The git tag prefix each harness repository uses to mark a released version.
+_VERSION_TAG_PREFIX = "harness-release-"
+
+
+def versions_of(name: str) -> list[str]:
+    """
+    The published versions of an implementation.
+
+    Read from the ``harness-release-*`` tags of the implementation's harness
+    repository (a sibling, in the Bowtie organization, of its published image).
+
+    Returns an empty list when the harness has no such repository or tags, or
+    when GitHub can't be reached -- callers then fall back to just the current
+    image, so version discovery is always best-effort and never fatal.
+    """
+    organization = IMAGE_REPOSITORY.rsplit("/", 1)[-1]
+    try:
+        repo: Any = github().repository(  # type: ignore[reportUnknownMemberType]
+            organization,
+            name,
+        )
+        if repo is None:
+            return []
+        return [
+            tag.name.removeprefix(_VERSION_TAG_PREFIX)
+            for tag in repo.tags()
+            if tag.name.startswith(_VERSION_TAG_PREFIX)
+        ]
+    except Exception:  # noqa: BLE001
+        return []
+
 
 _NO_ENGINE = (
     "Bowtie couldn't find a container engine. "

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -761,6 +761,111 @@ async def test_site_combine(tmp_path):
     )
 
 
+def _has_bugs_connectable(version):
+    return (
+        f"direct:{_miniatures.__name__}:has_bugs_by_versions,version={version}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_site_collect_versioned(tmp_path):
+    """
+    `site collect --versioned` writes one report tree per version, keyed by the
+    version each implementation reports, plus a matrix-versions.json index.
+    """
+    suite = tmp_path / "suite"
+    cases = _json.dumps(
+        [
+            {
+                "description": "integer",
+                "schema": {"type": "integer"},
+                "tests": [
+                    {"description": "an integer", "data": 1, "valid": True},
+                    {"description": "a string", "data": "foo", "valid": False},
+                ],
+            },
+        ],
+    )
+    for each in ("draft7", "draft2020-12"):
+        dialect_dir = suite / "tests" / each
+        dialect_dir.mkdir(parents=True)
+        dialect_dir.joinpath("type.json").write_text(cases)
+
+    out = tmp_path / "buggy"
+    await bowtie(
+        "site",
+        "collect",
+        "--versioned",
+        "-i",
+        _has_bugs_connectable("1.0"),
+        "-i",
+        _has_bugs_connectable("2.0"),
+        # A repeated version (e.g. the current image also matching a tag) is
+        # collected only once.
+        "-i",
+        _has_bugs_connectable("1.0"),
+        "--suite",
+        suite,
+        "--output",
+        out,
+    )
+
+    assert sorted(_json.loads((out / "matrix-versions.json").read_text())) == [
+        "1.0",
+        "2.0",
+    ]
+    for version in ("1.0", "2.0"):
+        report = Report.from_serialized(
+            out.joinpath(f"v{version}", "draft7.json")
+            .read_text()
+            .splitlines(),
+        )
+        assert report.metadata.dialect == Dialect.by_short_name()["draft7"]
+        assert not report.is_empty
+
+
+@pytest.mark.asyncio
+@pytest.mark.containers
+async def test_site_collect_versioned_skips_unavailable(tmp_path):
+    """
+    A version whose image can't start is skipped, leaving the others (and the
+    matrix-versions.json index) intact rather than aborting the whole trend.
+    """
+    suite = tmp_path / "suite"
+    dialect_dir = suite / "tests" / "draft7"
+    dialect_dir.mkdir(parents=True)
+    dialect_dir.joinpath("type.json").write_text(
+        _json.dumps(
+            [
+                {
+                    "description": "integer",
+                    "schema": {"type": "integer"},
+                    "tests": [{"description": "ok", "data": 1, "valid": True}],
+                },
+            ],
+        ),
+    )
+
+    out = tmp_path / "buggy"
+    await bowtie(
+        "site",
+        "collect",
+        "--versioned",
+        "-i",
+        _has_bugs_connectable("1.0"),
+        # No such image exists, so starting it fails and it is skipped.
+        "-i",
+        "image:bowtie-json-schema/does-not-exist:9.9.9",
+        "--suite",
+        suite,
+        "--output",
+        out,
+    )
+
+    assert _json.loads((out / "matrix-versions.json").read_text()) == ["1.0"]
+    assert out.joinpath("v1.0", "draft7.json").exists()
+
+
 @pytest.mark.asyncio
 async def test_set_schema_sets_a_dialect_explicitly():
     async with run("-i", "direct:null", "--set-schema") as send:


### PR DESCRIPTION
Builds on #3017. Moves versioned report generation — including version discovery — out of `versioned-report.yml`'s shell and into Bowtie, and makes the pipeline resilient to partial failure.

## `bowtie site collect --versioned`

Takes implementations with `-i` and collects each into a `v<version>/` subdirectory **keyed by the version the image itself reports**, deduplicating, **skipping any whose image can't start**, and writing the `matrix-versions.json` index of what it produced. It exits successfully even when some versions are unavailable, so one missing historical image no longer fails the whole implementation (which — since `combine` needs every job green — was dropping the entire run's output).

## Version discovery in Bowtie

`_containers.versions_of(name)` lists an implementation's `harness-release-*` tags (Bowtie already knows the org via `IMAGE_REPOSITORY` and has a token-aware client via `github()`), and `--versioned` expands a bare `-i image:<impl>` into the current image plus each published version. Discovery is best-effort — any GitHub error yields no extra versions rather than failing. Verified manually: `versions_of('js-ajv')` → `['8.12.0', '8.17.1']`; an unknown repo → `[]`.

So the workflow's per-implementation step collapses to `bowtie site collect --versioned -i image:$impl` for the ~48 extracted harnesses (the two still-in-repo snowflakes pass their committed `matrix-versions.json` through until they're extracted).

## Combine resilience

`combine-all-versioned-reports` now runs even when some implementations fail (`if: !cancelled()`) and **overlays this run's reports onto the last published set** — so a transient failure publishes the rest instead of gating everything, and never wipes a failed implementation's existing trend.

## Tests

`test_site_collect_versioned` drives the real CLI with the `has_bugs_by_versions` miniature at two versions (plus a duplicate): per-version trees, self-reported keying, dedup, and index. `test_site_collect_versioned_skips_unavailable` (containers) asserts an unstartable image is skipped without losing the rest. `versions_of` has no unit test — faithfully exercising it means real GitHub + remote images (mock is disallowed; the suite's container tests build local images, not remote pulls), so it's covered by manual validation above and the workflow run itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)