### PR TITLE
Repair the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,25 @@
 {
   "name": "Bowtie",
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  // Pin the Debian release explicitly.
+  // The unsuffixed tags follow whatever release is newest, which has silently broken this container before.
+  "image": "mcr.microsoft.com/devcontainers/python:3.14-trixie",
   "remoteUser": "vscode",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:": {},
-    "ghcr.io/devcontainers/features/node:": {},
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    }
+    // Docker CE, not moby, as Debian trixie has no moby packages.
+    "ghcr.io/devcontainers/features/docker-in-docker:4.1.0": {
+      "moby": false
+    },
+    "ghcr.io/devcontainers/features/node:2.1.0": {},
+    "ghcr.io/devcontainers/features/sshd:1.1.0": {}
   },
-  "onCreateCommand": "pip install -r requirements.txt -e .",
-  "postCreateCommand": "sudo cp /workspaces/bowtie/docs/motd.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"
+  // Put the project's environment on $PATH so bowtie itself (along with pytest, nox, ...) is directly runnable,
+  // as the first run notice below assumes.
+  "remoteEnv": {
+    "PATH": "${containerWorkspaceFolder}/.venv/bin:${containerEnv:PATH}"
+  },
+  "onCreateCommand": {
+    "bowtie": "pipx install uv && uv sync --group=test",
+    "ui": "pnpm --dir frontend install"
+  },
+  "postCreateCommand": "sudo cp ${containerWorkspaceFolder}/docs/motd.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"
 }

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,46 @@
+name: Dev Container
+
+on:
+  pull_request:
+    paths:
+      - .devcontainer/**
+      - .github/workflows/devcontainer.yml
+      - frontend/package.json
+      - frontend/pnpm-lock.yaml
+      - hatch_build.py
+      - pyproject.toml
+      - uv.lock
+  schedule:
+    # Daily at 6:12.
+    # What breaks this container generally happens elsewhere -- a floating base image tag following a new Debian release, or a file the container installs from disappearing from the repository -- so check it even when nothing here changes.
+    - cron: "12 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: devcontainer-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  devcontainer:
+    name: Build the Dev Container
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # Bowtie's version comes from its tags, and installing it needs one
+          persist-credentials: false
+
+      - name: Build it, then check it can run Bowtie and containers
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
+        with:
+          push: never
+          # Authenticates the GitHub API calls Bowtie's build makes, which are anonymous (and therefore easily rate limited) otherwise.
+          env: |
+            BUILD_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          runCmd: |
+            bowtie --version
+            docker version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ repos:
       - id: check-added-large-files
       - id: check-ast
       - id: check-json
+        # devcontainer.json is JSONC, which this hook cannot parse.
+        exclude: ^\.devcontainer/devcontainer\.json$
       - id: check-toml
       - id: check-vcs-permalinks
       - id: check-yaml


### PR DESCRIPTION
Closes #2420.

## Why

The dev container has been failing to build for months, in three unrelated ways -- only the first of which #2420 describes:

1. **The base image tag floats.** `mcr.microsoft.com/devcontainers/python:3.13` now resolves to Debian trixie (same digest as `:3.13-trixie`), where the moby packages `docker-in-docker` installs by default no longer exist, so the feature refuses to install. Still true of the newest feature release, 4.1.0.
2. **Two feature pins were empty tags** -- `"ghcr.io/devcontainers/features/docker-in-docker:"` and `"…/node:"` -- written by Dependabot in bef35172 and fa858670 when it crossed a major version. That's dependabot/dependabot-core#15316, fixed upstream by dependabot/dependabot-core#15445 in June, but the mangled refs stayed.
3. **`onCreateCommand` installed from a file deleted nine months ago**, `requirements.txt`, which went away in 62f8eef0 when nox moved to uv.

## What

* pin the Debian release explicitly, at 3.14 to match what `noxfile.py` tests
* `"moby": false`, so Docker CE -- which trixie *does* package -- gets installed
* pin all three features to exact versions
* set the environment up with `uv sync --group=test` and put `.venv/bin` on `$PATH`, so the `bowtie` invocations in the first run notice actually run
* `${containerWorkspaceFolder}` rather than a hardcoded `/workspaces/bowtie`
* install the UI's dependencies too, as the contributor guide sends people to `pnpm --dir frontend run start`

Plus a daily (and path-triggered) workflow which builds the container and checks it can run Bowtie and containers. Two of the three breakages above originated outside `.devcontainer`, so a build only on changes to it wouldn't have caught them.

`check-json` can't parse comments, so it now skips `devcontainer.json` -- which is JSONC, and the comments are what stop the pins from being "simplified" back.

## Verification

The container build itself is what this PR's own CI run verifies. Locally I checked:

* the setup commands in the real base image (run under Apple's `container`): Python 3.14.7, pipx present, `pipx install uv && uv sync --group=test` builds the project and gives a working `.venv/bin/bowtie --version`
* `:3.13`/`:3.14` and `:3.13-trixie`/`:3.14-trixie` are the same manifests, so the floating tags really are trixie today
* trixie is absent from the feature's moby codename list but present in its Docker CE one, and `download.docker.com/linux/debian/dists/trixie` exists
* all three pinned feature tags resolve, and `prek run` passes

## Follow-ups, not done here

* `uv sync` needs a live GitHub API call to succeed (`hatch_build.py`'s `_collect_harnesses`), so creating the container fails outright if it's rate limited. The workflow passes a token; Codespaces sets one; a local dev container is anonymous.
* `docs/index.rst` still promises Codespaces gives you "all of its supported implementations installed into it", but pre-pulling was deliberately dropped in d9adcfff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)