### PR TITLE
Report which implementation ran, not how we reached it

### DIFF
--- a/bowtie/_benchmarks.py
+++ b/bowtie/_benchmarks.py
@@ -1231,7 +1231,7 @@ class Benchmarker:
                 if dialect not in implementation.info.dialects:
                     incompatible_connectables.append(connectable)
                     continue
-                acknowledged[connectable.to_terse()] = implementation.info
+                acknowledged[connectable.report_id] = implementation.info
                 compatible_connectables.append(connectable)
 
         with Progress(
@@ -1324,7 +1324,7 @@ class Benchmarker:
                                         )
                                     except BowtieRunError as err:
                                         got_connectable_result(
-                                            connectable.to_terse(),
+                                            connectable.report_id,
                                             "Errored",
                                             0,
                                             [1e9]
@@ -1352,7 +1352,7 @@ class Benchmarker:
                                         ]
 
                                         run_needed = got_connectable_result(
-                                            connectable.to_terse(),
+                                            connectable.report_id,
                                             output,
                                             retries_allowed,
                                             measured_time_values,

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1825,7 +1825,7 @@ async def info(
 
         match format:
             case "json":
-                serializable[each.id] = dict(metadata)
+                serializable[each.report_id] = dict(metadata)
             case "pretty":
                 table = _info_table_for(dict(metadata))
                 STDOUT.print(table, "\n")
@@ -2458,7 +2458,11 @@ async def smoke(
     Smoke test implementations for basic correctness against Bowtie's protocol.
     """
     results = [
-        (implementation.id, implementation.info, await implementation.smoke())
+        (
+            implementation.report_id,
+            implementation.info,
+            await implementation.smoke(),
+        )
         async for _, implementation in start()
     ]
 
@@ -2739,7 +2743,6 @@ def collect(
 
 async def _collect_dialects(
     implementation: Implementation,
-    connectable_id: ConnectableId,
     available: set[Dialect],
     root: _suite._P,  # type: ignore[reportPrivateUsage]
     maybe_set_schema: Callable[[Dialect], CaseTransform],
@@ -2769,7 +2772,7 @@ async def _collect_dialects(
             runner=runner,
             dialect=dialect,
             cases=cases,
-            implementations={connectable_id: implementation.info},
+            implementations={implementation.report_id: implementation.info},
             maybe_set_schema=maybe_set_schema,
             run_metadata=run_metadata,
         )
@@ -2807,14 +2810,13 @@ async def _collect(
     ) as starting:
         (started,) = starting
         try:
-            connectable_id, implementation = await started
+            _, implementation = await started
         except STARTUP_ERRORS as error:
             STDERR.print(error)
             return EX.CONFIG
 
         wrote = await _collect_dialects(
             implementation=implementation,
-            connectable_id=connectable_id,
             available=available,
             root=root,
             maybe_set_schema=maybe_set_schema,
@@ -2873,7 +2875,7 @@ async def _collect_versions(
         ) as starting:
             (started,) = starting
             try:
-                connectable_id, implementation = await started
+                _, implementation = await started
             except STARTUP_ERRORS:
                 STDERR.print(
                     f"[yellow]Skipping[/] {connectable.to_terse()} "
@@ -2897,7 +2899,6 @@ async def _collect_versions(
 
             wrote = await _collect_dialects(
                 implementation=implementation,
-                connectable_id=connectable_id,
                 available=available,
                 root=root,
                 maybe_set_schema=maybe_set_schema,
@@ -3158,7 +3159,7 @@ async def _run_one(
     ) as starting:
         (started,) = starting
         try:
-            connectable_id, implementation = await started
+            _, implementation = await started
         except STARTUP_ERRORS as error:
             STDERR.print(error)
             return EX.CONFIG, None
@@ -3183,7 +3184,7 @@ async def _run_one(
             runner=runner,
             dialect=dialect,
             cases=cases,
-            implementations={connectable_id: implementation.info},
+            implementations={implementation.report_id: implementation.info},
             maybe_set_schema=maybe_set_schema,
             run_metadata=run_metadata,
             reporter=reporter,

--- a/bowtie/_connectables.py
+++ b/bowtie/_connectables.py
@@ -144,12 +144,27 @@ class Connectable:
         async with (
             self._connector.connect() as connection,
             Implementation.start(
-                id=self._id,
+                report_id=self.report_id,
                 connection=connection,
                 **kwargs,
             ) as implementation,
         ):
             yield implementation
+
+    @property
+    def report_id(self) -> ConnectableId:
+        """
+        The identity this connectable's implementation carries in a report.
+
+        A report should say *which* implementation it describes, not how we
+        happened to reach it, so the connector (``image:``, ``direct:``, ...)
+        and image registry -- both of which are transport -- are dropped.
+        The same implementation reached different ways therefore shares one
+        report id, and reports never leak the transport used to run them.
+        """
+        return self._id.removeprefix(f"{self.kind}:").removeprefix(
+            f"{_containers.IMAGE_REPOSITORY}/",
+        )
 
     def to_terse(self) -> ConnectableId:
         """

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -488,7 +488,7 @@ class Implementation:
     A running implementation under test.
     """
 
-    id: ConnectableId
+    report_id: ConnectableId
     info: ImplementationInfo
     _harness: HarnessClient = field(repr=False, alias="harness")
     _reporter: Reporter = field(alias="reporter")
@@ -509,7 +509,7 @@ class Implementation:
     @asynccontextmanager
     async def start(
         cls,
-        id: ConnectableId,
+        report_id: ConnectableId,
         reporter: Reporter,
         **kwargs: Any,
     ) -> AsyncGenerator[Self]:
@@ -518,16 +518,24 @@ class Implementation:
         try:
             harness, started = await _harness.transition(START_V1)
         except ProtocolError as err:
-            raise StartupFailed(id=id) from err
+            raise StartupFailed(id=report_id) from err
         except GotStderr as err:
-            raise StartupFailed(id=id, stderr=err.stderr.decode()) from err
+            raise StartupFailed(
+                id=report_id,
+                stderr=err.stderr.decode(),
+            ) from err
         else:
             if started is None:
-                raise StartupFailed(id=id)
+                raise StartupFailed(id=report_id)
 
         info = ImplementationInfo.from_dict(**started.implementation)
 
-        yield cls(harness=harness, id=id, info=info, reporter=reporter)
+        yield cls(
+            harness=harness,
+            report_id=report_id,
+            info=info,
+            reporter=reporter,
+        )
 
     def supports(self, *dialects: Dialect) -> bool:
         """
@@ -538,7 +546,7 @@ class Implementation:
     async def get_versions(self) -> Iterable[str]:
         from bowtie import _github  # noqa: PLC0415
 
-        versions: Set[str] = set(_github.versions_of(self.id))
+        versions: Set[str] = set(_github.versions_of(self.report_id))
         if self.info.version:
             versions.add(self.info.version)
         return sorted(versions, key=sortable_version_key, reverse=True)
@@ -573,7 +581,7 @@ class Implementation:
             raise UnsupportedDialect(implementation=self, dialect=dialect)
         try:
             return await DialectRunner.for_dialect(
-                implementation=self.id,
+                implementation=self.report_id,
                 dialect=dialect,
                 harness=self._harness,
                 reporter=self._reporter,

--- a/bowtie/_smoke.py
+++ b/bowtie/_smoke.py
@@ -93,7 +93,7 @@ async def test(implementation: Implementation):
             (failure,) = got
             ref = last, *failure
 
-    return Result(id=implementation.id, dialects=dialects, ref=ref)
+    return Result(id=implementation.report_id, dialects=dialects, ref=ref)
 
 
 @frozen

--- a/bowtie/exceptions.py
+++ b/bowtie/exceptions.py
@@ -208,7 +208,7 @@ class UnsupportedDialect(Exception):
         return DiagnosticWarning(
             code="unsupported-dialect",
             message=(
-                f"{self.implementation.id!r} does not "
+                f"{self.implementation.report_id!r} does not "
                 f"support {self.dialect.pretty_name}."
             ),
             causes=[],
@@ -233,8 +233,8 @@ class DialectError(Exception):
         return DiagnosticError(
             code="dialect-error",
             message=(
-                f"{self.implementation.id!r} failed as we were beginning to "
-                f"send {self.dialect.pretty_name} tests."
+                f"{self.implementation.report_id!r} failed as we were "
+                f"beginning to send {self.dialect.pretty_name} tests."
             ),
             causes=[],
             hint_stmt=(

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -31,6 +31,7 @@ import pytest_asyncio
 
 from bowtie._cli import EX
 from bowtie._commands import ErroredTest, TestResult
+from bowtie._connectables import Connectable
 from bowtie._core import (
     Dialect,
     Implementation,
@@ -74,6 +75,22 @@ class _Miniatures:
 
 
 miniatures = _Miniatures()
+
+
+class _ReportId:
+    """
+    The report id a miniature shows up as in a report.
+
+    A report identifies an implementation by *which* it is, not by how it was
+    reached, so ``report_id.always_invalid`` is ``miniatures.always_invalid``
+    with its connector dropped.
+    """
+
+    def __getattr__(self, name: str) -> str:
+        return Connectable.from_str(getattr(miniatures, name)).report_id
+
+
+report_id = _ReportId()
 
 #: An arbitrary harness for when behavior shouldn't depend on a specific one.
 ARBITRARY = miniatures.always_invalid
@@ -426,7 +443,7 @@ class TestRun:
             results, stderr = await send()
 
         assert results == [
-            {miniatures.always_invalid: TestResult.INVALID},
+            {report_id.always_invalid: TestResult.INVALID},
         ], stderr
 
     @pytest.mark.asyncio
@@ -457,8 +474,8 @@ class TestRun:
             [
                 {"type": "integer"},
                 [
-                    [12, {"direct:null": "valid"}],
-                    [12.5, {"direct:null": "valid"}],
+                    [12, {"null": "valid"}],
+                    [12.5, {"null": "valid"}],
                 ],
             ],
         ], run_stderr
@@ -525,13 +542,13 @@ async def test_suite(tmp_path):
                     (
                         one,
                         {
-                            miniatures.always_invalid: TestResult.INVALID,
+                            report_id.always_invalid: TestResult.INVALID,
                         },
                     ),
                     (
                         two,
                         {
-                            miniatures.always_invalid: TestResult.INVALID,
+                            report_id.always_invalid: TestResult.INVALID,
                         },
                     ),
                 ],
@@ -876,7 +893,7 @@ async def test_set_schema_sets_a_dialect_explicitly():
         )
 
     # XXX: we need to make run() return the whole report
-    assert results == [{"direct:null": TestResult.VALID}], stderr
+    assert results == [{"null": TestResult.VALID}], stderr
 
 
 @pytest.mark.asyncio
@@ -955,7 +972,7 @@ async def test_direct_connector_exception_does_not_crash():
         )
 
     assert results == [
-        {miniatures.crashes_on_validate: ErroredTest.in_errored_case()},
+        {report_id.crashes_on_validate: ErroredTest.in_errored_case()},
     ], stderr
 
 
@@ -997,8 +1014,8 @@ async def test_handles_dead_implementations(succeed_immediately):
         )
 
     assert results == [
-        {miniatures.always_invalid: TestResult.INVALID},
-        {miniatures.always_invalid: TestResult.INVALID},
+        {report_id.always_invalid: TestResult.INVALID},
+        {report_id.always_invalid: TestResult.INVALID},
     ], stderr
     assert "failed to start" in stderr, stderr
 
@@ -1042,8 +1059,8 @@ async def test_it_handles_immediately_broken_implementations(fail_immediately):
     assert "failed to start" in stderr, stderr
     assert "BOOM!" in stderr, stderr
     assert results == [
-        {miniatures.always_invalid: TestResult.INVALID},
-        {miniatures.always_invalid: TestResult.INVALID},
+        {report_id.always_invalid: TestResult.INVALID},
+        {report_id.always_invalid: TestResult.INVALID},
     ], stderr
 
 
@@ -1067,8 +1084,8 @@ async def test_it_handles_broken_start_implementations(fail_on_start):
     assert "failed to start" in stderr, stderr
     assert "BOOM!" in stderr, stderr
     assert results == [
-        {miniatures.always_invalid: TestResult.INVALID},
-        {miniatures.always_invalid: TestResult.INVALID},
+        {report_id.always_invalid: TestResult.INVALID},
+        {report_id.always_invalid: TestResult.INVALID},
     ], stderr
 
 
@@ -1327,8 +1344,8 @@ async def test_fail_fast():
         )
 
     assert results == [
-        {"direct:null": TestResult.VALID},
-        {"direct:null": TestResult.VALID},
+        {"null": TestResult.VALID},
+        {"null": TestResult.VALID},
     ], stderr
     assert stderr != ""
 
@@ -1345,9 +1362,9 @@ async def test_fail_fast_many_tests_at_once():
         )
 
     assert results == [
-        {"direct:null": TestResult.VALID},
-        {"direct:null": TestResult.VALID},
-        {"direct:null": TestResult.VALID},
+        {"null": TestResult.VALID},
+        {"null": TestResult.VALID},
+        {"null": TestResult.VALID},
     ], stderr
     assert stderr != ""
 
@@ -1365,9 +1382,9 @@ async def test_max_fail():
         )
 
     assert results == [
-        {"direct:null": TestResult.VALID},
-        {"direct:null": TestResult.VALID},
-        {"direct:null": TestResult.VALID},
+        {"null": TestResult.VALID},
+        {"null": TestResult.VALID},
+        {"null": TestResult.VALID},
     ], stderr
     assert stderr != ""
 
