### PR TITLE
Know about the JSON Schema v1 dialect

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,10 +28,9 @@ jobs:
       - name: Collect supported dialects
         id: dialects-matrix
         run: |
-          # Published dialects only. An unpublished one has no benchmarks and
-          # no harnesses declaring it, so its merge step would find no
-          # artifacts to combine.
-          printf 'dialects=%s\n' "$(jq -c '[.[] | select(has("firstPublicationDate")) | .shortName]' data/dialects.json)" >> $GITHUB_OUTPUT
+          # A prerelease dialect has no benchmarks and no harnesses
+          # declaring it, so its merge step would find no artifacts.
+          printf 'dialects=%s\n' "$(jq -c '[.[] | select(.prerelease != true) | .shortName]' data/dialects.json)" >> $GITHUB_OUTPUT
 
   benchmark_files:
     name: Collect Benchmark Files

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Collect supported dialects
         id: dialects-matrix
         run: |
-          printf 'dialects=%s\n' "$(jq -c '[.[].shortName]' data/dialects.json)" >> $GITHUB_OUTPUT
+          # Published dialects only. An unpublished one has no benchmarks and
+          # no harnesses declaring it, so its merge step would find no
+          # artifacts to combine.
+          printf 'dialects=%s\n' "$(jq -c '[.[] | select(has("firstPublicationDate")) | .shortName]' data/dialects.json)" >> $GITHUB_OUTPUT
 
   benchmark_files:
     name: Collect Benchmark Files

