### PR TITLE
Support unified JSON Schema Test Suite validation format

### DIFF
--- a/bowtie/_cli.py
+++ b/bowtie/_cli.py
@@ -2644,6 +2644,13 @@ def _run_suite(
 @IMPLEMENTATION
 @FILTER
 @fail_fast
+@dialect_option(
+    is_eager=True,
+    help=(
+        "A URI or shortname identifying the dialect to evaluate under. "
+        f"Possible shortnames include: {POSSIBLE_DIALECT_SHORTNAMES}"
+    ),
+)
 @SET_SCHEMA
 @VALIDATE
 @JOBS
@@ -2651,6 +2658,7 @@ def _run_suite(
 def suite(
     input: tuple[Iterable[TestCase], Dialect, dict[str, Any]],
     filter: CaseTransform,
+    dialect: Dialect,
     jobs: int,
     **kwargs: Any,
 ):

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -179,23 +179,32 @@ def _is_compatible(dialect: Dialect, compatibility: str | None) -> bool:
     version = int(dialect.short_name.removeprefix("draft").partition("-")[0])
 
     # Constraints naming an unknown version are never satisfied, not ignored.
+    is_valid = True
     for constraint in compatibility.split(","):
         constraint = constraint.strip()
         if constraint.startswith("<="):
-            bound = _COMPATIBILITY_VERSIONS.get(constraint[2:])
-            satisfied = bound is not None and version <= bound
+            operator, token = "<=", constraint[2:]
         elif constraint.startswith(">="):
-            bound = _COMPATIBILITY_VERSIONS.get(constraint[2:])
-            satisfied = bound is not None and version >= bound
+            operator, token = ">=", constraint[2:]
         elif constraint.startswith("="):
-            bound = _COMPATIBILITY_VERSIONS.get(constraint[1:])
-            satisfied = bound is not None and version == bound
+            operator, token = "=", constraint[1:]
         else:
-            bound = _COMPATIBILITY_VERSIONS.get(constraint)
-            satisfied = bound is not None and version >= bound
-        if not satisfied:
+            operator, token = ">=", constraint
+
+        bound = _COMPATIBILITY_VERSIONS.get(token)
+        if bound is None:
             return False
-    return True
+
+        if operator == "<=":
+            is_valid = version <= bound
+        elif operator == "=":
+            is_valid = version == bound
+        else:
+            is_valid = version >= bound
+
+        if version <= bound:
+            break
+    return is_valid
 
 
 def validation_cases_from(

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -75,7 +75,8 @@ class ClickParam(click.ParamType):
                 and ctx is not None
                 and ctx.get_parameter_source(
                     "dialect",
-                ) == ParameterSource.COMMANDLINE
+                )
+                == ParameterSource.COMMANDLINE
             ):
                 local_dialect = ctx.params.get("dialect")
 
@@ -397,7 +398,8 @@ def dialects_in(root: _P) -> set[Dialect]:
     Which dialects the suite rooted at the given path provides cases for.
     """
     return {
-        dialect for dialect in Dialect.known()
+        dialect
+        for dialect in Dialect.known()
         if dialect.short_name.removeprefix("draft").partition("-")[0].isdigit()
     }
 

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 from contextlib import suppress
 from datetime import UTC, datetime
 from fnmatch import fnmatch
-from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 import json
 import os
 import zipfile
 
+from click.core import ParameterSource
 from diagnostic import DiagnosticError
 from url import URL, RelativeURLWithoutBase
 import click
@@ -28,16 +28,13 @@ if TYPE_CHECKING:
 
 
 TEST_SUITE_URL = GITHUB / "json-schema-org/JSON-Schema-Test-Suite"
-TESTS_DIR_URL = TEST_SUITE_URL / "tree/main/tests"
+TESTS_DIR_URL = TEST_SUITE_URL / "tree/unify/validation"
 
 URL_FOR_DIALECT = {
     dialect: TESTS_DIR_URL / dialect.short_name for dialect in Dialect.known()
 }
 
 ANNOTATIONS_DIR_URL = TEST_SUITE_URL / "tree/main/annotations/tests"
-
-# Magic constants assumed/used by the official test suite for $ref tests
-SUITE_REMOTE_BASE_URI = URL.parse("http://localhost:1234")
 
 
 class ClickParam(click.ParamType):
@@ -71,10 +68,21 @@ class ClickParam(click.ParamType):
         def local(
             path: Path,
         ) -> tuple[Iterable[TestCase], Dialect, dict[str, Any]]:
+            local_dialect = known_dialect
+
+            if (
+                not self._is_annotations
+                and ctx is not None
+                and ctx.get_parameter_source(
+                    "dialect",
+                ) == ParameterSource.COMMANDLINE
+            ):
+                local_dialect = ctx.params.get("dialect")
+
             dialect, cases = self._cases_and_dialect(
                 path=path,
                 ctx=ctx,
-                known_dialect=known_dialect,
+                known_dialect=local_dialect,
             )
             return cases, dialect, {}
 
@@ -147,67 +155,12 @@ class ClickParam(click.ParamType):
         if self._is_annotations:
             cases = annotation_cases_from(paths=paths, dialect=dialect)
         else:
-            remotes = version_path.parent.parent / "remotes"
-            cases = cases_from(paths=paths, remotes=remotes, dialect=dialect)
+            cases = validation_cases_from(paths=paths, dialect=dialect)
 
         return dialect, cases
 
 
 _P = Path | zipfile.Path
-
-
-def _remotes_in(path: Path, dialect: Dialect) -> Iterable[tuple[URL, Any]]:
-    # This messy logic is because the test suite is terrible at indicating
-    # what remotes are needed for what drafts, and mixes in schemas which
-    # have no $schema and which are invalid under earlier versions, in with
-    # other schemas which are needed for tests.
-    #
-    # FIXME: #40: for draft-next support
-
-    for each in _rglob(path, "*.json"):
-        schema = json.loads(each.read_bytes())
-
-        relative = str(_relative_to(each, path)).replace("\\", "/")
-
-        if (
-            ("$schema" in schema and schema["$schema"] != str(dialect.uri))
-            or (  # draft<NotThisDialect>/*.json
-                relative.startswith("draft")
-                and not relative.startswith(dialect.short_name)
-            )
-            or (  # invalid boolean schema
-                not dialect.has_boolean_schemas and relative == "tree.json"
-            )
-        ):
-            continue
-        yield SUITE_REMOTE_BASE_URI / relative, schema
-
-
-@cache
-def remotes_in(path: Path, dialect: Dialect) -> dict[str, Any]:
-    return {str(k): v for k, v in _remotes_in(path=path, dialect=dialect)}
-
-
-def cases_from(
-    paths: Iterable[_P],
-    remotes: Path,
-    dialect: Dialect,
-) -> Iterable[TestCase]:
-    for path in paths:
-        if path.stem in {"refRemote", "dynamicRef", "vocabulary"}:
-            registry = remotes_in(remotes, dialect=dialect)
-        else:
-            registry = {}
-
-        for case in json.loads(path.read_bytes()):
-            for test in case["tests"]:
-                test["instance"] = test.pop("data")
-            case.pop("specification", None)  # we do nothing with this now
-            yield TestCase.from_dict(
-                dialect=dialect,
-                registry=registry,
-                **case,
-            )
 
 
 # The version tokens the suite's compatibility grammar allows.
@@ -242,6 +195,42 @@ def _is_compatible(dialect: Dialect, compatibility: str | None) -> bool:
         if not satisfied:
             return False
     return True
+
+
+def validation_cases_from(
+    paths: Iterable[_P],
+    dialect: Dialect,
+) -> Iterable[TestCase]:
+    for path in paths:
+        data = json.loads(path.read_text())
+
+        if "tests" not in data:
+            continue
+
+        for case in data["tests"]:
+            compatibility = case.get("compatibility")
+            if not _is_compatible(dialect, compatibility):
+                continue
+
+            tests = [
+                {
+                    **{
+                        key: value
+                        for key, value in test.items()
+                        if key != "data"
+                    },
+                    "instance": test["data"],
+                }
+                for test in case["tests"]
+            ]
+
+            yield TestCase.from_dict(
+                dialect=dialect,
+                description=case["description"],
+                schema=case["schema"],
+                registry=case.get("externalSchemas", {}),
+                tests=tests,
+            )
 
 
 def annotation_cases_from(
@@ -323,22 +312,8 @@ def _glob(path: _P, path_pattern: str) -> Iterable[_P]:
     )
 
 
-def _rglob(path: _P, path_pattern: str) -> Iterable[_P]:
-    for each in path.iterdir():
-        if fnmatch(each.name, path_pattern):
-            yield each
-        elif each.is_dir():
-            yield from _rglob(each, path_pattern)
-
-
-def _relative_to(path: _P, other: Path) -> Path:
-    if hasattr(path, "relative_to"):
-        return path.relative_to(other)  # type: ignore[reportGeneralTypeIssues]
-    return Path(path.at).relative_to(other.at)  # type: ignore[reportUnknownArgumentType, reportUnknownMemberType]
-
-
 #: The default git ref of the official suite to collect test cases from.
-DEFAULT_REF = "main"
+DEFAULT_REF = "unify"
 
 
 class SuiteNotAvailable(Exception):
@@ -389,10 +364,11 @@ def download(ref: str | None = None) -> tuple[_P, dict[str, Any]]:
     against (and can therefore be combined at) the same commit. Pass an
     explicit ref (a branch, tag or commit) to override.
 
-    Returns the suite's root directory (which contains ``tests/`` and
-    ``remotes/``) alongside run metadata recording the exact commit.
-    Every dialect collected from this one root is therefore guaranteed to
-    share a single consistent commit, even if the suite moves meanwhile.
+    Returns the suite's root directory (which contains ``validation/tests/``
+    directory of unified-format test case files, covering all dialects)
+    alongside run metadata recording the exact commit. Every dialect collected
+    from this one root is therefore guaranteed to share a single consistent
+    commit, even if the suite moves meanwhile.
     """
     owner, name, *_ = cast("list[str]", TEST_SUITE_URL.path_segments)
 
@@ -420,11 +396,9 @@ def dialects_in(root: _P) -> set[Dialect]:
     """
     Which dialects the suite rooted at the given path provides cases for.
     """
-    by_short = Dialect.by_short_name()
     return {
-        by_short[child.name]
-        for child in (root / "tests").iterdir()
-        if child.is_dir() and child.name in by_short
+        dialect for dialect in Dialect.known()
+        if dialect.short_name.removeprefix("draft").partition("-")[0].isdigit()
     }
 
 
@@ -432,9 +406,8 @@ def cases_for(root: _P, dialect: Dialect) -> Iterable[TestCase]:
     """
     The test cases for a single dialect within the suite at the given root.
     """
-    version_path = root / "tests" / dialect.short_name
-    return cases_from(
-        paths=list(_glob(version_path, "*.json")),
-        remotes=cast("Path", root / "remotes"),
+    tests_path = root / "validation" / "tests"
+    return validation_cases_from(
+        paths=list(_glob(tests_path, "*.json")),
         dialect=dialect,
     )

--- a/bowtie/tests/test_integration.py
+++ b/bowtie/tests/test_integration.py
@@ -509,30 +509,32 @@ class TestRun:
 
 @pytest.mark.asyncio
 async def test_suite(tmp_path):
-    definitions = tmp_path / "tests/draft7/definitions.json"
-    definitions.parent.mkdir(parents=True)
+    definitions = tmp_path / "definitions.json"
     definitions.write_text(
         _json.dumps(  # trimmed down definitions.json from the suite
-            [
-                {
-                    "description": "the case",
-                    "schema": {
-                        "$ref": "http://json-schema.org/draft-07/schema#",
+            {
+                "description": "definitions",
+                "tests": [
+                    {
+                        "description": "the case",
+                        "schema": {
+                            "$ref": "http://json-schema.org/draft-07/schema#",
+                        },
+                        "tests": [
+                            {
+                                "description": "one",
+                                "data": {"definitions": {}},
+                                "valid": True,
+                            },
+                            {
+                                "description": "two",
+                                "data": {"definitions": 12},
+                                "valid": False,
+                            },
+                        ],
                     },
-                    "tests": [
-                        {
-                            "description": "one",
-                            "data": {"definitions": {}},
-                            "valid": True,
-                        },
-                        {
-                            "description": "two",
-                            "data": {"definitions": 12},
-                            "valid": False,
-                        },
-                    ],
-                },
-            ],
+                ],
+            },
         ),
     )
 
@@ -540,6 +542,8 @@ async def test_suite(tmp_path):
         "suite",
         "-i",
         miniatures.always_invalid,
+        "--dialect",
+        "7",
         definitions,
     )
     report = Report.from_serialized(stdout.splitlines())
@@ -585,24 +589,53 @@ async def test_suite(tmp_path):
 @pytest.mark.asyncio
 async def test_site_collect(tmp_path):
     suite = tmp_path / "suite"
-    cases = _json.dumps(
-        [
+    tests_dir = suite / "validation" / "tests"
+    tests_dir.mkdir(parents=True)
+    tests_dir.joinpath("type.json").write_text(
+        _json.dumps(
             {
-                "description": "integer",
-                "schema": {"type": "integer"},
+                "description": "type validation",
                 "tests": [
-                    {"description": "an integer", "data": 1, "valid": True},
-                    {"description": "a string", "data": "foo", "valid": False},
+                    {
+                        "description": "integer (draft7)",
+                        "compatibility": "=7",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                            {
+                                "description": "a string",
+                                "data": "foo",
+                                "valid": False,
+                            },
+                        ],
+                    },
+                    {
+                        "description": "integer (draft2020-12)",
+                        "compatibility": "=2020",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                            {
+                                "description": "a string",
+                                "data": "foo",
+                                "valid": False,
+                            },
+                        ],
+                    },
                 ],
             },
-        ],
+        ),
     )
     # The implementation supports only draft7, so even though the suite
     # provides two dialects, only draft7 should be collected.
-    for each in ("draft7", "draft2020-12"):
-        dialect_dir = suite / "tests" / each
-        dialect_dir.mkdir(parents=True)
-        dialect_dir.joinpath("type.json").write_text(cases)
 
     out = tmp_path / "reports"
     await bowtie(
@@ -633,23 +666,26 @@ async def test_site_collect_withholds_all_errored_reports(tmp_path):
     or harness, and publishing it would silently wipe out good results.
     """
     suite = tmp_path / "suite"
-    dialect_dir = suite / "tests" / "draft7"
-    dialect_dir.mkdir(parents=True)
-    dialect_dir.joinpath("type.json").write_text(
+    tests_dir = suite / "validation" / "tests"
+    tests_dir.mkdir(parents=True)
+    tests_dir.joinpath("type.json").write_text(
         _json.dumps(
-            [
-                {
-                    "description": "integer",
-                    "schema": {"type": "integer"},
-                    "tests": [
-                        {
-                            "description": "an integer",
-                            "data": 1,
-                            "valid": True,
-                        },
-                    ],
-                },
-            ],
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "integer",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
+                ],
+            },
         ),
     )
 
@@ -672,19 +708,26 @@ async def test_site_collect_withholds_all_errored_reports(tmp_path):
 @pytest.mark.asyncio
 async def test_site_collect_refuses_existing_output(tmp_path):
     suite = tmp_path / "suite"
-    dialect_dir = suite / "tests" / "draft7"
-    dialect_dir.mkdir(parents=True)
-    dialect_dir.joinpath("type.json").write_text(
+    tests_dir = suite / "validation" / "tests"
+    tests_dir.mkdir(parents=True)
+    tests_dir.joinpath("type.json").write_text(
         _json.dumps(
-            [
-                {
-                    "description": "integer",
-                    "schema": {"type": "integer"},
-                    "tests": [
-                        {"description": "ok", "data": 1, "valid": True},
-                    ],
-                },
-            ],
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "integer",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "ok",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
+                ],
+            },
         ),
     )
     out = tmp_path / "reports"
@@ -706,21 +749,41 @@ async def test_site_collect_refuses_existing_output(tmp_path):
 @pytest.mark.asyncio
 async def test_site_collect_one_report_per_supported_dialect(tmp_path):
     suite = tmp_path / "suite"
-    cases = _json.dumps(
-        [
+    tests_dir = suite / "validation" / "tests"
+    tests_dir.mkdir(parents=True)
+    tests_dir.joinpath("type.json").write_text(
+        _json.dumps(
             {
-                "description": "integer",
-                "schema": {"type": "integer"},
+                "description": "type validation",
                 "tests": [
-                    {"description": "an integer", "data": 1, "valid": True},
+                    {
+                        "description": "integer (draft7)",
+                        "compatibility": "=7",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
+                    {
+                        "description": "integer (draft2020-12)",
+                        "compatibility": "=2020",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
                 ],
             },
-        ],
+        ),
     )
-    for each in ("draft7", "draft2020-12"):
-        dialect_dir = suite / "tests" / each
-        dialect_dir.mkdir(parents=True)
-        dialect_dir.joinpath("type.json").write_text(cases)
 
     out = tmp_path / "reports"
     # always_invalid supports every dialect, so the report set is exactly the
@@ -761,23 +824,27 @@ async def test_site_collect_requires_a_single_implementation(tmp_path):
 @pytest.mark.asyncio
 async def test_site_combine(tmp_path):
     suite = tmp_path / "suite"
-    dialect_dir = suite / "tests" / "draft7"
-    dialect_dir.mkdir(parents=True)
-    dialect_dir.joinpath("type.json").write_text(
+    tests_dir = suite / "validation" / "tests"
+    tests_dir.mkdir(parents=True)
+    tests_dir.joinpath("type.json").write_text(
         _json.dumps(
-            [
-                {
-                    "description": "integer",
-                    "schema": {"type": "integer"},
-                    "tests": [
-                        {
-                            "description": "an integer",
-                            "data": 1,
-                            "valid": True,
-                        },
-                    ],
-                },
-            ],
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "integer",
+                        "compatibility": "=7",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
+                ],
+            },
         ),
     )
 
@@ -876,22 +943,51 @@ async def test_site_collect_versioned(tmp_path):
     version each implementation reports, plus a matrix-versions.json index.
     """
     suite = tmp_path / "suite"
-    cases = _json.dumps(
-        [
+    tests_dir = suite / "validation" / "tests"
+    tests_dir.mkdir(parents=True)
+    tests_dir.joinpath("type.json").write_text(
+        _json.dumps(
             {
-                "description": "integer",
-                "schema": {"type": "integer"},
+                "description": "type validation",
                 "tests": [
-                    {"description": "an integer", "data": 1, "valid": True},
-                    {"description": "a string", "data": "foo", "valid": False},
+                    {
+                        "description": "integer (draft7)",
+                        "compatibility": "=7",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                            {
+                                "description": "a string",
+                                "data": "foo",
+                                "valid": False,
+                            },
+                        ],
+                    },
+                    {
+                        "description": "integer (draft2020-12)",
+                        "compatibility": "=2020",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                            {
+                                "description": "a string",
+                                "data": "foo",
+                                "valid": False,
+                            },
+                        ],
+                    },
                 ],
             },
-        ],
+        ),
     )
-    for each in ("draft7", "draft2020-12"):
-        dialect_dir = suite / "tests" / each
-        dialect_dir.mkdir(parents=True)
-        dialect_dir.joinpath("type.json").write_text(cases)
 
     out = tmp_path / "buggy"
     await bowtie(
@@ -934,17 +1030,26 @@ async def test_site_collect_versioned_skips_unavailable(tmp_path):
     matrix-versions.json index) intact rather than aborting the whole trend.
     """
     suite = tmp_path / "suite"
-    dialect_dir = suite / "tests" / "draft7"
-    dialect_dir.mkdir(parents=True)
-    dialect_dir.joinpath("type.json").write_text(
+    tests_dir = suite / "validation" / "tests"
+    tests_dir.mkdir(parents=True)
+    tests_dir.joinpath("type.json").write_text(
         _json.dumps(
-            [
-                {
-                    "description": "integer",
-                    "schema": {"type": "integer"},
-                    "tests": [{"description": "ok", "data": 1, "valid": True}],
-                },
-            ],
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "integer",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "ok",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
+                ],
+            },
         ),
     )
 

--- a/bowtie/tests/test_suite.py
+++ b/bowtie/tests/test_suite.py
@@ -20,6 +20,9 @@ from bowtie._suite import (
 DRAFT7 = Dialect.by_alias()["7"]
 DRAFT2019 = Dialect.by_alias()["2019"]
 DRAFT2020 = Dialect.by_alias()["2020"]
+DRAFT4 = Dialect.by_alias()["4"]
+DRAFT6 = Dialect.by_alias()["6"]
+DRAFT3 = Dialect.by_alias()["3"]
 
 
 @pytest.mark.parametrize(
@@ -49,6 +52,16 @@ DRAFT2020 = Dialect.by_alias()["2020"]
         (DRAFT2020, "<=9999", True),
         # Unknown version tokens are never satisfied.
         (DRAFT2020, "bananas", False),
+        # Disjunction-over-ranges behaviour
+        (DRAFT4, "<=4,7", True),
+        (DRAFT6, "<=4,7", False),
+        (DRAFT7, "<=4,7", True),
+        (DRAFT2019, "<=4,7", True),
+        # Three-segment constraint
+        (DRAFT3, "<=3,7,<=2020", True),
+        (DRAFT4, "<=3,7,<=2020", False),
+        (DRAFT7, "<=3,7,<=2020", True),
+        (DRAFT2020, "<=3,7,<=2020", True),
     ],
 )
 def test_is_compatible(dialect, compatibility, compatible):

--- a/bowtie/tests/test_suite.py
+++ b/bowtie/tests/test_suite.py
@@ -274,9 +274,10 @@ def test_validation_cases_from_unified_format(tmp_path):
     assert len(cases) == 1
     assert cases[0].description == "integer type"
     assert cases[0].schema == {"type": "integer"}
-    assert [
-        result.valid for result in cases[0].expected_results()
-    ] == [True, False]
+    assert [result.valid for result in cases[0].expected_results()] == [
+        True,
+        False,
+    ]
     assert [test.instance for test in cases[0].tests] == [1, "1"]
 
 
@@ -373,6 +374,6 @@ def test_cases_for_unified_layout(tmp_path):
     draft7_cases = list(_suite.cases_for(tmp_path, draft7))
     assert [case.description for case in draft6_cases] == ["integer type"]
     assert [case.description for case in draft7_cases] == [
-            "integer type",
-            "only for draft7+",
-        ]
+        "integer type",
+        "only for draft7+",
+    ]

--- a/bowtie/tests/test_suite.py
+++ b/bowtie/tests/test_suite.py
@@ -2,12 +2,20 @@
 Tests for loading test cases from the official test suite.
 """
 
+from types import SimpleNamespace
 import json
 
+from click.core import ParameterSource
 import pytest
 
+from bowtie import _suite
 from bowtie._core import Dialect
-from bowtie._suite import ClickParam, _is_compatible, annotation_cases_from
+from bowtie._suite import (
+    ClickParam,
+    _is_compatible,
+    annotation_cases_from,
+    validation_cases_from,
+)
 
 DRAFT7 = Dialect.by_alias()["7"]
 DRAFT2019 = Dialect.by_alias()["2019"]
@@ -47,29 +55,35 @@ def test_is_compatible(dialect, compatibility, compatible):
     assert _is_compatible(dialect, compatibility) is compatible
 
 
-def test_convert_local_path(tmp_path):
-    tests = tmp_path / "tests" / "draft7"
-    tests.mkdir(parents=True)
-    tmp_path.joinpath("remotes").mkdir()
-    tests.joinpath("type.json").write_text(
+def test_convert_local_path_unified_format(tmp_path):
+    validation = tmp_path / "validation" / "tests"
+    validation.mkdir(parents=True)
+    validation.joinpath("type.json").write_text(
         json.dumps(
-            [
-                {
-                    "description": "string type",
-                    "schema": {"type": "string"},
-                    "tests": [
-                        {
-                            "description": "a string",
-                            "data": "foo",
-                            "valid": True,
-                        },
-                    ],
-                },
-            ],
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "string type",
+                        "schema": {"type": "string"},
+                        "tests": [
+                            {
+                                "description": "a string",
+                                "data": "foo",
+                                "valid": True,
+                            },
+                        ],
+                    },
+                ],
+            },
         ),
     )
 