@@ -1410,7 +1427,7 @@ async def test_filter():
             """,  # noqa: E501
         )
 
-    assert results == [{"direct:null": TestResult.VALID}], stderr
+    assert results == [{"null": TestResult.VALID}], stderr
     assert stderr == ""
 
 
@@ -2139,14 +2156,14 @@ class TestSmoke:
             exit_code=EX.DATAERR,  # because indeed invalid isn't always right
         )
         assert (await command_validator("smoke")).validated(jsonout) == {
-            miniatures.passes_smoke: {
+            report_id.passes_smoke: {
                 "success": True,
                 "dialects": [
                     dialect.short_name
                     for dialect in sorted(Dialect.known(), reverse=True)
                 ],
             },
-            miniatures.always_invalid: {
+            report_id.always_invalid: {
                 "success": False,
                 "dialects": {
                     "draft2019-09": [
@@ -2597,7 +2614,7 @@ async def test_info_json_multiple_implementations():
     jsonout = _json.loads(stdout)
 
     assert (await command_validator("info")).validated(jsonout) == {
-        miniatures.always_invalid: {
+        report_id.always_invalid: {
             "name": "always_invalid",
             "language": "python",
             "homepage": "https://bowtie.report/",
@@ -2616,7 +2633,7 @@ async def test_info_json_multiple_implementations():
                 "http://json-schema.org/draft-03/schema#",
             ],
         },
-        miniatures.links: {
+        report_id.links: {
             "name": "links",
             "language": "python",
             "homepage": "urn:example",
@@ -3010,11 +3027,11 @@ async def test_summary_show_failures_json(tmp_path):
 
     assert (await command_validator("summary")).validated(jsonout) == [
         [
-            "direct:null",
+            "null",
             dict(failed=0, skipped=0, errored=0),
         ],
         [
-            miniatures.always_invalid,
+            report_id.always_invalid,
             dict(failed=2, skipped=0, errored=0),
         ],
     ]
@@ -3260,14 +3277,14 @@ async def test_summary_show_validation_json(envsonschema):
                 [
                     12,
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "valid",
                     },
                 ],
                 [
                     12.5,
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "invalid",
                     },
                 ],
@@ -3279,7 +3296,7 @@ async def test_summary_show_validation_json(envsonschema):
                 [
                     "{}",
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "error",
                     },
                 ],
@@ -3291,14 +3308,14 @@ async def test_summary_show_validation_json(envsonschema):
                 [
                     "{}",
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "error",
                     },
                 ],
                 [
                     37,
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "error",
                     },
                 ],
@@ -3310,7 +3327,7 @@ async def test_summary_show_validation_json(envsonschema):
                 [
                     "",
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "skipped",
                     },
                 ],
@@ -3322,7 +3339,7 @@ async def test_summary_show_validation_json(envsonschema):
                 [
                     "",
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "skipped",
                     },
                 ],
@@ -3334,14 +3351,14 @@ async def test_summary_show_validation_json(envsonschema):
                 [
                     "",
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "error",
                     },
                 ],
                 [
                     12,
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "invalid",
                     },
                 ],
@@ -3353,7 +3370,7 @@ async def test_summary_show_validation_json(envsonschema):
                 [
                     "",
                     {
-                        "direct:null": "valid",
+                        "null": "valid",
                         tag("envsonschema"): "error",
                     },
                 ],
@@ -3938,7 +3955,7 @@ async def test_run_mismatched_dialect():
             """,  # noqa: E501
         )
 