--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -1768,6 +1768,13 @@ async def filter_dialects(
     async for _, implementation in start():
         matching &= implementation.info.dialects
 
+    if latest:
+        # Latest means the latest published dialect, as it does everywhere
+        # else in Bowtie. A caller who asked only about dialects still being
+        # written gets an answer about those instead of nothing.
+        published = matching & frozenset(Dialect.published())
+        matching = published or matching
+
     if not matching:
         click.echo("No dialects match.", file=sys.stderr)
         return EX.DATAERR

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -10,7 +10,11 @@ from uuid import uuid4
 import json
 
 from attrs import Factory, asdict, evolve, field, frozen, mutable
-from referencing.jsonschema import EMPTY_REGISTRY, specification_with
+from referencing.jsonschema import (
+    DRAFT202012,
+    EMPTY_REGISTRY,
+    specification_with,
+)
 from rpds import HashTrieMap, HashTrieSet
 from url import URL
 import httpx
@@ -65,6 +69,16 @@ if TYPE_CHECKING:
     from bowtie._report import Reporter
 
 
+#: Dialects whose identifiers `referencing` does not know, mapped to the
+#: specification whose resource structure they share, meaning the rules for
+#: finding ``$id``\ s, anchors and subschemas. A dialect only belongs here
+#: while it is too new for referencing to have shipped support, and the entry
+#: should be deleted once it has.
+REFERENCING_FALLBACK: Mapping[URL, Specification[Schema]] = {
+    URL.parse("https://json-schema.org/v1"): DRAFT202012,
+}
+
+
 @frozen
 @total_ordering
 class Dialect:
@@ -75,7 +89,10 @@ class Dialect:
     pretty_name: str
     uri: URL = field(repr=False)
     short_name: str = field(repr=False)
-    first_publication_date: date = field(repr=False)
+    #: `None` for a dialect which has not been published yet. Explicit
+    #: rather than defaulted, as forgetting a date should not quietly mean
+    #: a dialect is unpublished.
+    first_publication_date: date | None = field(repr=False)
     aliases: Set[str] = field(
         default=cast("frozenset[str]", frozenset()),
         repr=False,
@@ -108,7 +125,26 @@ class Dialect:
     def __lt__(self, other: Any):
         if other.__class__ is not Dialect:
             return NotImplemented
-        return self.first_publication_date < other.first_publication_date
+        return self._age < other._age
+
+    @property
+    def _age(self):
+        """
+        Order dialects oldest to newest, with unpublished ones newest of all.
+
+        The short name breaks ties, so that two unpublished dialects still
+        have a total order and sort the same way every run.
+        """
+        if self.first_publication_date is None:
+            return date.max, self.short_name
+        return self.first_publication_date, self.short_name
+
+    @property
+    def is_published(self):
+        """
+        Has this dialect been published as a document yet?
+        """
+        return self.first_publication_date is not None
 
     @classmethod
     @cache
@@ -143,19 +179,36 @@ class Dialect:
 
     @classmethod
     @cache
+    def published(cls) -> Iterable[Dialect]:
+        """
+        Every dialect Bowtie knows which has actually been published.
+
+        The rest are dialects still being written, which Bowtie knows about
+        only so that their test suite can be run against harnesses opting
+        in to them.
+        """
+        return HashTrieSet(each for each in cls.known() if each.is_published)
+
+    @classmethod
+    @cache
     def latest(cls):
         """
-        The latest dialect known to Bowtie.
+        The latest published dialect known to Bowtie.
+
+        Bowtie knows about dialects which are still being written, so that
+        their test suite can be run, but an unpublished dialect is not what
+        anyone means by "latest", and defaulting to one would send schemas
+        no harness has agreed to support.
         """
-        return max(cls.known())
+        return max(cls.published())
 
     @classmethod
     def from_dict(
         cls,
-        firstPublicationDate: str,
         prettyName: str,
         shortName: str,
         uri: str,
+        firstPublicationDate: str | None = None,
         aliases: Iterable[str] = (),
         hasBooleanSchemas: bool = True,
         **kwargs: Any,
@@ -169,7 +222,11 @@ class Dialect:
             uri=URL.parse(uri),
             pretty_name=prettyName,
             short_name=shortName,
-            first_publication_date=date.fromisoformat(firstPublicationDate),
+            first_publication_date=(
+                None
+                if firstPublicationDate is None
+                else date.fromisoformat(firstPublicationDate)
+            ),
             aliases=frozenset(aliases),
             has_boolean_schemas=hasBooleanSchemas,
             **kwargs,
@@ -196,6 +253,9 @@ class Dialect:
         return str(self.uri)
 
     def specification(self, **kwargs: Any) -> Specification[Schema]:
+        fallback = REFERENCING_FALLBACK.get(self.uri)
+        if fallback is not None:
+            kwargs.setdefault("default", fallback)
         return specification_with(str(self.uri), **kwargs)
 
     @property

--- a/bowtie/_core.py
+++ b/bowtie/_core.py
@@ -79,6 +79,20 @@ REFERENCING_FALLBACK: Mapping[URL, Specification[Schema]] = {
 }
 
 
+def _dated_unless_prerelease(dialect: Dialect, _: Any, prerelease: bool):
+    """
+    Say when you were published, or say you have not been.
+
+    The dialect schema states the same rule as a ``oneOf``.
+    """
+    if prerelease == (dialect.first_publication_date is None):
+        return
+    raise ValueError(
+        "A dialect has a first publication date unless it is a prerelease, "
+        f"but {dialect.pretty_name} says otherwise.",
+    )
+
+
 @frozen
 @total_ordering
 class Dialect:
@@ -89,10 +103,17 @@ class Dialect:
     pretty_name: str
     uri: URL = field(repr=False)
     short_name: str = field(repr=False)
-    #: `None` for a dialect which has not been published yet. Explicit
-    #: rather than defaulted, as forgetting a date should not quietly mean
-    #: a dialect is unpublished.
+    #: `None` for a prerelease dialect, which has no date to give.
     first_publication_date: date | None = field(repr=False)
+    #: Is this dialect still being written? Bowtie knows about one so that
+    #: its tests can be run against harnesses which opt into it, but does
+    #: not treat it as the latest dialect, benchmark it, or report on it.
+    prerelease: bool = field(
+        default=False,
+        repr=False,
+        validator=_dated_unless_prerelease,
+    )
+
     aliases: Set[str] = field(
         default=cast("frozenset[str]", frozenset()),
         repr=False,
@@ -132,19 +153,12 @@ class Dialect:
         """
         Order dialects oldest to newest, with unpublished ones newest of all.
 
-        The short name breaks ties, so that two unpublished dialects still
+        The short name breaks ties, so that two prerelease dialects still
         have a total order and sort the same way every run.
         """
         if self.first_publication_date is None:
             return date.max, self.short_name
         return self.first_publication_date, self.short_name
-
-    @property
-    def is_published(self):
-        """
-        Has this dialect been published as a document yet?
-        """
-        return self.first_publication_date is not None
 
     @classmethod
     @cache
@@ -181,13 +195,12 @@ class Dialect:
     @cache
     def published(cls) -> Iterable[Dialect]:
         """
-        Every dialect Bowtie knows which has actually been published.
+        Every dialect Bowtie knows which is not still being written.
 
-        The rest are dialects still being written, which Bowtie knows about
-        only so that their test suite can be run against harnesses opting
-        in to them.
+        Bowtie knows about a prerelease dialect only so that its test suite
+        can be run against harnesses opting into it.
         """
-        return HashTrieSet(each for each in cls.known() if each.is_published)
+        return HashTrieSet(each for each in cls.known() if not each.prerelease)
 
     @classmethod
     @cache
@@ -196,9 +209,9 @@ class Dialect:
         The latest published dialect known to Bowtie.
 
         Bowtie knows about dialects which are still being written, so that
-        their test suite can be run, but an unpublished dialect is not what
-        anyone means by "latest", and defaulting to one would send schemas
-        no harness has agreed to support.
+        their test suite can be run, but a prerelease is not what anyone
+        means by "latest", and defaulting to one would send schemas no
+        harness has agreed to support.
         """
         return max(cls.published())
 
@@ -209,6 +222,7 @@ class Dialect:
         shortName: str,
         uri: str,
         firstPublicationDate: str | None = None,
+        prerelease: bool = False,
         aliases: Iterable[str] = (),
         hasBooleanSchemas: bool = True,
         **kwargs: Any,
@@ -227,6 +241,7 @@ class Dialect:
                 if firstPublicationDate is None
                 else date.fromisoformat(firstPublicationDate)
             ),
+            prerelease=prerelease,
             aliases=frozenset(aliases),
             has_boolean_schemas=hasBooleanSchemas,
             **kwargs,

--- a/bowtie/schemas/models/dialect.json
+++ b/bowtie/schemas/models/dialect.json
@@ -5,7 +5,7 @@
   "$id": "tag:bowtie.report,2024:models:dialect",
 
   "type": "object",
-  "required": ["firstPublicationDate", "prettyName", "shortName", "uri"],
+  "required": ["prettyName", "shortName", "uri"],
   "properties": {
     "uri": {
       "description": "The URI representing this dialect, also known as its dialect identifier",
@@ -32,7 +32,7 @@
       "pattern": "[a-z]+[a-z0-9-]*"
     },
     "firstPublicationDate": {
-      "description": "The date when the dialect was first published publicly as a document",
+      "description": "The date when the dialect was first published publicly as a document. Absent for a dialect which has not been published yet, which is also how Bowtie knows not to treat it as the latest dialect.",
       "readOnly": true,
 
       "type": "string",

--- a/bowtie/schemas/models/dialect.json
+++ b/bowtie/schemas/models/dialect.json
@@ -6,6 +6,19 @@
 
   "type": "object",
   "required": ["prettyName", "shortName", "uri"],
+
+  "oneOf": [
+    {
+      "description": "A dialect which has been published, and says when it was",
+      "required": ["firstPublicationDate"]
+    },
+    {
+      "description": "A dialect still being written, which has no publication date to give",
+      "required": ["prerelease"],
+      "properties": { "prerelease": { "const": true } }
+    }
+  ],
+
   "properties": {
     "uri": {
       "description": "The URI representing this dialect, also known as its dialect identifier",
@@ -32,11 +45,18 @@
       "pattern": "[a-z]+[a-z0-9-]*"
     },
     "firstPublicationDate": {
-      "description": "The date when the dialect was first published publicly as a document. Absent for a dialect which has not been published yet, which is also how Bowtie knows not to treat it as the latest dialect.",
+      "description": "The date when the dialect was first published publicly as a document",
       "readOnly": true,
 
       "type": "string",
       "format": "date"
+    },
+    "prerelease": {
+      "description": "Is this dialect still being written? Bowtie knows about a prerelease dialect so its tests can be run against harnesses which opt into it, but does not treat it as the latest dialect, benchmark it, or show it on the report.",
+      "readOnly": true,
+
+      "type": "boolean",
+      "default": false
     },
     "hasBooleanSchemas": {
       "description": "Does the dialect have a notion of boolean schemas?",

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/models/dialect.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/models/dialect.json
@@ -5,7 +5,7 @@
   "$id": "tag:bowtie.report,2024:models:dialect",
 
   "type": "object",
-  "required": ["firstPublicationDate", "prettyName", "shortName", "uri"],
+  "required": ["prettyName", "shortName", "uri"],
   "properties": {
     "uri": {
       "description": "The URI representing this dialect, also known as its dialect identifier",
@@ -32,7 +32,7 @@
       "pattern": "[a-z]+[a-z0-9-]*"
     },
     "firstPublicationDate": {
-      "description": "The date when the dialect was first published publicly as a document",
+      "description": "The date when the dialect was first published publicly as a document. Absent for a dialect which has not been published yet, which is also how Bowtie knows not to treat it as the latest dialect.",
       "readOnly": true,
 
       "type": "string",

--- a/bowtie/tests/fauxmplementations/lintsonschema/schemas/models/dialect.json
+++ b/bowtie/tests/fauxmplementations/lintsonschema/schemas/models/dialect.json
@@ -6,6 +6,19 @@
 
   "type": "object",
   "required": ["prettyName", "shortName", "uri"],
+
+  "oneOf": [
+    {
+      "description": "A dialect which has been published, and says when it was",
+      "required": ["firstPublicationDate"]
+    },
+    {
+      "description": "A dialect still being written, which has no publication date to give",
+      "required": ["prerelease"],
+      "properties": { "prerelease": { "const": true } }
+    }
+  ],
+
   "properties": {
     "uri": {
       "description": "The URI representing this dialect, also known as its dialect identifier",
@@ -32,11 +45,18 @@
       "pattern": "[a-z]+[a-z0-9-]*"
     },
     "firstPublicationDate": {
-      "description": "The date when the dialect was first published publicly as a document. Absent for a dialect which has not been published yet, which is also how Bowtie knows not to treat it as the latest dialect.",
+      "description": "The date when the dialect was first published publicly as a document",
       "readOnly": true,
 
       "type": "string",
       "format": "date"
+    },
+    "prerelease": {
+      "description": "Is this dialect still being written? Bowtie knows about a prerelease dialect so its tests can be run against harnesses which opt into it, but does not treat it as the latest dialect, benchmark it, or show it on the report.",
+      "readOnly": true,
+
+      "type": "boolean",
+      "default": false
     },
     "hasBooleanSchemas": {
       "description": "Does the dialect have a notion of boolean schemas?",

--- a/bowtie/tests/test_dialect.py
+++ b/bowtie/tests/test_dialect.py
@@ -1,8 +1,14 @@
 from datetime import date
+from importlib.resources import files
+from pathlib import Path
+import json
 
+from referencing.jsonschema import specification_with
+from url import URL
 import pytest
 
 from bowtie._core import Dialect
+from bowtie._direct_connectable import Direct
 
 
 def test_known_latest():
@@ -68,3 +74,106 @@ def test_ordering():
     assert draft7 <= draft7  # noqa: PLR0124
     assert draft7 >= draft7  # noqa: PLR0124
     assert not draft7 < draft7  # noqa: PLR0124
+
+
+def test_latest_ignores_unpublished_dialects():
+    """
+    A dialect still being written is known, but it is not the latest one.
+
+    Defaulting to one would send schemas to harnesses which have not said
+    they support the dialect.
+    """
+    unpublished = [each for each in Dialect.known() if not each.is_published]
+    assert unpublished, "this test is only meaningful with one of these"
+    assert Dialect.latest() not in unpublished
+
+
+def test_unpublished_dialects_sort_newest():
+    v1 = Dialect.by_short_name()["v1"]
+
+    assert max(Dialect.known()) == v1
+    assert v1 > Dialect.latest()
+    assert Dialect.latest() < v1
+
+
+def test_unpublished_dialect_has_no_publication_date():
+    v1 = Dialect.by_short_name()["v1"]
+
+    assert v1.first_publication_date is None
+    assert not v1.is_published
+
+
+def test_v1():
+    v1 = Dialect.by_short_name()["v1"]
+
+    assert v1.uri == URL.parse("https://json-schema.org/v1")
+    assert Dialect.from_str("https://json-schema.org/v1") == v1
+    for alias in ("draft-next",):
+        assert Dialect.by_alias()[alias] == v1
+
+
+def test_v1_specification():
+    """
+    `referencing` does not know v1 yet, so Bowtie says what it looks like.
+
+    Without this, loading a single v1 test case raises `UnknownDialect`.
+    """
+    v1 = Dialect.by_short_name()["v1"]
+
+    assert v1.specification() == specification_with(
+        "https://json-schema.org/draft/2020-12/schema",
+    )
+
+
+def test_every_dialect_has_a_specification():
+    for each in Dialect.known():
+        each.specification()
+
+
+def test_dialects_json_matches_its_own_schema():
+    registry = Direct.from_id("python-jsonschema").registry()
+    validator = registry.for_uri("tag:bowtie.report,2024:models:dialect")
+
+    data = files("bowtie") / "data"
+    if not data.is_dir():
+        data = Path(__file__).parent.parent.parent / "data"
+
+    for each in json.loads(data.joinpath("dialects.json").read_text()):
+        # $schema here identifies the model the entry follows, so it is
+        # metadata about the entry rather than part of what is described
+        validator.validate({k: v for k, v in each.items() if k != "$schema"})
+
+
+def test_two_unpublished_dialects_still_have_a_total_order():
+    """
+    Two dialects being written at once must not compare as incomparable.
+
+    `Dialect.known()` is a set, so without a tie-break the sort order would
+    also differ between runs.
+    """
+    one = Dialect(
+        pretty_name="One",
+        short_name="one",
+        uri="urn:example:one",
+        first_publication_date=None,
+    )
+    two = Dialect(
+        pretty_name="Two",
+        short_name="two",
+        uri="urn:example:two",
+        first_publication_date=None,
+    )
+
+    assert one < two
+    assert two > one
+    assert sorted([two, one]) == [one, two]
+    assert sorted([one, two]) == [one, two]
+
+
+def test_a_dialect_must_say_whether_it_is_published():
+    with pytest.raises(TypeError):
+        Dialect(  # type: ignore[reportCallIssue]
+            pretty_name="Undated",
+            short_name="undated",
+            uri="urn:example:undated",
+        )

--- a/bowtie/tests/test_dialect.py
+++ b/bowtie/tests/test_dialect.py
@@ -76,19 +76,19 @@ def test_ordering():
     assert not draft7 < draft7  # noqa: PLR0124
 
 
-def test_latest_ignores_unpublished_dialects():
+def test_latest_ignores_prereleases():
     """
     A dialect still being written is known, but it is not the latest one.
 
     Defaulting to one would send schemas to harnesses which have not said
     they support the dialect.
     """
-    unpublished = [each for each in Dialect.known() if not each.is_published]
-    assert unpublished, "this test is only meaningful with one of these"
-    assert Dialect.latest() not in unpublished
+    prereleases = [each for each in Dialect.known() if each.prerelease]
+    assert prereleases, "this test is only meaningful with one of these"
+    assert Dialect.latest() not in prereleases
 
 
-def test_unpublished_dialects_sort_newest():
+def test_prereleases_sort_newest():
     v1 = Dialect.by_short_name()["v1"]
 
     assert max(Dialect.known()) == v1
@@ -96,11 +96,11 @@ def test_unpublished_dialects_sort_newest():
     assert Dialect.latest() < v1
 
 
-def test_unpublished_dialect_has_no_publication_date():
+def test_a_prerelease_has_no_publication_date():
     v1 = Dialect.by_short_name()["v1"]
 
+    assert v1.prerelease
     assert v1.first_publication_date is None
-    assert not v1.is_published
 
 
 def test_v1():
@@ -144,7 +144,7 @@ def test_dialects_json_matches_its_own_schema():
         validator.validate({k: v for k, v in each.items() if k != "$schema"})
 
 
-def test_two_unpublished_dialects_still_have_a_total_order():
+def test_two_prereleases_still_have_a_total_order():
     """
     Two dialects being written at once must not compare as incomparable.
 
@@ -156,12 +156,14 @@ def test_two_unpublished_dialects_still_have_a_total_order():
         short_name="one",
         uri="urn:example:one",
         first_publication_date=None,
+        prerelease=True,
     )
     two = Dialect(
         pretty_name="Two",
         short_name="two",
         uri="urn:example:two",
         first_publication_date=None,
+        prerelease=True,
     )
 
     assert one < two
@@ -170,10 +172,31 @@ def test_two_unpublished_dialects_still_have_a_total_order():
     assert sorted([one, two]) == [one, two]
 
 
-def test_a_dialect_must_say_whether_it_is_published():
+def test_a_dialect_must_say_when_it_was_published():
     with pytest.raises(TypeError):
         Dialect(  # type: ignore[reportCallIssue]
             pretty_name="Undated",
             short_name="undated",
             uri="urn:example:undated",
+        )
+
+
+def test_only_a_prerelease_may_have_no_publication_date():
+    with pytest.raises(ValueError, match="unless it is a prerelease"):
+        Dialect(
+            pretty_name="Undated",
+            short_name="undated",
+            uri="urn:example:undated",
+            first_publication_date=None,
+        )
+
+
+def test_a_prerelease_may_not_have_a_publication_date():
+    with pytest.raises(ValueError, match="unless it is a prerelease"):
+        Dialect(
+            pretty_name="Dated",
+            short_name="dated",
+            uri="urn:example:dated",
+            first_publication_date=date.today(),
+            prerelease=True,
         )

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -1532,6 +1532,79 @@ class TestSmoke:
         assert (await command_validator("smoke")).validated(jsonout) == {
             "success": False,
             "dialects": {
+                "v1": [
+                    {
+                        "schema": {
+                            "$schema": "https://json-schema.org/v1",
+                        },
+                        "instances": [
+                            None,
+                            True,
+                            37,
+                            37.37,
+                            "37",
+                            [
+                                37,
+                            ],
+                            {
+                                "foo": 37,
+                            },
+                        ],
+                        "expected": [
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                        ],
+                        "results": [
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                        ],
+                    },
+                    {
+                        "schema": {
+                            "$schema": "https://json-schema.org/v1",
+                            "not": {
+                                "$schema": "https://json-schema.org/v1",
+                            },
+                        },
+                        "instances": [
+                            None,
+                            True,
+                            37,
+                            37.37,
+                            "37",
+                            [37],
+                            {"foo": 37},
+                        ],
+                        "expected": [
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                            {"valid": False},
+                        ],
+                        "results": [
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                            {"valid": True},
+                        ],
+                    },
+                ],
                 "draft2020-12": [
                     {
                         "schema": {
@@ -1973,6 +2046,7 @@ class TestSmoke:
                 "draft3": [],
                 "draft4": [],
                 "draft6": [],
+                "v1": [],
                 "draft7": [
                     {
                         "expected": [
@@ -2116,6 +2190,7 @@ class TestSmoke:
 
             ## Dialects
 
+            * v1
             * Draft 2020-12
             * Draft 2019-09
             * Draft 7 **(failed)**
@@ -2282,6 +2357,40 @@ class TestSmoke:
                             ],
                             "schema": {
                                 "$schema": "https://json-schema.org/draft/2019-09/schema",
+                            },
+                        },
+                    ],
+                    "v1": [
+                        {
+                            "expected": [
+                                {"valid": True},
+                                {"valid": True},
+                                {"valid": True},
+                                {"valid": True},
+                                {"valid": True},
+                                {"valid": True},
+                                {"valid": True},
+                            ],
+                            "instances": [
+                                None,
+                                True,
+                                37,
+                                37.37,
+                                "37",
+                                [37],
+                                {"foo": 37},
+                            ],
+                            "results": [
+                                {"valid": False},
+                                {"valid": False},
+                                {"valid": False},
+                                {"valid": False},
+                                {"valid": False},
+                                {"valid": False},
+                                {"valid": False},
+                            ],
+                            "schema": {
+                                "$schema": "https://json-schema.org/v1",
                             },
                         },
                     ],
@@ -2512,7 +2621,8 @@ async def test_info_pretty():
         ╭────────────────┬─────────────────────────────────────────────────────────────╮
         │ implementation │ fake_language_and_os v1.0.0                                 │
         │ language       │ python 1.2.3                                                │
-        │ dialects       │ Draft 2020-12                                               │
+        │ dialects       │ v1                                                          │
+        │                │ Draft 2020-12                                               │
         │                │ Draft 2019-09                                               │
         │                │ Draft 7                                                     │
         │                │ Draft 6                                                     │
@@ -2551,6 +2661,7 @@ async def test_info_markdown():
         **os_version**: "{platform.release()}"
         **source**: "https://github.com/bowtie-json-schema/bowtie"
         **dialects**: [
+          "https://json-schema.org/v1",
           "https://json-schema.org/draft/2020-12/schema",
           "https://json-schema.org/draft/2019-09/schema",
           "http://json-schema.org/draft-07/schema#",
@@ -2644,6 +2755,8 @@ async def test_info_valid_markdown():
                   <text>
                   <softbreak>
                   <text>
+                  <softbreak>
+                  <text>
             """,
         ).strip()
     )
@@ -2673,6 +2786,7 @@ async def test_info_json():
         "os": platform.system(),
         "version": "v1.0.0",
         "dialects": [
+            "https://json-schema.org/v1",
             "https://json-schema.org/draft/2020-12/schema",
             "https://json-schema.org/draft/2019-09/schema",
             "http://json-schema.org/draft-07/schema#",
@@ -2710,6 +2824,7 @@ async def test_info_json_multiple_implementations():
             "os": platform.system(),
             "version": "v1.0.0",
             "dialects": [
+                "https://json-schema.org/v1",
                 "https://json-schema.org/draft/2020-12/schema",
                 "https://json-schema.org/draft/2019-09/schema",
                 "http://json-schema.org/draft-07/schema#",

--- a/data/dialects.json
+++ b/data/dialects.json
@@ -4,6 +4,7 @@
     "uri": "https://json-schema.org/v1",
     "shortName": "v1",
     "prettyName": "v1",
+    "prerelease": true,
     "aliases": ["draft-next"]
   },
   {

--- a/data/dialects.json
+++ b/data/dialects.json
@@ -1,6 +1,13 @@
 [
   {
     "$schema": "tag:bowtie.report,2024:models:dialect",
+    "uri": "https://json-schema.org/v1",
+    "shortName": "v1",
+    "prettyName": "v1",
+    "aliases": ["draft-next"]
+  },
+  {
+    "$schema": "tag:bowtie.report,2024:models:dialect",
     "uri": "https://json-schema.org/draft/2020-12/schema",
     "shortName": "draft2020-12",
     "prettyName": "Draft 2020-12",

--- a/frontend/src/data/Dialect.ts
+++ b/frontend/src/data/Dialect.ts
@@ -115,10 +115,17 @@ class DialectError extends Error {
 
 for (const each of data) {
   // TODO: Replace Dialect.all so we aren't relying on side effects.
+
+  // A dialect with no publication date has not been published yet. Bowtie
+  // knows about it so that its tests can be run, but there is no report to
+  // link to, so it stays off the site until there is one.
+  const publicationDate = each.firstPublicationDate;
+  if (publicationDate === undefined) continue;
+
   new Dialect(
     each.shortName,
     each.prettyName,
     each.uri,
-    new Date(each.firstPublicationDate),
+    new Date(publicationDate),
   );
 }

--- a/frontend/src/data/Dialect.ts
+++ b/frontend/src/data/Dialect.ts
@@ -116,9 +116,11 @@ class DialectError extends Error {
 for (const each of data) {
   // TODO: Replace Dialect.all so we aren't relying on side effects.
 
-  // A dialect with no publication date has not been published yet. Bowtie
-  // knows about it so that its tests can be run, but there is no report to
-  // link to, so it stays off the site until there is one.
+  // Bowtie knows about a prerelease dialect so that its tests can be run,
+  // but there is no report to link to, so it stays off the site until it is
+  // published. Everything else has a publication date, which the dialect
+  // schema requires and this then narrows.
+  if (each.prerelease) continue;
   const publicationDate = each.firstPublicationDate;
   if (publicationDate === undefined) continue;
 


### PR DESCRIPTION
Refs #40. Backend only, as you suggested, so nothing about the website changes.

`bowtie suite {PATH}/tests/v1` runs against any harness which declares
`https://json-schema.org/v1` in the dialects it returns from `start`.

My issue was wrong about one of the three pieces. The suite loader needs no
change: `_cases_and_dialect` looks a dialect up by the name of the directory
the tests are in, and the suite already lays v1 out as `tests/v1` with its
remotes under `remotes/v1`, so a `shortName` of `v1` is enough. `_remotes_in`
also already picks up the 17 remotes under `v1/` and the 6 shared ones, and
skips every `draft*` one. So this is the `dialects.json` entry, plus what that
entry then breaks.

### The publication date

v1 has not been published, so it has no first publication date, and that field
is now optional and means exactly that. It matters because `Dialect.latest()`
is `max()` over publication date, and `latest` decides the default dialect for
a run, so leaving it alone means every harness is suddenly sent v1 schemas it
never said it supports. An unpublished dialect sorts newest but is kept out of
four places:

* `Dialect.latest()`
* `bowtie filter-dialects --latest`, which is what scripts read
* the website, which has no report to link to for it yet
* the benchmark workflow's dialect matrix. This one caught me while reviewing.
  `filter-benchmarks -D v1` correctly returns nothing, so no benchmark job is
  created, but `merge_benchmarks_into_single_report` matrices over every
  dialect in `dialects.json` and would then call `iterdir()` on a directory the
  download step never created. That fails the merge, which fails the upload job
  that needs it. One `jq` `select` fixes it.

It is still listed by `filter-dialects`, still selectable by name, and still
reported as supported by a harness which declares it, since answering "which
dialects does this implementation support?" with a wrong list would be worse
than the surprise. Filling the date in later makes it appear everywhere with
no further code change.

That is the "gated behind anything" question from the issue, answered the least
surprising way I could find. Happy to reshape it if you would rather it were an
explicit flag than an absent date.

### The specification

`referencing` does not know the v1 identifier, so `Dialect.specification()`
raises `UnknownDialect`, and it is called for every test case in
`TestCase.from_dict`, so nothing loads at all. It now falls back to the
specification whose resource structure v1 shares, meaning the rules for finding
`$id`s, anchors and subschemas. Every structural keyword in `tests/v1` is a
2020-12 keyword, so 2020-12 is that specification for now. The entry should be
deleted once referencing knows v1 itself, and the comment says so.

### Verification

`tests/v1` end to end against a locally built `js-ata` image with the URI added
to its dialects array: 1133 tests ran, 1 failure, 0 errors, 0 skips.

That failure is `remote ref, containing refs itself`, and it is not mine. It
fails identically on draft2020-12, with the same empty registry, because
`cases_from` supplies remotes only for `refRemote`, `dynamicRef` and
`vocabulary` while `ref.json` and `anchor.json` reference `localhost:1234` too.
Left alone here. Say the word and I will open an issue.

The full test suite passes with nothing deselected, containers included, 341
tests. Also ran pyright, ruff, prettier, `tsc --noEmit`, eslint, and the
pre-commit hooks which touch these files.

### Calls I made that you may want to reverse

* The integration fixtures which spell out every dialect gain v1, since the
  miniatures declare whatever Bowtie knows. The alternative was having the
  miniatures declare only published dialects, which felt like bending the fakes
  to avoid updating expectations.
* The date stays a mandatory argument even though it may now be `None`, so that
  forgetting one is a `TypeError` rather than a quiet claim that a dialect is
  unpublished.
* Ordering falls back to the short name, so a second unpublished dialect would
  not make two dialects incomparable, or make `sorted(Dialect.known())` differ
  between runs.
* Only `draft-next` as an alias. `1` reads as draft 1 next to the existing
  `3`/`4`/`6`/`7`, and `next` stops being true the moment a v2 is drafted.
* `prettyName` is just `v1`, which reads a little bare next to "Draft 2020-12".
* One test validates `data/dialects.json` against `models/dialect.json`, since
  nothing did and I had just changed both. Drop it if it is not wanted.

### Not covered

* No implementation in this repo declares v1, so it will read as unsupported
  everywhere until harnesses opt in. That goes to `js-ata` separately.
* `hypothesis.dialects()` still always generates a publication date, so the
  unpublished path is covered by the explicit tests rather than by property
  tests. Teaching the strategy about it also means guaranteeing unique short
  names, which seemed like more than this change should carry.
* Nothing about `tests/v1/proposals/`. `_glob` does not recurse, so it is
  excluded the same way `optional/` is.
