### PR TITLE
Confine github3 to a single `_github` module

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -46,7 +46,7 @@ from bowtie import (
     HOMEPAGE,
     _benchmarks,
     _connectables,
-    _containers,
+    _github,
     _report,
     _suite,
 )
@@ -2707,7 +2707,7 @@ def collect(
                     _connectables.Connectable.from_str(
                         f"image:{terse}:{version}",
                     )
-                    for version in _containers.versions_of(terse)
+                    for version in _github.versions_of(terse)
                 )
         context.exit(
             asyncio.run(

--- a/bowtie/_containers.py
+++ b/bowtie/_containers.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from contextlib import AsyncExitStack, asynccontextmanager
 from os import environ
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 import json
 
 from attrs import field, frozen, mutable
@@ -28,7 +28,7 @@ from imaged import (
 )
 import anyio
 
-from bowtie._core import InvalidResponse, Restarted, github
+from bowtie._core import InvalidResponse, Restarted
 from bowtie.exceptions import (
     CannotConnect,
     GotStderr,
@@ -43,37 +43,6 @@ if TYPE_CHECKING:
 
 
 IMAGE_REPOSITORY = "ghcr.io/bowtie-json-schema"
-
-#: The git tag prefix each harness repository uses to mark a released version.
-_VERSION_TAG_PREFIX = "harness-release-"
-
-
-def versions_of(name: str) -> list[str]:
-    """
-    The published versions of an implementation.
-
-    Read from the ``harness-release-*`` tags of the implementation's harness
-    repository (a sibling, in the Bowtie organization, of its published image).
-
-    Returns an empty list when the harness has no such repository or tags, or
-    when GitHub can't be reached -- callers then fall back to just the current
-    image, so version discovery is always best-effort and never fatal.
-    """
-    organization = IMAGE_REPOSITORY.rsplit("/", 1)[-1]
-    client: Any = github()
-    try:
-        repo = client.repository(organization, name)
-        if repo is None:
-            return []
-        tags = list(repo.tags())
-    except Exception:  # noqa: BLE001
-        return []
-    return [
-        tag.name.removeprefix(_VERSION_TAG_PREFIX)
-        for tag in tags
-        if tag.name.startswith(_VERSION_TAG_PREFIX)
-    ]
-
 
 _NO_ENGINE = (
     "Bowtie couldn't find a container engine. "

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from datetime import date
 from functools import cache
 from importlib.resources import files
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 from uuid import uuid4
 import json
-import os
 
 from attrs import Factory, asdict, evolve, field, frozen, mutable
 from referencing.jsonschema import EMPTY_REGISTRY, specification_with
@@ -17,7 +16,7 @@ from url import URL
 import httpx
 import referencing_loaders
 
-from bowtie import HOMEPAGE, ORG_NAME
+from bowtie import HOMEPAGE
 from bowtie._commands import (
     START_V1,
     CaseErrored,
@@ -61,9 +60,6 @@ if TYPE_CHECKING:
     from bowtie._connectables import ConnectableId
     from bowtie._registry import ValidatorRegistry
     from bowtie._report import Reporter
-
-ORG_API = URL.parse("https://api.github.com/orgs/") / ORG_NAME
-CONTAINER_PACKAGES_API = ORG_API / "packages" / "container"
 
 
 @frozen
@@ -540,35 +536,11 @@ class Implementation:
         return self.info.dialects.issuperset(dialects)
 
     async def get_versions(self) -> Iterable[str]:
-        from github3.exceptions import (  # type: ignore[reportMissingTypeStubs]  # noqa: PLC0415
-            GitHubError,
-        )
-        from github3.models import (  # type: ignore[reportMissingTypeStubs]  # noqa: PLC0415
-            GitHubCore,
-        )
+        from bowtie import _github  # noqa: PLC0415
 
-        url = CONTAINER_PACKAGES_API / self.id / "versions"
-
-        gh = github()
-        pages: list[GitHubCore] = []
-        with suppress(GitHubError):
-            pages = gh._iter(count=-1, url=str(url), cls=GitHubCore)  # type: ignore[reportPrivateUsage]
-
-        versions: Set[str] = (
-            {self.info.version} if self.info.version else set()
-        )
-        for page in pages:
-            try:
-                data = cast("Mapping[str, Any]", page.as_dict() or {})
-                tags = cast(
-                    "Iterable[str]",
-                    data["metadata"]["container"]["tags"],
-                )
-            except KeyError:
-                continue
-            else:
-                versions.update([tag for tag in tags if "." in tag])
-
+        versions: Set[str] = set(_github.versions_of(self.id))
+        if self.info.version:
+            versions.add(self.info.version)
         return sorted(versions, key=sortable_version_key, reverse=True)
 
     async def validate(
@@ -845,17 +817,3 @@ def sortable_version_key(version: str):
     """
     parts = version.split(".")
     return [int(part) if part.isdigit() else part for part in parts]
-
-
-def github():
-    """
-    Construct a GitHub client, optionally looking for a token.
-
-    This extra behavior is just useful in GitHub actions workflows, and
-    presumably if ``github3.py`` was more active would be default behavior.
-    """
-    from github3 import (  # type: ignore[reportMissingTypeStubs]  # noqa: PLC0415
-        GitHub,
-    )
-
-    return GitHub(token=os.environ.get("GITHUB_TOKEN", ""))

--- a/bowtie/_github.py
+++ b/bowtie/_github.py
@@ -1,0 +1,129 @@
+"""
+Bowtie's runtime interactions with the GitHub API.
+
+All of Bowtie's runtime GitHub access -- discovering an implementation's
+published versions, fetching the test suite, reading commit metadata -- goes
+through here, so that ``github3.py`` (which ships no type stubs, and whose
+public API didn't cover listing container versions without a private method)
+stays confined to a single module behind a small, typed interface.
+
+The build-time hook (``hatch_build.py``) deliberately talks to GitHub on its
+own: it must not import the package it is building.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import TYPE_CHECKING, Any
+import os
+
+from bowtie import ORG_NAME
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+#: The git tag prefix each harness repository uses to mark a released version.
+HARNESS_RELEASE_TAG = "harness-release-"
+
+
+def _client() -> Any:
+    """
+    A GitHub client, authenticated from ``$GITHUB_TOKEN`` when one is set.
+
+    Authenticating (even with the automatic token in CI) lifts the API rate
+    limit well above the anonymous one, which matters when a single run touches
+    many repositories.
+    """
+    from github3 import (  # type: ignore[reportMissingTypeStubs]  # noqa: PLC0415
+        GitHub,
+    )
+
+    return GitHub(token=os.environ.get("GITHUB_TOKEN", ""))
+
+
+def versions_of(name: str, organization: str = ORG_NAME) -> list[str]:
+    """
+    The published versions of an implementation.
+
+    Read from the ``harness-release-*`` tags of the implementation's harness
+    repository (a sibling, in the Bowtie organization, of its published image).
+
+    Best-effort: an empty list is returned when the harness has no such
+    repository or tags, or when GitHub can't be reached -- callers then fall
+    back to just the current image, so version discovery is never fatal.
+    """
+    try:
+        repository = _client().repository(organization, name)
+        if repository is None:
+            return []
+        tags = list(repository.tags())
+    except Exception:  # noqa: BLE001
+        return []
+    return [
+        tag.name.removeprefix(HARNESS_RELEASE_TAG)
+        for tag in tags
+        if tag.name.startswith(HARNESS_RELEASE_TAG)
+    ]
+
+
+def latest_commit_before(
+    owner: str,
+    name: str,
+    branch: str,
+    when: datetime,
+) -> str | None:
+    """
+    The newest commit on ``branch`` of ``owner/name`` at or before ``when``.
+
+    Returns ``None`` when there is no such commit.
+    """
+    commits = (
+        _client()
+        .repository(owner, name)
+        .commits(
+            sha=branch,
+            until=when,
+            number=1,
+        )
+    )
+    commit = next(iter(commits), None)
+    return None if commit is None else commit.sha
+
+
+def download_tree(
+    owner: str,
+    name: str,
+    ref: str,
+) -> tuple[BytesIO, dict[str, Any]] | None:
+    """
+    Download ``owner/name`` at ``ref`` as a zipball, with run metadata.
+
+    Returns the zipball (seeked to its start) alongside metadata recording the
+    exact commit the ref resolved to, or ``None`` if the archive could not be
+    fetched.
+    """
+    repository = _client().repository(owner, name)
+
+    data = BytesIO()
+    data.name = ""
+    if not repository.archive(format="zipball", path=data, ref=ref):
+        return None
+    data.seek(0)
+    return data, _commit_metadata(repository, ref)
+
+
+def _commit_metadata(repository: Any, ref: str) -> dict[str, Any]:
+    """Run metadata recording the exact commit a suite ``ref`` resolves to."""
+    from github3.exceptions import (  # type: ignore[reportMissingTypeStubs]  # noqa: PLC0415
+        NotFoundError,
+    )
+
+    try:
+        commit = repository.commit(ref)
+    except NotFoundError:
+        info: Any = ref
+    else:
+        # TODO: Make this the tree URL maybe, but tree(...) doesn't come with
+        #       an html_url.
+        info = {"text": commit.sha[:7], "href": commit.html_url}
+    return {"Commit": info}

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -8,7 +8,6 @@ from contextlib import suppress
 from datetime import UTC, datetime
 from fnmatch import fnmatch
 from functools import cache
-from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 import json
@@ -20,8 +19,8 @@ from url import URL, RelativeURLWithoutBase
 import click
 import rich
 
-from bowtie import GITHUB
-from bowtie._core import Dialect, TestCase, github
+from bowtie import GITHUB, _github
+from bowtie._core import Dialect, TestCase
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -77,15 +76,11 @@ class ClickParam(click.ParamType):
             else:
                 value = cast("URL", value)
 
-                gh = github()
                 org, repo_name, *rest = value.path_segments
-                repo = gh.repository(org, repo_name)  # type: ignore[reportUnknownMemberType]
-
                 path, ref = path_and_ref_from_gh_path(rest)
-                data = BytesIO()
-                data.name = ""
-                succeeded = repo.archive(format="zipball", path=data, ref=ref)  # type: ignore[reportUnknownMemberType]
-                if not succeeded:
+
+                downloaded = _github.download_tree(org, repo_name, ref)
+                if downloaded is None:
                     message = "Fetching the test suite from GitHub failed."
                     error = DiagnosticError(
                         code="suite-fetch-failed",
@@ -104,15 +99,13 @@ class ClickParam(click.ParamType):
                     )
                     rich.print(error)
                     return self.fail(message)
-                data.seek(0)
+                data, run_metadata = downloaded
                 with zipfile.ZipFile(data) as zf:
                     (contents,) = zipfile.Path(zf).iterdir()
                     cases, dialect = self._cases_and_dialect(
                         path=contents / path,
                     )
                     cases = list(cases)
-
-                run_metadata: dict[str, Any] = _commit_metadata(repo, ref)
 
         return cases, dialect, run_metadata
 
@@ -248,25 +241,6 @@ class SuiteNotAvailable(Exception):
         )
 
 
-def _commit_metadata(repo: Any, ref: str) -> dict[str, Any]:
-    """
-    Run metadata recording the exact commit a suite ``ref`` resolves to.
-    """
-    from github3.exceptions import (  # type: ignore[reportMissingTypeStubs]  # noqa: PLC0415
-        NotFoundError,
-    )
-
-    try:
-        commit = repo.commit(ref)
-    except NotFoundError:
-        commit_info = ref
-    else:
-        # TODO: Make this the tree URL maybe, but tree(...) doesn't come with
-        #       an html_url.
-        commit_info = {"text": commit.sha[:7], "href": commit.html_url}
-    return {"Commit": commit_info}
-
-
 def hour_start() -> datetime:
     """
     The start of the current hour, in UTC.
@@ -281,17 +255,6 @@ def hour_start() -> datetime:
         second=0,
         microsecond=0,
     )
-
-
-def _commit_at_hour_start(repo: Any) -> str:
-    """
-    The newest commit on the suite's main branch at or before this hour.
-    """
-    commits = repo.commits(sha=DEFAULT_REF, until=hour_start(), number=1)
-    commit = next(iter(commits), None)
-    if commit is None:
-        return DEFAULT_REF
-    return commit.sha
 
 
 def download(ref: str | None = None) -> tuple[_P, dict[str, Any]]:
@@ -309,21 +272,26 @@ def download(ref: str | None = None) -> tuple[_P, dict[str, Any]]:
     Every dialect collected from this one root is therefore guaranteed to
     share a single consistent commit, even if the suite moves meanwhile.
     """
-    segments = cast("list[str]", TEST_SUITE_URL.path_segments)
-    repo = github().repository(segments[0], segments[1])  # type: ignore[reportUnknownMemberType]
+    owner, name, *_ = cast("list[str]", TEST_SUITE_URL.path_segments)
 
     if ref is None:
-        ref = _commit_at_hour_start(repo)
+        ref = (
+            _github.latest_commit_before(
+                owner,
+                name,
+                DEFAULT_REF,
+                hour_start(),
+            )
+            or DEFAULT_REF
+        )
 
-    data = BytesIO()
-    data.name = ""
-    succeeded = repo.archive(format="zipball", path=data, ref=ref)  # type: ignore[reportUnknownMemberType]
-    if not succeeded:
+    downloaded = _github.download_tree(owner, name, ref)
+    if downloaded is None:
         raise SuiteNotAvailable(ref)
-    data.seek(0)
+    data, run_metadata = downloaded
     (root,) = zipfile.Path(zipfile.ZipFile(data)).iterdir()
 
-    return root, _commit_metadata(repo, ref)
+    return root, run_metadata
 
 
 def dialects_in(root: _P) -> set[Dialect]:


### PR DESCRIPTION
Stacked on #3018. Centralizes Bowtie's runtime GitHub access.

## Before
GitHub access was scattered: the org identity was spelled three ways (`ORG_NAME`, `IMAGE_REPOSITORY`, a bare literal in `hatch_build`); there were two client factories (`_core.github()` and `hatch_build`'s `login/GitHub`); **two inconsistent version-enumeration paths** (`bowtie info`'s `get_versions` via the ghcr Packages API using a *private* github3 method `gh._iter`, which is 401 anonymously, vs the `harness-release-*` tags used by `site collect --versioned`); and github3 calls with per-call `type: ignore`s in `_core`, `_suite`, and `_containers`.

## After
All runtime GitHub access lives in **`bowtie/_github.py`** behind a small typed interface: `versions_of`, `latest_commit_before`, `download_tree` (zipball + commit metadata). Because `_client()` is typed as returning `Any`, github3's lack of type stubs no longer forces per-call ignores — only the two library imports carry one.

- `bowtie info`'s `get_versions` now uses the **same tag discovery** as `site collect --versioned`, so the two agree and it works unauthenticated (the Packages-API path returned nothing anonymously).
- `_core.github()`, `ORG_API`, `CONTAINER_PACKAGES_API`, and the `gh._iter` private-method use are gone.
- `_suite`'s two archive downloads and two commit-metadata reads now go through `_github.download_tree`.

**`hatch_build.py` is intentionally left alone** — it's a build hook and must not import the package it's building, so its build-time github3 use stays separate.

Verified: `nox -s typing` clean; `_suite.download()`, `versions_of`, and `get_versions` exercised against real GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)