### PR TITLE
Run Bowtie via `python -m` when benchmarking, not a bare `bowtie`

### DIFF
--- a/bowtie/_benchmarks.py
+++ b/bowtie/_benchmarks.py
@@ -1411,6 +1411,11 @@ class Benchmarker:
                 encoding="utf-8",
             )
             return await self._pyperf_benchmark_command(
+                # Run Bowtie via the current interpreter rather than relying on
+                # a `bowtie` executable being on PATH (it isn't when Bowtie is
+                # run as `python -m bowtie`, e.g. in the test suite).
+                sys.executable,
+                "-m",
                 "bowtie",
                 "run",
                 "-i",


### PR DESCRIPTION
`bowtie perf` benchmarks a connectable by having pyperf run `bowtie run ...`, but the command it handed pyperf started with a bare `bowtie` — which isn't on PATH when Bowtie is run as `python -m bowtie`. That's how the test suite runs it, so every benchmark/perf test failed with `FileNotFoundError: 'bowtie'`.

Use `sys.executable -m bowtie`, exactly as the tests already invoke Bowtie elsewhere. All 9 benchmark/perf tests pass with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)