### PR TITLE
Key the combined site by report id, and build badges within `site combine`

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -138,12 +138,9 @@ jobs:
 
       - name: Combine into Site Data
         # Combines the per-implementation reports for each dialect and writes
-        # implementations.json and the public API data -- all read from the
-        # reports, so no implementations are started here.
+        # implementations.json, badges and the public API data -- all read
+        # from the reports, so no implementations are started here.
         run: bowtie site combine collected/* --output site
-
-      - name: Generate Badges
-        run: bowtie badges --site site
 
         # FIXME: We ignore for now as this exits unsuccessfully if there are
         #        *test* failures.

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -7,7 +7,6 @@ from fnmatch import fnmatch
 from functools import wraps
 from io import TextIOWrapper
 from pathlib import Path
-from pprint import pformat
 from statistics import mean, median, quantiles
 from textwrap import dedent
 from time import perf_counter_ns
@@ -149,7 +148,7 @@ _COMMAND_GROUPS = {
         ),
         CommandGroupDict(
             name="Plumbing Commands",
-            commands=["badges", "smoke"],
+            commands=["smoke"],
         ),
         CommandGroupDict(
             name="Benchmarking Commands",
@@ -437,100 +436,6 @@ def implementation_subcommand(
         return cmd
 
     return wrapper
-
-
-@subcommand
-@click.option(
-    "--site",
-    default=Path("site"),
-    show_default=True,
-    type=click.Path(
-        path_type=Path,
-        file_okay=False,
-        dir_okay=True,
-        exists=True,
-    ),
-    help=(
-        "The path to a previously generated collection of reports, "
-        "used to generate the badges."
-    ),
-)
-def badges(site: Path):
-    """
-    Generate Bowtie badges for implementations using a previous Bowtie run.
-
-    Will generate badges for any existing dialects, and ignore any for which a
-    report was not generated.
-    """
-    outdir = site / "badges"
-    try:
-        outdir.mkdir()
-    except FileExistsError:
-        error = DiagnosticError(
-            code="already-exists",
-            message="Badge output directory already exists.",
-            causes=[f"{outdir} is an existing directory."],
-            hint_stmt=(
-                "If you intended to replace its contents with new badges, "
-                "delete the directory first."
-            ),
-        )
-        STDERR.print(error)
-        return EX.CONFIG
-
-    supported_versions: dict[Path, Iterable[Dialect]] = {}
-
-    for name, dialect in Dialect.by_short_name().items():
-        try:
-            file = site.joinpath(f"{name}.json").open()
-        except FileNotFoundError:
-            continue
-        with file:
-            report = _report.Report.from_serialized(file)
-            if report.is_empty:
-                error = DiagnosticError(
-                    code="empty-report",
-                    message="A Bowtie report is empty.",
-                    causes=[f"The {name} report contains no results."],
-                    hint_stmt="Check that site generation has not failed.",
-                )
-                STDERR.print(error)
-                return EX.DATAERR
-
-            badge_name = f"{dialect.short_name}.json"
-
-            for each, badge in report.compliance_badges():
-                dir = outdir / each.id
-
-                compliance = dir / "compliance"
-                compliance.mkdir(parents=True, exist_ok=True)
-                compliance.joinpath(badge_name).write_text(json.dumps(badge))
-
-                dialects = each.dialects
-                seen = supported_versions.setdefault(dir, dialects)
-                if seen != dialects:
-                    message = (
-                        f"{dir.name} appears with different "
-                        "supported dialects in the provided reports."
-                    )
-                    error = DiagnosticError(
-                        code="inconsistent-reports",
-                        message=message,
-                        causes=[
-                            f"{file.name} contains:\n{pformat(dialects)}",
-                            f"{pformat(seen)} was previously seen.",
-                        ],
-                        hint_stmt=(
-                            "Check that the implementation produces "
-                            "consistent output and that a run has not failed."
-                        ),
-                    )
-                    STDERR.print(error)
-                    return EX.CONFIG
-
-    for dir, dialects in supported_versions.items():
-        badge = _report.supported_version_badge(dialects=dialects)
-        dir.joinpath("supported_versions.json").write_text(json.dumps(badge))
 
 
 _F = Literal["json", "pretty", "markdown"]
@@ -2947,10 +2852,10 @@ def site_combine(
     produced by `bowtie site collect` (or an individual report file). For
     each dialect the matching reports are combined into a single
     multi-implementation report, and every implementation's own metadata is
-    gathered into ``implementations.json``. The public API data under
-    ``api/`` is written too, with each implementation's compliance-badge
-    URLs resolved from its own dialects. All of this is read from the
-    reports themselves, without starting any implementation.
+    gathered into ``implementations.json``. Compliance and supported-version
+    ``badges`` are written for each implementation, and the public API data
+    under ``api/`` too. All of this is read from the reports themselves,
+    without starting any implementation.
     """
     context.exit(_combine(collected=collected, output=output))
 
@@ -2985,8 +2890,7 @@ def _combine(collected: tuple[Path, ...], output: Path) -> int:
         if report.is_empty:
             continue
         by_dialect.setdefault(report.metadata.dialect, []).append(report)
-        for info in report.metadata.implementations.values():
-            infos[info.id] = info
+        infos.update(report.metadata.implementations)
 
     if not by_dialect:
         error = DiagnosticError(
@@ -3019,6 +2923,25 @@ def _combine(collected: tuple[Path, ...], output: Path) -> int:
         output.joinpath(f"{dialect.short_name}.json").write_text(
             "\n".join(combined.serialized()),
         )
+        # Badges live under both the report id -- how the site, reports and
+        # version trends refer to an implementation -- and the self-reported
+        # id, kept so pre-existing badge URLs (in harness READMEs) don't break.
+        for id, info, badge in combined.compliance_badges():
+            for badge_id in {id, info.id}:
+                compliance = output / "badges" / badge_id / "compliance"
+                compliance.mkdir(parents=True, exist_ok=True)
+                compliance.joinpath(f"{dialect.short_name}.json").write_text(
+                    json.dumps(badge),
+                )
+
+    for id, info in infos.items():
+        badge = _report.supported_version_badge(dialects=info.dialects)
+        for badge_id in {id, info.id}:
+            directory = output / "badges" / badge_id
+            directory.mkdir(parents=True, exist_ok=True)
+            directory.joinpath("supported_versions.json").write_text(
+                json.dumps(badge),
+            )
 
     output.joinpath("implementations.json").write_text(
         json.dumps(

--- a/bowtie/_report.py
+++ b/bowtie/_report.py
@@ -518,13 +518,16 @@ class Report:  # noqa: PLW1641
                 test_results.append((test, test_result))
             yield case, test_results
 
-    def compliance_badges(self) -> Iterable[tuple[ImplementationInfo, Badge]]:
+    def compliance_badges(
+        self,
+    ) -> Iterable[tuple[ConnectableId, ImplementationInfo, Badge]]:
         for id, implementation in self.implementations.items():
             unsuccessful = self.unsuccessful(id)
             passed = self.total_tests - unsuccessful.total
             percentage = int(100 * (passed / self.total_tests))
             r, g, b = 100 - percentage, percentage, 0
             yield (
+                id,
                 implementation,
                 Badge(
                     schemaVersion=1,

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -739,6 +739,10 @@ async def test_site_combine(tmp_path):
     site = tmp_path / "site"
     await bowtie("site", "combine", str(a), str(b), "--output", site)
 
+    # Badges are written under each implementation's report id, and also under
+    # its (differing) self-reported id so existing badge URLs keep resolving.
+    # null's ids differ (null vs python-null), so it gets both; for
+    # python-jsonschema they coincide, so it gets a single directory.
     assert {path.relative_to(site) for path in site.rglob("*")} == {
         Path("draft7.json"),
         Path("implementations.json"),
@@ -746,6 +750,19 @@ async def test_site_combine(tmp_path):
         Path("api/v1"),
         Path("api/v1/json-schema-org"),
         Path("api/v1/json-schema-org/implementations"),
+        Path("badges"),
+        Path("badges/null"),
+        Path("badges/null/compliance"),
+        Path("badges/null/compliance/draft7.json"),
+        Path("badges/null/supported_versions.json"),
+        Path("badges/python-null"),
+        Path("badges/python-null/compliance"),
+        Path("badges/python-null/compliance/draft7.json"),
+        Path("badges/python-null/supported_versions.json"),
+        Path("badges/python-jsonschema"),
+        Path("badges/python-jsonschema/compliance"),
+        Path("badges/python-jsonschema/compliance/draft7.json"),
+        Path("badges/python-jsonschema/supported_versions.json"),
     }
 
     # The combined per-dialect report contains both implementations.
@@ -3378,64 +3395,6 @@ async def test_summary_show_validation_json(envsonschema):
         ],
     ], run_stderr
     assert stderr == ""
-
-
-@pytest.mark.asyncio
-@pytest.mark.containers
-async def test_badges(envsonschema, tmp_path):
-    site = tmp_path / "site"
-    site.mkdir()
-
-    raw = """
-        {"description":"one","schema":{"type": "integer"},"tests":[{"description":"valid:1","instance":12},{"description":"valid:0","instance":12.5}]}
-        {"description":"two","schema":{"type": "string"},"tests":[{"description":"crash:1","instance":"{}"}]}
-        {"description":"crash:1","schema":{"type": "number"},"tests":[{"description":"three","instance":"{}"}, {"description": "another", "instance": 37}]}
-        {"description":"four","schema":{"type": "array"},"tests":[{"description":"skip:message=foo","instance":""}]}
-        {"description":"skip:message=bar","schema":{"type": "boolean"},"tests":[{"description":"five","instance":""}]}
-        {"description":"six","schema":{"type": "array"},"tests":[{"description":"error:message=boom","instance":""}, {"description":"valid:0", "instance":12}]}
-        {"description":"error:message=boom","schema":{"type": "array"},"tests":[{"description":"seven","instance":""}]}
-    """  # noqa: E501
-
-    run_stdout, _ = await bowtie(
-        "run",
-        "-i",
-        envsonschema,
-        stdin=dedent(raw.strip("\n")),
-    )
-
-    site.joinpath("draft2020-12.json").write_text(run_stdout)
-
-    _stdout, _stderr = await bowtie("badges", "--site", site)
-
-    badges = site / "badges"
-    assert {path.relative_to(badges) for path in badges.rglob("*")} == {
-        Path("python-envsonschema"),
-        Path("python-envsonschema/supported_versions.json"),
-        Path("python-envsonschema/compliance"),
-        Path("python-envsonschema/compliance/draft2020-12.json"),
-    }
-
-
-@pytest.mark.asyncio
-async def test_badges_nothing_ran(tmp_path):
-    run_stdout, _ = await bowtie(
-        "run",
-        "-i",
-        ARBITRARY,
-        stdin="",
-        exit_code=-1,  # no test cases run causes a non-zero here
-    )
-
-    badges = tmp_path / "badges"
-    stdout, stderr = await bowtie(
-        "badges",
-        badges,
-        stdin=run_stdout,
-        exit_code=2,  # comes from click
-    )
-    assert stdout == ""
-    assert stderr != ""
-    assert not badges.is_dir()
 
 
 @pytest.mark.asyncio

--- a/docs/motd.txt
+++ b/docs/motd.txt
@@ -23,7 +23,6 @@ Options:
   -h, --help                      Show this message and exit.
 
 Commands:
-  badges    Generate Bowtie badges from previous runs.
   info      Retrieve a particular implementation (harness)'s metadata.
   run       Run a sequence of cases provided on standard input.
   smoke     Smoke test one or more implementations for basic correctness.


### PR DESCRIPTION
## Why the site went empty

`bowtie site combine` keyed `implementations.json` by each implementation's **self-reported id** (`ImplementationInfo.id` = `{language}-{name}` → `c++-blaze`, `dotnet-JsonSchema.Net`, `java-com.networknt-...`), but the per-dialect reports **and** the versioned-trend directories key by the **report id** (the connectable/repo name → `cpp-blaze`, `dotnet-jsonschema-net`, `java-networknt-...`).

The frontend builds its results map from the reports (report id) and its implementation list from `implementations.json` (self-reported id). For every implementation whose two ids differ — ~34 of 51 on the live site — results couldn't attach, so the page rendered (mostly) empty. Verified against the deployed data: `implementations.json` had `c++-blaze` while `draft2020-12.json` had `cpp-blaze`, and `implementations/dotnet-jsonschema-net/` exists but `implementations/dotnet-JsonSchema.Net/` 404s.

This is independent of the earlier `report_id` change (that left report keys byte-identical for image harnesses); it came in with `bowtie site combine` (2026-07-25).

## Fix

- **Key `implementations.json` by the report id** — the same id the reports and trends already use, and the URL-safe one (`info.id` can carry `+`, `.`, uppercase). This is the actual empty-site fix.
- **Fold badge generation into `site combine`.** Combine already reads every report and now has both ids per implementation, which the standalone `bowtie badges` command never did. Each badge (compliance per dialect + supported-versions) is written under **both** the report id (what the site now uses) and the **self-reported id** (the previous path — kept so badge URLs embedded in harness READMEs keep resolving). When the two ids coincide, a single directory is written.
- **Remove** the standalone `badges` command and its separate `report.yml` step — one pass now does reports + `implementations.json` + badges + api.
- The public **json-schema.org API is unchanged** (still keyed by source URL, badge URLs pointing at the preserved self-reported-id badges).

## Verification (local)

- `nox -s typing`, `nox -s style`, `nox -s "docs(spelling)"`: clean.
- `test_site_combine` updated and passing — it now asserts badges appear under **both** ids for `null` (`null` + `python-null`) and a single dir for `python-jsonschema` (ids coincide), and that `implementations.json` keys are the report ids.
- `test_report.py` (31 passed) and the site/collect/combine slice pass.
- Removed `test_badges` / `test_badges_nothing_ran` (they exercised the deleted command; badge coverage now lives in `test_site_combine`).

Net −119 lines. Reaches the live site on the next `report.yml` cron after a release, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