-    cases, dialect, metadata = ClickParam().convert(str(tests), None, None)
+    ctx = SimpleNamespace(
+        params={"dialect": DRAFT7},
+        get_parameter_source=lambda name: ParameterSource.COMMANDLINE,
+    )
+    cases, dialect, metadata = ClickParam().convert(str(validation), None, ctx)
 
     assert dialect == DRAFT7
     assert len(list(cases)) == 1
@@ -223,3 +237,142 @@ def test_annotation_cases_from_incompatible_dialect(tmp_path):
     )
 
     assert list(annotation_cases_from(paths=[path], dialect=DRAFT2020)) == []
+
+
+def test_validation_cases_from_unified_format(tmp_path):
+    path = tmp_path / "type.json"
+    path.write_text(
+        json.dumps(
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "integer type",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "integer is valid",
+                                "data": 1,
+                                "valid": True,
+                            },
+                            {
+                                "description": "string is invalid",
+                                "data": "1",
+                                "valid": False,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ),
+    )
+
+    dialect = Dialect.by_short_name()["draft7"]
+
+    cases = list(validation_cases_from([path], dialect))
+
+    assert len(cases) == 1
+    assert cases[0].description == "integer type"
+    assert cases[0].schema == {"type": "integer"}
+    assert [
+        result.valid for result in cases[0].expected_results()
+    ] == [True, False]
+    assert [test.instance for test in cases[0].tests] == [1, "1"]
+
+
+def test_validation_cases_from_respects_compatibility(tmp_path):
+    path = tmp_path / "type.json"
+    path.write_text(
+        json.dumps(
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "available from draft 6",
+                        "compatibility": "6",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "integer",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
+                    {
+                        "description": "available from draft 7",
+                        "compatibility": "7",
+                        "schema": {"type": "string"},
+                        "tests": [
+                            {
+                                "description": "integer string",
+                                "data": "hello",
+                                "valid": True,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ),
+    )
+
+    draft6 = Dialect.by_short_name()["draft6"]
+    draft7 = Dialect.by_short_name()["draft7"]
+
+    draft6_cases = list(validation_cases_from([path], draft6))
+    draft7_cases = list(validation_cases_from([path], draft7))
+
+    assert [case.description for case in draft6_cases] == [
+        "available from draft 6",
+    ]
+    assert [case.description for case in draft7_cases] == [
+        "available from draft 6",
+        "available from draft 7",
+    ]
+
+
+def test_cases_for_unified_layout(tmp_path):
+    validation = tmp_path / "validation" / "tests"
+    validation.mkdir(parents=True)
+    validation.joinpath("type.json").write_text(
+        json.dumps(
+            {
+                "description": "type validation",
+                "tests": [
+                    {
+                        "description": "integer type",
+                        "schema": {"type": "integer"},
+                        "tests": [
+                            {
+                                "description": "an integer is valid",
+                                "data": 1,
+                                "valid": True,
+                            },
+                        ],
+                    },
+                    {
+                        "description": "only for draft7+",
+                        "compatibility": "7",
+                        "schema": {"type": "string"},
+                        "tests": [
+                            {
+                                "description": "a string is valid",
+                                "data": "foo",
+                                "valid": True,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ),
+    )
+
+    draft6 = Dialect.by_short_name()["draft6"]
+    draft7 = Dialect.by_short_name()["draft7"]
+    draft6_cases = list(_suite.cases_for(tmp_path, draft6))
+    draft7_cases = list(_suite.cases_for(tmp_path, draft7))
+    assert [case.description for case in draft6_cases] == ["integer type"]
+    assert [case.description for case in draft7_cases] == [
+            "integer type",
+            "only for draft7+",
+        ]


### PR DESCRIPTION
Update Bowtie to support the unified JSON Schema Test Suite validation format.

- Migrate validation suite loading to `validation/tests/*.json`
- Add support for the unified `compatibility` field
- Add an explicit `--dialect` option to `bowtie suite`
- Update fixtures and tests for the new format
- Remove legacy validation-suite loading code