### PR TITLE
Give ref.json and anchor.json the remote registry

### DIFF
--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -199,7 +199,13 @@ def cases_from(
         # the files which were named here. The rest are left with an empty one
         # on purpose: a case which does not ask for a remote should not be
         # handed 20-odd extra schemas it never mentions.
-        if path.stem in {"refRemote", "dynamicRef", "vocabulary", "ref", "anchor"}:
+        if path.stem in {
+            "refRemote",
+            "dynamicRef",
+            "vocabulary",
+            "ref",
+            "anchor",
+        }:
             registry = remotes_in(remotes, dialect=dialect)
         else:
             registry = {}

--- a/bowtie/_suite.py
+++ b/bowtie/_suite.py
@@ -194,7 +194,12 @@ def cases_from(
     dialect: Dialect,
 ) -> Iterable[TestCase]:
     for path in paths:
-        if path.stem in {"refRemote", "dynamicRef", "vocabulary"}:
+        # ref.json and anchor.json reference http://localhost:1234 too, in
+        # every dialect which has them, so they need the registry as much as
+        # the files which were named here. The rest are left with an empty one
+        # on purpose: a case which does not ask for a remote should not be
+        # handed 20-odd extra schemas it never mentions.
+        if path.stem in {"refRemote", "dynamicRef", "vocabulary", "ref", "anchor"}:
             registry = remotes_in(remotes, dialect=dialect)
         else:
             registry = {}


### PR DESCRIPTION
Closes #3068.

`cases_from` decides which files need the remote registry by name, and
`ref.json` and `anchor.json` were not on the list even though they reference
`http://localhost:1234` in every dialect which has them.

This is the small change you preferred: the two files join the allowlist,
everything else still gets an empty registry, so nothing outside these files
is handed remotes it never mentions.

The failure this fixes shows only on v1 today. `tests/v1/ref.json` has

```json
{
  "description": "remote ref, containing refs itself",
  "schema": {
    "$schema": "https://json-schema.org/v1",
    "$ref": "http://localhost:1234/v1/ref-and-defs.json"
  }
}
```

where the case of the same name in `tests/draft2020-12/ref.json` refs the
metaschema, which an implementation already has. So the 2020-12 one passes on
an empty registry and the v1 one cannot, and every implementation fails it once
harnesses start declaring v1.

I left the upstream side alone, since as you said the magic URI was only ever
meant for `refRemote.json` and that is the suite's to fix.