-    assert results == [{miniatures.always_invalid: TestResult.INVALID}], stderr
+    assert results == [{report_id.always_invalid: TestResult.INVALID}], stderr
     assert "$schema keyword does not" in stderr, stderr
 
 
@@ -3951,7 +3968,7 @@ async def test_run_registry_metasschema_not_mismatched_dialect():
             """,  # noqa: E501
         )
 
-    assert results == [{miniatures.always_invalid: TestResult.INVALID}], stderr
+    assert results == [{report_id.always_invalid: TestResult.INVALID}], stderr
     assert stderr == ""
 
 
@@ -3964,7 +3981,7 @@ async def test_run_registry_metasschema_still_mismatched_dialect():
             """,  # noqa: E501
         )
 
-    assert results == [{miniatures.always_invalid: TestResult.INVALID}], stderr
+    assert results == [{report_id.always_invalid: TestResult.INVALID}], stderr
     assert "$schema keyword does not" in stderr, stderr
 
 
@@ -3982,7 +3999,7 @@ async def test_run_mismatched_dialect_total_junk():
             """,  # noqa: E501
         )
 
-    assert results == [{miniatures.always_invalid: TestResult.INVALID}], stderr
+    assert results == [{report_id.always_invalid: TestResult.INVALID}], stderr
     assert stderr == ""
 
 
@@ -4011,7 +4028,7 @@ async def test_run_boolean_schema(tmp_path):
             """,  # noqa: E501
         )
 
