### PR TITLE
Deploy the latest completed versioned reports, not only successful runs

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -95,6 +95,11 @@ jobs:
         with:
           workflow: versioned-report.yml
           branch: main
+          # The latest COMPLETED run, not only a fully successful one: its
+          # combine step runs on `!cancelled()` and merges onto the last
+          # published set, so it always produces a valid, up-to-date artifact
+          # even when a few implementations failed to (re)generate.
+          workflow_conclusion: ""
           name: implementations
           path: _site/implementations
 


### PR DESCRIPTION
The last mile of the versioned-report resilience work (#3018).

versioned-report.yml's `combine` step runs on `if: !cancelled()` and overlays this run's reports onto the last published `implementations` set — so it produces a **valid, up-to-date artifact even when a few implementations fail to regenerate** (e.g. an old harness version that crashes the protocol, or a version string an artifact path rejects).

But `ui.yml` downloaded the versioned reports only from a *fully successful* run (dawidd6's default `workflow_conclusion: success`). So the moment any implementation straggled, the whole run was `failure`, ui.yml ignored it, and the site kept stale versioned data — which is exactly what happened: 23/25 implementations regenerated and combine published them, but the trends never reached the site.

This takes the latest **completed** run instead (`workflow_conclusion: ""`), which is safe precisely because combine always merges onto the last-published set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)