-    assert results == [{miniatures.always_invalid: TestResult.INVALID}], stderr
+    assert results == [{report_id.always_invalid: TestResult.INVALID}], stderr
     assert stderr == "", stderr
 
 
@@ -4228,14 +4245,18 @@ async def test_container_connectables(
     assert stderr == ""
 
     report = Report.from_serialized(stdout.splitlines())
+    # A report identifies an implementation transport-free, so the container
+    # connectables show up under their report id, not the `container:` string.
+    envsonschema_id = Connectable.from_str(envsonschema_container).report_id
+    lintsonschema_id = Connectable.from_str(lintsonschema_container).report_id
     assert [
         [test_results for _, test_results in results]
         for _, results in report.cases_with_results()
     ] == [
         [
             {
-                envsonschema_container: TestResult.INVALID,
-                lintsonschema_container: TestResult.VALID,
+                envsonschema_id: TestResult.INVALID,
+                lintsonschema_id: TestResult.VALID,
             },
         ],
     ], stderr
@@ -4261,7 +4282,7 @@ async def test_direct_connectable_python_jsonschema(tmp_path):
         [test_results for _, test_results in results]
         for _, results in report.cases_with_results()
     ] == [
-        [{"direct:python-jsonschema": TestResult.VALID}],
+        [{"python-jsonschema": TestResult.VALID}],
     ], stderr
 
 
@@ -4440,7 +4461,7 @@ class TestBenchmarkRun:
 
             Benchmark: Tests with benchmark
 
-            | Test Name | direct:python-jsonschema |
+            | Test Name | python-jsonschema |
         """,
         ).strip()
 
@@ -4490,7 +4511,7 @@ class TestBenchmarkRun:
 
             Benchmark: Tests with varying Array Size
 
-            | Test Name | direct:python-jsonschema |
+            | Test Name | python-jsonschema |
         """,
         ).strip()
 
@@ -4498,7 +4519,7 @@ class TestBenchmarkRun:
             """
             Benchmark: Tests with benchmark 2
 
-            | Test Name | direct:python-jsonschema |
+            | Test Name | python-jsonschema |
         """,
         ).strip()
 


### PR DESCRIPTION
## What

Reports now identify an implementation by *which* implementation it is, not by *how* it was reached.

Previously the report id came from the connectable, so `image:foo` and `direct:foo` gave different ids for the same implementation. Worse, an `image:` run keyed its metadata under `foo` (the terse connectable) but labelled results `image:foo`, so the frontend matched nothing and rendered **"no results"**.

## How

`Connectable.to_terse()` had been quietly serving two purposes. Split them:

- **`to_terse()`** — unchanged in meaning: the tersest *pipeable* connectable (keeps `direct:`, strips `image:` + registry). Used for `filter-implementations` output and the `-i` args benchmarking hands to subprocesses.
- **`Connectable.report_id`** (new) — the transport-free identity: drops the connector kind *and* image registry, so `image:foo`, `direct:foo`, and a bare `foo` all report as `foo`.

`Implementation.id` → `Implementation.report_id`, fed by `Connectable.report_id`, and is now the single source for both report metadata keys and result labels, so they always match. Benchmark reports key by `report_id` too (their `-i` subprocess args stay terse). The two methods only coincide for `image:`, which is why only image runs were visibly broken.

Net: run an implementation via a direct or a docker connectable → identical reports.

## Verification (local)

- `nox -s typing` (pyright): 0 errors · `nox -s style` (ruff): clean · `nox -s "docs(spelling)"`: clean
- Full `test_integration.py` with a local container engine running: **108 passed**.
- Image path verified — the original bug's locus — via `test_summary_show_validation_json` (an `image:` implementation through `validate` → `summary`, asserting report keys) and `test_it_preserves_all_metadata`.
- Two local non-passes are environmental, **not** this change:
  - `test_no_such_image` fails identically on clean `main` — Apple `container` v0.6.0 reports a missing image as "failed to start" rather than podman/docker's "no such image".
  - 10 "Failed to build" errors were flaky Apple-`container` buildkit failures under an 88-minute load (the same tests pass in isolation).

CI (podman on Linux) is the real gate for the image path and all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
